### PR TITLE
LSP broken pipeline crash fix

### DIFF
--- a/src/LanguageServers/PowerPlatformLS/Impl.Core/JsonRpcStream.cs
+++ b/src/LanguageServers/PowerPlatformLS/Impl.Core/JsonRpcStream.cs
@@ -40,7 +40,18 @@ namespace Microsoft.PowerPlatformLS.Impl.Core
                 if (message is JsonRpcResponse errorMessage)
                 {
                     _logger.LogWarning($"Error message. Sending message back: '{errorMessage.GetType().Name}' with Error ({errorMessage.Error?.Code}): {errorMessage.Error?.Message}");
-                    await _transport.SendAsync(errorMessage, stoppingToken).ConfigureAwait(false);
+                    try
+                    {
+                        await _transport.SendAsync(errorMessage, stoppingToken).ConfigureAwait(false);
+                    }
+                    catch (IOException ex)
+                    {
+                        // Peer (VS Code extension host) closed the IPC pipe. Treat as a graceful
+                        // transport shutdown instead of letting IOException escape RunAsync and
+                        // trigger BackgroundServiceStoppingHost on the IHost.
+                        _logger.LogInformation($"IPC transport closed while sending error response; {ex.Message}");
+                        break;
+                    }
                 }
                 else if (message is LspJsonRpcMessage lspMessage)
                 {

--- a/src/LanguageServers/PowerPlatformLS/Impl.Core/LanguageServerListener.cs
+++ b/src/LanguageServers/PowerPlatformLS/Impl.Core/LanguageServerListener.cs
@@ -24,7 +24,19 @@ namespace Microsoft.PowerPlatformLS.Impl.Core
             var streamTask = stream.RunAsync(stoppingToken);
 
             logger.LogInformation("Language Server Listening!");
-            await streamTask;
+            try
+            {
+                await streamTask;
+            }
+            catch (IOException ex)
+            {
+                // An IPC peer-close surfacing as IOException/SocketException must not
+                // propagate out of this BackgroundService. With the default
+                // HostOptions.BackgroundServiceExceptionBehavior (StopHost) it would
+                // terminate the LSP host process, which the client then surfaces as
+                // "Object reference not set to an instance of an object." on the next RPC.
+                logger.LogInformation("IPC transport closed: {message}", ex.Message);
+            }
 
             logger.LogInformation("Stream Ended. Waiting for Exit signal...");
             await server.WaitForExitAsync();

--- a/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.Core/JsonRpcStreamTests.cs
+++ b/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.Core/JsonRpcStreamTests.cs
@@ -1,0 +1,71 @@
+namespace Microsoft.PowerPlatformLS.UnitTests.Impl.Core
+{
+    using Microsoft.Extensions.Logging.Abstractions;
+    using Microsoft.PowerPlatformLS.Contracts.Internal;
+    using Microsoft.PowerPlatformLS.Contracts.Lsp.Models;
+    using Microsoft.PowerPlatformLS.Impl.Core;
+    using System.IO;
+    using System.Net.Sockets;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Xunit;
+
+    public class JsonRpcStreamTests
+    {
+        // Regression: client-disconnect during SendAsync must not escape RunAsync. Without the
+        // fix the IOException propagates through LanguageServerListener.ExecuteAsync and the
+        // BackgroundService host terminates the LSP process (BackgroundServiceExceptionBehavior
+        // defaults to StopHost), which the extension then surfaces as
+        // "Object reference not set to an instance of an object." on the next RPC.
+        [Fact]
+        public async Task RunAsync_Does_Not_Propagate_IOException_From_SendAsync()
+        {
+            var transport = new BrokenPipeTransport();
+            var stream = new JsonRpcStream(transport, NullLogger<JsonRpcStream>.Instance);
+
+            var ex = await Record.ExceptionAsync(() => stream.RunAsync(CancellationToken.None));
+
+            Assert.Null(ex);
+            Assert.True(transport.SendAsyncWasCalled);
+        }
+
+        private sealed class BrokenPipeTransport : ILspTransport
+        {
+            private int _readCount;
+            private bool _active = true;
+
+            public bool SendAsyncWasCalled { get; private set; }
+
+            public bool IsActive => _active;
+
+            public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+            public Task<BaseJsonRpcMessage> GetNextMessageAsync(CancellationToken cancellationToken)
+            {
+                if (_readCount++ == 0)
+                {
+                    BaseJsonRpcMessage err = new JsonRpcResponse
+                    {
+                        Error = new JsonRpcError { Message = "Unexpected end of stream" }
+                    };
+                    return Task.FromResult(err);
+                }
+
+                _active = false;
+                BaseJsonRpcMessage sentinel = new JsonRpcResponse { Error = new JsonRpcError() };
+                return Task.FromResult(sentinel);
+            }
+
+            public Task SendAsync<T>(T response, CancellationToken cancellationToken) where T : BaseJsonRpcMessage
+            {
+                SendAsyncWasCalled = true;
+                _active = false;
+                return Task.FromException(new IOException(
+                    "Unable to write data to the transport connection: Broken pipe.",
+                    new SocketException()));
+            }
+
+            public void Dispose() { }
+        }
+    }
+}

--- a/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.Core/LanguageServerListenerTests.cs
+++ b/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.Core/LanguageServerListenerTests.cs
@@ -37,7 +37,9 @@ namespace Microsoft.PowerPlatformLS.UnitTests.Impl.Core
 
             var executeTask = listener.ExecuteTask;
             Assert.NotNull(executeTask);
+#pragma warning disable VSTHRD003 // Awaiting BackgroundService.ExecuteTask is the behavior under test
             var execEx = await Record.ExceptionAsync(() => executeTask!);
+#pragma warning restore VSTHRD003
             Assert.Null(execEx);
 
             serverMock.Verify(s => s.WaitForExitAsync(), Times.Once);

--- a/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.Core/LanguageServerListenerTests.cs
+++ b/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.Core/LanguageServerListenerTests.cs
@@ -1,0 +1,46 @@
+namespace Microsoft.PowerPlatformLS.UnitTests.Impl.Core
+{
+    using Microsoft.CommonLanguageServerProtocol.Framework;
+    using Microsoft.CommonLanguageServerProtocol.Framework.JsonRpc;
+    using Microsoft.PowerPlatformLS.Contracts.Internal;
+    using Microsoft.PowerPlatformLS.Impl.Core;
+    using Moq;
+    using System.IO;
+    using System.Net.Sockets;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Xunit;
+
+    public class LanguageServerListenerTests
+    {
+        // Belt-and-suspenders regression: even if a future transport exception slips past
+        // the JsonRpcStream guard, the BackgroundService must not terminate the host.
+        [Fact]
+        public async Task ExecuteAsync_Swallows_IOException_Surfaced_By_Stream()
+        {
+            var streamMock = new Mock<IJsonRpcStream>();
+            streamMock
+                .Setup(s => s.RunAsync(It.IsAny<CancellationToken>()))
+                .Returns(Task.FromException(new IOException(
+                    "Unable to write data to the transport connection: Broken pipe.",
+                    new SocketException())));
+
+            var serverMock = new Mock<ILanguageServer>();
+            serverMock.Setup(s => s.WaitForExitAsync()).Returns(Task.CompletedTask);
+
+            var loggerMock = new Mock<ILspLogger>();
+
+            var listener = new LanguageServerListener(streamMock.Object, loggerMock.Object, serverMock.Object);
+
+            var startEx = await Record.ExceptionAsync(() => listener.StartAsync(CancellationToken.None));
+            Assert.Null(startEx);
+
+            var executeTask = listener.ExecuteTask;
+            Assert.NotNull(executeTask);
+            var execEx = await Record.ExceptionAsync(() => executeTask!);
+            Assert.Null(execEx);
+
+            serverMock.Verify(s => s.WaitForExitAsync(), Times.Once);
+        }
+    }
+}


### PR DESCRIPTION
Issue: https://github.com/microsoft/vscode-copilotstudio/issues/156

This pull request improves the robustness of the language server by ensuring that IOExceptions caused by IPC transport closure (such as a client disconnect) are gracefully handled and do not crash the host process. It also adds regression tests to verify this behavior at both the transport and service levels.

**Error handling improvements:**

* Wrapped `SendAsync` in `JsonRpcStream.RunAsync` with a try/catch to log and suppress `IOException` when the IPC transport is closed, preventing the exception from escaping and shutting down the host.
* Wrapped the awaited `stream.RunAsync` call in `LanguageServerListener.ExecuteAsync` with a try/catch to log and suppress `IOException`, ensuring that a transport-level disconnect does not terminate the LSP host process.

**Regression test coverage:**

* Added `JsonRpcStreamTests` to verify that `IOException` from `SendAsync` does not propagate out of `RunAsync`, using a custom `BrokenPipeTransport` to simulate the failure.
* Added `LanguageServerListenerTests` to verify that an `IOException` thrown by the stream does not terminate the background service, ensuring the server waits for exit as expected.