### PR TITLE
Remove dotnet-sdk ecosystem and ignore breaking npm majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,20 +17,6 @@ updates:
       all-dependencies:
         patterns:
           - "*"
-  - package-ecosystem: dotnet-sdk
-    directory: /
-    schedule:
-      interval: weekly
-      day: wednesday
-    ignore:
-      - dependency-name: '*'
-        update-types:
-          - version-update:semver-major
-          - version-update:semver-minor
-    groups:
-      dotnet-sdk:
-        patterns:
-          - "*"
   - package-ecosystem: npm
     directories:
       - "/src/vscode-extensions/*"
@@ -41,6 +27,16 @@ updates:
       - 'dependencies'
     reviewers:
       - 'microsoft/vscode-copilot-studio-approvers'
+    ignore:
+      - dependency-name: '@types/node'
+        update-types:
+          - version-update:semver-major
+      - dependency-name: 'typescript'
+        update-types:
+          - version-update:semver-major
+      - dependency-name: 'uuid'
+        update-types:
+          - version-update:semver-major
     groups:
       all-dependencies:
         patterns:


### PR DESCRIPTION
This repo is a consumer application, not an SDK: global.json pins the .NET SDK version as a deliberate team decision, so removing the dotnet-sdk ecosystem stops dependabot from opening PRs against it.

Ignore major bumps for @types/node, typescript, and uuid under the npm ecosystem. @types/node 25 broke the TypeScript build in PR #159; typescript 6 and uuid 13 are held as conservative pins until the surrounding ecosystem (vscode-jsonrpc, module system) is ready.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>