### PR TITLE
Filter majors at group level in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,16 @@ updates:
       all-dependencies:
         patterns:
           - "*"
+        # Filters which update types are rolled into the grouped PR.
+        # Majors are release decisions for this consumer app, not
+        # dependency updates — keep them out of the group.
+        # Note: unlike the npm ecosystem below, there is no top-level
+        # `ignore` here, so a nuget major may still arrive as an
+        # individual PR. Add a matching `ignore` block if that
+        # becomes noisy.
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: npm
     directories:
       - "/src/vscode-extensions/*"
@@ -27,6 +37,14 @@ updates:
       - 'dependencies'
     reviewers:
       - 'microsoft/vscode-copilot-studio-approvers'
+    # Companion to the group-level `update-types` filter below.
+    # When a group excludes an update type, dependabot falls back to
+    # creating an *individual* PR for that dependency. This ignore
+    # suppresses that fallback so no major-bump PRs are created at all.
+    # Do not rely on this alone to filter grouped updates — dependabot
+    # does not apply `ignore` rules to members of a group
+    # (dependabot/dependabot-core#10122); group-level `update-types`
+    # is what actually filters the grouped PR.
     ignore:
       - dependency-name: '*'
         update-types:
@@ -35,3 +53,12 @@ updates:
       all-dependencies:
         patterns:
           - "*"
+        # Filters which update types are rolled into the grouped PR.
+        # Without this, the grouped PR includes majors even when they
+        # match the top-level `ignore` above (known dependabot bug
+        # dependabot/dependabot-core#10122). PR #180 was the repro:
+        # @types/node 20.x → 25.x slipped into an all-dependencies group
+        # even though the ignore rule was live in main.
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
PR #177 switched to a wildcard `ignore` expecting it to filter grouped updates, citing a known bug (dependabot/dependabot-core#10122) where per-dependency ignores are not applied to group members. PR #180 disproved that: with the wildcard ignore live in main, dependabot still rolled @types/node 20.x → 25.x into the all-dependencies grouped PR. Wildcards do not take a different code path.

The correct knob for grouped PRs is `update-types` on the group itself. Add it to both ecosystems so majors are excluded from the group. Keep the npm top-level `ignore` — it still blocks the individual-PR fallback dependabot creates for excluded update types. Comment both rules so the next reader understands why both are required and doesn't retry the wildcard theory.

Nuget has no top-level ignore today; flagged in a comment as a follow-up if individual nuget major PRs become noisy.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>