### PR TITLE
Broaden npm major-version ignore to all dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,13 +28,7 @@ updates:
     reviewers:
       - 'microsoft/vscode-copilot-studio-approvers'
     ignore:
-      - dependency-name: '@types/node'
-        update-types:
-          - version-update:semver-major
-      - dependency-name: 'typescript'
-        update-types:
-          - version-update:semver-major
-      - dependency-name: 'uuid'
+      - dependency-name: '*'
         update-types:
           - version-update:semver-major
     groups:


### PR DESCRIPTION
The previous per-dep ignore rules for @types/node, typescript, and uuid did not filter inside the grouped PR — a known dependabot bug where per-dependency ignore rules are not respected when the dependency is part of a group (dependabot/dependabot-core#10122). PR #175 reproduced this: its @types/node 20.x → 25.x bump broke the TypeScript build (verified by running check-types — Symbol.dispose iterator conflict in vscode-jsonrpc's LinkedMap).

Switch to a wildcard dependency-name ignore, matching the pattern used by microsoft/Agents-for-net's dotnet-sdk ecosystem (the origin of this template). Wildcard ignores take a different code path in dependabot and reliably filter grouped updates. Trade-off: all npm majors are now blocked; intentional major bumps require merging manually or using @dependabot ignore commands in the PR.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>