### PR TITLE
Skip non-language files on Deleted watched-file events

### DIFF
--- a/src/LanguageServers/PowerPlatformLS/Impl.Core/LSP/Handlers/DidChangeWatchedFilesHandler.cs
+++ b/src/LanguageServers/PowerPlatformLS/Impl.Core/LSP/Handlers/DidChangeWatchedFilesHandler.cs
@@ -55,6 +55,13 @@
                         }
                     }
 
+                    if (!WorkspacePath.TryGetLanguageType(filePath, out _))
+                    {
+                        _logger.LogInformation(
+                            $"Client notified '{changeFileEvent.Type}' event on watched files that has no language definition: {filePath.FileName}. Change won't be tracked.");
+                        continue;
+                    }
+
                     var context = _contextResolver.Resolve(new TextDocumentIdentifier { Uri = changeFileEvent.Uri });
                     if (context.IsInvalid)
                     {

--- a/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.Core/ChangeMethodTests.cs
+++ b/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.Core/ChangeMethodTests.cs
@@ -76,6 +76,44 @@
         }
 
         [Fact]
+        public async Task DeletedFileWithoutLanguageDefinition_DoesNotCrashLsp_Async()
+        {
+            (string filepath, bool isFiltered)[] testData =
+            [
+                ("file:///c:/path/topics/Topic1.mcs.yml", false),
+                ("file:///c:/path/data/readme.md", true),
+                ("file:///c:/path/scripts/script.py", true),
+                ("file:///c:/path/data/test_list.txt", true),
+            ];
+            TestLogger logs;
+            await using (var context = new TestHost([new McsLspModule(), new PassRequestModule(), new TestFileModule()]))
+            {
+                await context.InitializeLanguageServerAsync();
+                var changeParams = new DidChangeWatchedFilesParams
+                {
+                    Changes = testData.Select(x => new FileEvent
+                    {
+                        Uri = new Uri(x.filepath),
+                        Type = FileChangeType.Deleted,
+                    }).ToArray()
+                };
+                var changeMessage = JsonRpc.CreateMessage(LspMethods.DidChangeWatchedFiles, changeParams);
+                context.TestStream.WriteMessage(changeMessage);
+                logs = context.Logs;
+
+                // make sure notification are not cancelled and the queue did not crash
+                await PassRequestModule.AssertPassAsync(context);
+            }
+
+            Assert.Empty(logs.Error);
+
+            foreach (var entry in testData.Where(x => x.isFiltered))
+            {
+                Assert.Single(logs.Info.Where(x => x == $"Client notified 'Deleted' event on watched files that has no language definition: {entry.filepath.Split('/')[^1]}. Change won't be tracked."));
+            }
+        }
+
+        [Fact]
         public async Task IgnoreFileRenaming_OnDidChangeWatchedFiles_Async()
         {
             (string filepath, FileChangeType changeType, bool shouldIgnore)[] testData =


### PR DESCRIPTION
The DidChangeWatchedFilesHandler Deleted branch called IRequestContextResolver.Resolve without first checking that the URI maps to a known language. Resolve throws InvalidOperationException for any URI scheme it cannot resolve, which propagated up the request execution queue and triggered LspLifeCycleManager.ShutdownAsync. Once the server shut down, every subsequent request (listWorkspaces, getRemoteChanges, reattachAgent) failed with "Server was requested to shut down", which manifested in VS Code as the Clone Agent screen and a broken reattach.

Mirror the existing Created/Changed guard in the Deleted branch so non-language files (e.g. .pdf, .md, .py, .txt) are logged and skipped instead of reaching the resolver. Add a unit test that fires Deleted events for filtered file types and asserts the queue keeps processing.

Fix: https://github.com/microsoft/vscode-copilotstudio/issues/169