### PR TITLE
Add step to print VSIX path in GitHub Actions workflow

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -40,5 +40,5 @@ jobs:
       if: matrix.node-version == '22.x'
       uses: actions/upload-artifact@v4
       with:
-        name: vsix-package
+        name: CopilotStudioVsixPackage
         path: "*.vsix"


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/node.js.yml` file. The change adds a new step to print the VSIX path after running the `npm run package` command.

* [`.github/workflows/node.js.yml`](diffhunk://#diff-014228303dff9a1af15f4bbd18401f906380129b10ae2a2c62f8b8be592ff88eR39-R48): Added a step to print the VSIX path using an echo statement.