### PR TITLE
Bundle Microsoft.CopilotStudio.McsCore.dll inside Sync nupkg

### DIFF
--- a/src/CopilotStudio.Sync/CopilotStudio.Sync.csproj
+++ b/src/CopilotStudio.Sync/CopilotStudio.Sync.csproj
@@ -9,7 +9,14 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
+    <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);IncludeMcsCoreInPackage</TargetsForTfmSpecificBuildOutput>
   </PropertyGroup>
+
+  <Target Name="IncludeMcsCoreInPackage">
+    <ItemGroup>
+      <BuildOutputInPackage Include="$(OutputPath)Microsoft.CopilotStudio.McsCore.dll" />
+    </ItemGroup>
+  </Target>
 
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.CopilotStudio.Sync.TestHarness, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9" />


### PR DESCRIPTION
Complete the private-assets strategy: Sync's ProjectReference to McsCore already used PrivateAssets=all, which correctly suppresses McsCore as a separate NuGet dependency. This adds the matching half — pack McsCore.dll into Sync's lib/net10.0 folder via BuildOutputInPackage, so consumers of the Sync nupkg receive both assemblies from one package reference.

Without this, Sync 1.4.2-prerelease shipped as Sync.dll alone while Sync.dll had an assembly-level reference to McsCore that consumers could not resolve. Adding the using Microsoft.CopilotStudio.McsCore; is now sufficient on the consumer side; no separate PackageReference needed.