### PR TITLE
Add metadata fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,12 @@
     "type": "git",
     "url": "https://github.com/microsoft/vscode-copilotstudio"
   },
+  "author": "Microsoft Copilot Studio Team",
+  "license": "See license in license file",
+  "homepage": "https://github.com/microsoft/vscode-copilotstudio/blob/main/README.md",
+  "keywords": [
+    "Copilot Studio"
+  ],
   "activationEvents": [],
   "main": "./extension.js",
   "contributes": {


### PR DESCRIPTION
This pull request includes several updates to the `package.json` file to enhance metadata and improve project documentation.

Metadata enhancements:

* Added `author` field to specify the Microsoft Copilot Studio Team as the author.
* Included `license` field to reference the license file.
* Added `homepage` field to link to the project's README.md file on GitHub.
* Introduced `keywords` field with "Copilot Studio" to improve discoverability.