### PR TITLE
Updated VSIX File name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "copilot-studio",
+  "name": "vscode-copilotstudio",
   "displayName": "Copilot Studio",
   "description": "Build Agents with Copilot Studio",
   "version": "0.0.1",
@@ -8,7 +8,7 @@
     "vscode": "^1.98.0"
   },
   "categories": [
-    "Copilot STudio",
+    "Copilot Studio",
     "Agents",
     "M365",
     "Azure AI",


### PR DESCRIPTION
Changes name in package json so emitted vsix is "vscode-copilotstudio" which follows the standard naming pattern. 