### PR TITLE
Cleemullins/build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Build CI](https://github.com/microsoft/vscode-copilotstudio/actions/workflows/node.js.yml/badge.svg?branch=main)](https://github.com/microsoft/vscode-copilotstudio/actions/workflows/node.js.yml)
 
-
 Copilot Studio VSCode Extension
 
 ## Features


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change adds a build status badge to the top of the file.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R3-R4): Added a build status badge to the top of the file to display the CI build status.