### PR TITLE
Add GitHub Action to label new issues with triage

### DIFF
--- a/.github/workflows/auto-label-triage.yml
+++ b/.github/workflows/auto-label-triage.yml
@@ -1,0 +1,23 @@
+name: Auto label new issues with triage
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  add-triage-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add "triage" label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              labels: ["triage"]
+            });


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the labeling of new issues. Now, whenever an issue is opened, it will automatically receive the "triage" label to help streamline the triage process.

Automation improvements:

* Added a new workflow file `.github/workflows/auto-label-triage.yml` that automatically adds the "triage" label to all newly opened issues using the `actions/github-script` action.