### PR TITLE
Add netstandard2.0 target to Sync to unblock net48 pac build for consuming copilot.sync

### DIFF
--- a/src/CopilotStudio.McsCore/CopilotStudio.McsCore.csproj
+++ b/src/CopilotStudio.McsCore/CopilotStudio.McsCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net10.0</TargetFrameworks>
     <AssemblyName>Microsoft.CopilotStudio.McsCore</AssemblyName>
     <RootNamespace>$(AssemblyName)</RootNamespace>
     <SignAssembly>True</SignAssembly>

--- a/src/CopilotStudio.McsCore/FileAccessorFactory.cs
+++ b/src/CopilotStudio.McsCore/FileAccessorFactory.cs
@@ -98,7 +98,7 @@ internal class FileAccessorFactory : IFileAccessorFactory
 
             foreach (var file in Directory.EnumerateFiles(fullSearchPath, filePattern, SearchOption.AllDirectories))
             {
-                var relative = Path.GetRelativePath(rootPath, file).Replace('\\', '/');
+                var relative = PathHelper.GetRelativePath(rootPath, file).Replace('\\', '/');
                 yield return new AgentFilePath(relative);
             }
         }

--- a/src/CopilotStudio.McsCore/IFileAccessor.cs
+++ b/src/CopilotStudio.McsCore/IFileAccessor.cs
@@ -50,17 +50,23 @@ public interface IFileAccessor
 
 internal static class FileAccessorExtensions
 {
+    // No #if for the WriteAsync/ReadStringAsync overloads below: the
+    // netstandard2.0-compatible call shapes produce identical behavior on net10.
+    //   - WriteAsync(string) avoids the contents.AsMemory() detour. We already hold
+    //     a string; the ROM<char> overload offers no allocation savings here.
+    //   - Stream.WriteAsync(byte[], 0, len, CT) is the underlying overload that
+    //     net10's WriteAsync(byte[], CT) wraps. Pass the offset/length explicitly
+    //     so the same call shape works on both TFMs without any per-TFM cost.
+    //   - StreamReader.ReadToEndAsync() with a boundary cancel check matches
+    //     net10's ReadToEndAsync(CT) for our use case (small agent files);
+    //     mid-read cancellation isn't observable for sub-second reads.
     public static async Task WriteAsync(this IFileAccessor writer, AgentFilePath path, string contents, CancellationToken cancel)
     {
         cancel.ThrowIfCancellationRequested();
 
         using var stream = writer.OpenWrite(path);
         using TextWriter sw = new StreamWriter(stream, Encoding.UTF8);
-#if NETSTANDARD2_0
         await sw.WriteAsync(contents).ConfigureAwait(false);
-#else
-        await sw.WriteAsync(contents.AsMemory(), cancel).ConfigureAwait(false);
-#endif
     }
 
     public static async Task WriteAsync(this IFileAccessor writer, AgentFilePath path, byte[] bytes, CancellationToken cancel)
@@ -69,11 +75,7 @@ internal static class FileAccessorExtensions
 
         using var stream = writer.OpenWrite(path);
 
-#if NETSTANDARD2_0
         await stream.WriteAsync(bytes, 0, bytes.Length, cancel).ConfigureAwait(false);
-#else
-        await stream.WriteAsync(bytes, cancel).ConfigureAwait(false);
-#endif
     }
 
     public static async Task<string> ReadStringAsync(this IFileAccessor writer, AgentFilePath path, CancellationToken cancel)
@@ -83,11 +85,6 @@ internal static class FileAccessorExtensions
         using var stream = writer.OpenRead(path);
         using var sr = new StreamReader(stream);
 
-#if NETSTANDARD2_0
-        var str = await sr.ReadToEndAsync().ConfigureAwait(false);
-#else
-        var str = await sr.ReadToEndAsync(cancel).ConfigureAwait(false);
-#endif
-        return str;
+        return await sr.ReadToEndAsync().ConfigureAwait(false);
     }
 }

--- a/src/CopilotStudio.McsCore/IFileAccessor.cs
+++ b/src/CopilotStudio.McsCore/IFileAccessor.cs
@@ -56,7 +56,11 @@ internal static class FileAccessorExtensions
 
         using var stream = writer.OpenWrite(path);
         using TextWriter sw = new StreamWriter(stream, Encoding.UTF8);
+#if NETSTANDARD2_0
+        await sw.WriteAsync(contents).ConfigureAwait(false);
+#else
         await sw.WriteAsync(contents.AsMemory(), cancel).ConfigureAwait(false);
+#endif
     }
 
     public static async Task WriteAsync(this IFileAccessor writer, AgentFilePath path, byte[] bytes, CancellationToken cancel)
@@ -65,7 +69,11 @@ internal static class FileAccessorExtensions
 
         using var stream = writer.OpenWrite(path);
 
+#if NETSTANDARD2_0
+        await stream.WriteAsync(bytes, 0, bytes.Length, cancel).ConfigureAwait(false);
+#else
         await stream.WriteAsync(bytes, cancel).ConfigureAwait(false);
+#endif
     }
 
     public static async Task<string> ReadStringAsync(this IFileAccessor writer, AgentFilePath path, CancellationToken cancel)
@@ -75,7 +83,11 @@ internal static class FileAccessorExtensions
         using var stream = writer.OpenRead(path);
         using var sr = new StreamReader(stream);
 
+#if NETSTANDARD2_0
+        var str = await sr.ReadToEndAsync().ConfigureAwait(false);
+#else
         var str = await sr.ReadToEndAsync(cancel).ConfigureAwait(false);
+#endif
         return str;
     }
 }

--- a/src/CopilotStudio.McsCore/IsExternalInit.cs
+++ b/src/CopilotStudio.McsCore/IsExternalInit.cs
@@ -1,0 +1,7 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+
+#if NETSTANDARD2_0
+namespace System.Runtime.CompilerServices;
+
+internal static class IsExternalInit { }
+#endif

--- a/src/CopilotStudio.McsCore/LspComponentPathResolver.cs
+++ b/src/CopilotStudio.McsCore/LspComponentPathResolver.cs
@@ -114,7 +114,7 @@ internal sealed class LspComponentPathResolver : IComponentPathResolver
         var infixIndex = schemaName.IndexOf(infix, StringComparison.OrdinalIgnoreCase);
         if (infixIndex >= 0)
         {
-            return schemaName[(infixIndex + infix.Length)..];
+            return schemaName.Substring(infixIndex + infix.Length);
         }
 
         return string.IsNullOrWhiteSpace(schemaName) ? "Unknown" : schemaName;

--- a/src/CopilotStudio.McsCore/LspProjection.cs
+++ b/src/CopilotStudio.McsCore/LspProjection.cs
@@ -665,10 +665,15 @@ internal static class LspProjection
             return schemaName;
         }
 
-        // Remove bot prefix
+        // Remove bot prefix.
+        // schemaName is guaranteed non-null by the early-return at the top of this
+        // method, but netstandard2.0's BCL lacks the [NotNullWhen(false)] annotation
+        // on string.IsNullOrEmpty that net10 has, so the compiler can't narrow it.
+        // The ! operator is a compile-time-only annotation (no IL emitted), symmetric
+        // across both TFMs.
         var withoutPrefix = !string.IsNullOrEmpty(botName)
-            ? schemaName.Substring(botName.Length)
-            : schemaName;
+            ? schemaName!.Substring(botName.Length)
+            : schemaName!;
 
         // Find and remove the infix
         var infixIndex = withoutPrefix.IndexOf(infix, StringComparison.OrdinalIgnoreCase);
@@ -679,7 +684,8 @@ internal static class LspProjection
             // Reserved filenames should not be shortened.
             if (IsReservedShortName(shortName, infix))
             {
-                return schemaName;
+                // schemaName non-null by early-return; ! is compile-time only.
+                return schemaName!;
             }
 
             return shortName;
@@ -688,7 +694,8 @@ internal static class LspProjection
         // Infix not found - schema name doesn't follow expected pattern.
         // Return original schemaName unchanged (e.g., already-qualified names
         // that passed through GetSchemaName without expansion).
-        return schemaName;
+        // schemaName non-null by early-return; ! is compile-time only.
+        return schemaName!;
     }
 
     private static bool IsReservedShortName(string shortName, string infix)

--- a/src/CopilotStudio.McsCore/LspProjection.cs
+++ b/src/CopilotStudio.McsCore/LspProjection.cs
@@ -501,7 +501,7 @@ internal static class LspProjection
         var lastDot = schemaName.LastIndexOf('.');
         if (lastDot < 0 || lastDot == schemaName.Length - 1) return false;
 
-        var suffix = schemaName[(lastDot + 1)..];
+        var suffix = schemaName.Substring(lastDot + 1);
         return IsLocaleSuffix(suffix);
     }
 
@@ -667,14 +667,14 @@ internal static class LspProjection
 
         // Remove bot prefix
         var withoutPrefix = !string.IsNullOrEmpty(botName)
-            ? schemaName[botName.Length..]
+            ? schemaName.Substring(botName.Length)
             : schemaName;
 
         // Find and remove the infix
         var infixIndex = withoutPrefix.IndexOf(infix, StringComparison.OrdinalIgnoreCase);
         if (infixIndex >= 0)
         {
-            var shortName = withoutPrefix[(infixIndex + infix.Length)..];
+            var shortName = withoutPrefix.Substring(infixIndex + infix.Length);
 
             // Reserved filenames should not be shortened.
             if (IsReservedShortName(shortName, infix))

--- a/src/CopilotStudio.McsCore/NullabilityAttributes.cs
+++ b/src/CopilotStudio.McsCore/NullabilityAttributes.cs
@@ -1,0 +1,17 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+//
+// Polyfills for System.Diagnostics.CodeAnalysis nullability annotations that
+// are public on net5+ but internal in netstandard2.0's BCL. Same-namespace
+// internal copies in this assembly take precedence over the BCL's internal
+// copies (which are invisible across assembly boundaries).
+
+#if NETSTANDARD2_0
+namespace System.Diagnostics.CodeAnalysis;
+
+[AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]
+internal sealed class NotNullWhenAttribute : Attribute
+{
+    public NotNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
+    public bool ReturnValue { get; }
+}
+#endif

--- a/src/CopilotStudio.McsCore/PathTypes.cs
+++ b/src/CopilotStudio.McsCore/PathTypes.cs
@@ -28,8 +28,49 @@ internal static class PathHelper
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static int GetHashCode<T>(T path, Func<T, string> getValue)
     {
-        return getValue(path).GetHashCode(StringComparison.OrdinalIgnoreCase);
+        return StringComparer.OrdinalIgnoreCase.GetHashCode(getValue(path));
     }
+
+    internal static string GetRelativePath(string relativeTo, string path)
+    {
+#if NETSTANDARD2_0
+        return GetRelativePathPolyfill(relativeTo, path);
+#else
+        return Path.GetRelativePath(relativeTo, path);
+#endif
+    }
+
+#if NETSTANDARD2_0
+    private static string GetRelativePathPolyfill(string relativeTo, string path)
+    {
+        if (string.IsNullOrEmpty(relativeTo)) throw new ArgumentNullException(nameof(relativeTo));
+        if (string.IsNullOrEmpty(path)) throw new ArgumentNullException(nameof(path));
+
+        var rt = Path.GetFullPath(relativeTo);
+        var p = Path.GetFullPath(path);
+
+        if (rt.Length == 0 || (rt[rt.Length - 1] != Path.DirectorySeparatorChar
+                              && rt[rt.Length - 1] != Path.AltDirectorySeparatorChar))
+        {
+            rt += Path.DirectorySeparatorChar;
+        }
+
+        var rtUri = new Uri(rt);
+        var pUri = new Uri(p);
+
+        if (rtUri.Scheme != pUri.Scheme) return p;
+
+        var relativeUri = rtUri.MakeRelativeUri(pUri);
+        var rel = Uri.UnescapeDataString(relativeUri.ToString());
+
+        if (string.Equals(pUri.Scheme, "file", StringComparison.OrdinalIgnoreCase))
+        {
+            rel = rel.Replace('/', Path.DirectorySeparatorChar);
+        }
+
+        return rel;
+    }
+#endif
 
     internal static T GetRelativeTo<T>(T path, DirectoryPath parent, Func<T, string> getValue, Func<string, T> create)
     {
@@ -73,8 +114,8 @@ public readonly struct DirectoryPath : IEquatable<DirectoryPath>
 
     public DirectoryPath(string path)
     {
-        ArgumentNullException.ThrowIfNull(path);
-        _value = path.Length == 0 || (path[^1] == '/') ? path : path + "/";
+        if (path is null) throw new ArgumentNullException(nameof(path));
+        _value = path.Length == 0 || (path[path.Length - 1] == '/') ? path : path + "/";
         PathHelper.ValidatePath(_value);
     }
 
@@ -175,7 +216,7 @@ public readonly struct DirectoryPath : IEquatable<DirectoryPath>
         EnsureIsRooted();
         parent.EnsureIsRooted();
 
-        var relative = Path.GetRelativePath(parent._value, _value);
+        var relative = PathHelper.GetRelativePath(parent._value, _value);
         relative = relative.Replace('\\', '/');
 
         return new RelativeDirectoryPath(relative);
@@ -214,7 +255,7 @@ public readonly struct FilePath : IEquatable<FilePath>
 
     public FilePath(string path)
     {
-        ArgumentNullException.ThrowIfNull(path);
+        if (path is null) throw new ArgumentNullException(nameof(path));
         if (path.Length == 0 || path == "/")
         {
             throw new ArgumentException($"File path cannot be empty or root. Use '{nameof(DirectoryPath)}'.", nameof(path));
@@ -286,7 +327,7 @@ public readonly struct RelativeDirectoryPath : IEquatable<RelativeDirectoryPath>
 
     public RelativeDirectoryPath(string value)
     {
-        ArgumentNullException.ThrowIfNull(value);
+        if (value is null) throw new ArgumentNullException(nameof(value));
         _value = value;
         PathHelper.ValidatePath(_value);
     }
@@ -308,7 +349,7 @@ public readonly struct RelativeDirectoryPath : IEquatable<RelativeDirectoryPath>
 
     public override int GetHashCode()
     {
-        return _value?.GetHashCode(StringComparison.OrdinalIgnoreCase) ?? 0;
+        return _value is null ? 0 : StringComparer.OrdinalIgnoreCase.GetHashCode(_value);
     }
 
     public static bool operator ==(RelativeDirectoryPath left, RelativeDirectoryPath right) => left.Equals(right);

--- a/src/CopilotStudio.McsCore/PathTypes.cs
+++ b/src/CopilotStudio.McsCore/PathTypes.cs
@@ -33,6 +33,11 @@ internal static class PathHelper
 
     internal static string GetRelativePath(string relativeTo, string path)
     {
+        // #if kept: net10's Path.GetRelativePath uses an in-place character walk;
+        // the netstandard2.0 polyfill below uses Uri.MakeRelativeUri which allocates
+        // two Uri objects per call. The cost is real (extra allocations + parsing
+        // overhead) on a path that fires once per file walked, so we keep BCL on
+        // net10 and only fall back to the Uri-based polyfill when targeting ns2.0.
 #if NETSTANDARD2_0
         return GetRelativePathPolyfill(relativeTo, path);
 #else

--- a/src/CopilotStudio.McsCore/Polyfills.cs
+++ b/src/CopilotStudio.McsCore/Polyfills.cs
@@ -1,0 +1,32 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+//
+// Polyfills for string APIs added after netstandard2.0. Same-namespace
+// internal extension methods take precedence over the BCL's internal
+// equivalents (which are invisible across assembly boundaries).
+
+#if NETSTANDARD2_0
+using System.Collections.Generic;
+
+namespace System;
+
+internal static class StringPolyfills
+{
+    public static bool Contains(this string source, string value, StringComparison comparisonType)
+        => source.IndexOf(value, comparisonType) >= 0;
+
+    public static bool StartsWith(this string source, char value)
+        => source.Length > 0 && source[0] == value;
+
+    public static bool EndsWith(this string source, char value)
+        => source.Length > 0 && source[source.Length - 1] == value;
+}
+
+internal static class EnumerableToHashSetPolyfill
+{
+    public static HashSet<TSource> ToHashSet<TSource>(this IEnumerable<TSource> source)
+        => new HashSet<TSource>(source);
+
+    public static HashSet<TSource> ToHashSet<TSource>(this IEnumerable<TSource> source, IEqualityComparer<TSource>? comparer)
+        => new HashSet<TSource>(source, comparer);
+}
+#endif

--- a/src/CopilotStudio.Sync.Net48Smoke/CopilotStudio.Sync.Net48Smoke.csproj
+++ b/src/CopilotStudio.Sync.Net48Smoke/CopilotStudio.Sync.Net48Smoke.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+    <AssemblyName>Microsoft.CopilotStudio.Sync.Net48Smoke</AssemblyName>
+    <RootNamespace>$(AssemblyName)</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\CopilotStudio.Sync\CopilotStudio.Sync.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/CopilotStudio.Sync.Net48Smoke/IsExternalInitTests.cs
+++ b/src/CopilotStudio.Sync.Net48Smoke/IsExternalInitTests.cs
@@ -1,0 +1,47 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+//
+// Smoke tests targeting net48 to validate that the netstandard2.0 build of
+// Microsoft.CopilotStudio.Sync is consumable from a net48 host.
+//
+// Compile-time gate (always active):
+//   Net48's BCL does not provide System.Runtime.CompilerServices.IsExternalInit,
+//   so any public init-only setter on a Sync type forces the consumer to bind
+//   IsExternalInit at compile time. The test methods below construct
+//   AgentSyncInfo via init setters; if Sync's polyfill is missing or unresolvable
+//   from a net48 consumer, this project fails to compile. Building the project
+//   is the test for that.
+//
+// Runtime tests (skipped by default):
+//   The test bodies also assert the loaded type behaves correctly. Running them
+//   requires loading the dev-built (delay-signed) Sync.dll, which fails strong-
+//   name verification on net48 unless skip-verification is registered. See
+//   Net48RuntimeFactAttribute.cs for how to enable. Published builds of the
+//   package are fully signed, so this only affects local dev validation.
+
+using Microsoft.CopilotStudio.Sync;
+using Xunit;
+
+namespace Microsoft.CopilotStudio.Sync.Net48Smoke;
+
+public class IsExternalInitTests
+{
+    [Net48RuntimeFact]
+    public void Net48ConsumerCanConstructPublicRecordWithInitSetters()
+    {
+        var info = new AgentSyncInfo
+        {
+            DataverseEndpoint = new System.Uri("https://example.com/"),
+            EnvironmentId = "smoke-test-env",
+        };
+
+        Assert.NotNull(info);
+        Assert.Equal("smoke-test-env", info.EnvironmentId);
+        Assert.Equal("https://example.com/", info.DataverseEndpoint.ToString());
+    }
+
+    [Net48RuntimeFact]
+    public void Net48BinaryLoadsAndExposesPublicTypes()
+    {
+        Assert.NotNull(typeof(AgentSyncInfo));
+    }
+}

--- a/src/CopilotStudio.Sync.Net48Smoke/Net48RuntimeFactAttribute.cs
+++ b/src/CopilotStudio.Sync.Net48Smoke/Net48RuntimeFactAttribute.cs
@@ -1,0 +1,42 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+
+using Xunit;
+
+namespace Microsoft.CopilotStudio.Sync.Net48Smoke;
+
+/// <summary>
+/// xUnit Fact that auto-skips on hosts where strong-name verification is still
+/// enforced for delay-signed assemblies (the default on a fresh net48 dev box).
+///
+/// This project's primary value is its compile success: the project builds against
+/// the netstandard2.0 binary of Microsoft.CopilotStudio.Sync from a net48 consumer,
+/// proving that public init-only setters are usable cross-assembly without a public
+/// IsExternalInit polyfill. The runtime test bodies are bonus -- they exercise the
+/// loaded assembly to catch type-load issues -- but they require the dev-built
+/// delay-signed Sync.dll to be loadable, which means strong-name verification must
+/// be disabled for the assembly's public key token.
+///
+/// CI does this once at pipeline start via:
+///   reg ADD "HKLM\Software\Microsoft\StrongName\Verification\*,*" /f
+///
+/// To enable the runtime tests on a local dev box:
+///   1. Either run the same registry add (admin shell), or use sn.exe:
+///        sn -Vr *,31bf3856ad364e35
+///      (where 31bf3856ad364e35 is the public key token reported in the load
+///       failure message; same value as Microsoft's public key).
+///   2. Set the env var ENABLE_NET48_SMOKE_RUNTIME=1 and re-run tests.
+///
+/// Published builds of the package are fully signed, so consumers of the released
+/// nupkg do not need any of this -- they just reference and use Sync normally.
+/// </summary>
+internal sealed class Net48RuntimeFactAttribute : FactAttribute
+{
+    public Net48RuntimeFactAttribute()
+    {
+        if (string.IsNullOrEmpty(System.Environment.GetEnvironmentVariable("ENABLE_NET48_SMOKE_RUNTIME")))
+        {
+            Skip = "Disabled by default. Requires strong-name verification skip for the delay-signed dev-build assembly. " +
+                   "Set ENABLE_NET48_SMOKE_RUNTIME=1 to enable; see Net48RuntimeFactAttribute.cs for setup.";
+        }
+    }
+}

--- a/src/CopilotStudio.Sync/CopilotStudio.Sync.csproj
+++ b/src/CopilotStudio.Sync/CopilotStudio.Sync.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net10.0</TargetFrameworks>
     <AssemblyName>Microsoft.CopilotStudio.Sync</AssemblyName>
     <RootNamespace>$(AssemblyName)</RootNamespace>
     <SignAssembly>True</SignAssembly>

--- a/src/CopilotStudio.Sync/Dataverse/SchemaNameGenerator.cs
+++ b/src/CopilotStudio.Sync/Dataverse/SchemaNameGenerator.cs
@@ -44,7 +44,11 @@ public static class SchemaNameGenerator
     private static string RandId(int length)
     {
         const string chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+#if NETSTANDARD2_0
+        return new string(Enumerable.Range(0, length).Select(_ => chars[RandomNumberGeneratorPolyfill.GetInt32(chars.Length)]).ToArray());
+#else
         return new string(Enumerable.Range(0, length).Select(_ => chars[RandomNumberGenerator.GetInt32(chars.Length)]).ToArray());
+#endif
     }
 
     /// <summary>

--- a/src/CopilotStudio.Sync/Dataverse/SchemaNameGenerator.cs
+++ b/src/CopilotStudio.Sync/Dataverse/SchemaNameGenerator.cs
@@ -44,6 +44,10 @@ public static class SchemaNameGenerator
     private static string RandId(int length)
     {
         const string chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+        // #if kept: net10's RandomNumberGenerator.GetInt32 is a native implementation
+        // that avoids managed buffer allocation. The netstandard2.0 polyfill performs
+        // rejection sampling in managed code with a per-call 4-byte buffer alloc -- a
+        // small but real cost on net10 if we LCD'd here. Keeping the dispatch.
 #if NETSTANDARD2_0
         return new string(Enumerable.Range(0, length).Select(_ => chars[RandomNumberGeneratorPolyfill.GetInt32(chars.Length)]).ToArray());
 #else

--- a/src/CopilotStudio.Sync/Dataverse/SyncDataverseClient.cs
+++ b/src/CopilotStudio.Sync/Dataverse/SyncDataverseClient.cs
@@ -274,7 +274,8 @@ public class SyncDataverseClient : ISyncDataverseClient
 
             while (!string.IsNullOrEmpty(nextBotComponentWorkflowUrl))
             {
-                var response = await SendAsync<JsonElement>(HttpMethod.Get, nextBotComponentWorkflowUrl, null, false, cancellationToken).ConfigureAwait(false);
+                // ns2.0 BCL's IsNullOrEmpty lacks NotNullWhen annotation; ! is compile-time only.
+                var response = await SendAsync<JsonElement>(HttpMethod.Get, nextBotComponentWorkflowUrl!, null, false, cancellationToken).ConfigureAwait(false);
 
                 if (response.TryGetProperty("value", out var valueArray) && valueArray.ValueKind == JsonValueKind.Array)
                 {
@@ -320,7 +321,8 @@ public class SyncDataverseClient : ISyncDataverseClient
 
             while (!string.IsNullOrEmpty(nextWorkflowUrl))
             {
-                var response = await SendAsync<JsonElement>(HttpMethod.Get, nextWorkflowUrl, null, false, cancellationToken).ConfigureAwait(false);
+                // ns2.0 BCL's IsNullOrEmpty lacks NotNullWhen annotation; ! is compile-time only.
+                var response = await SendAsync<JsonElement>(HttpMethod.Get, nextWorkflowUrl!, null, false, cancellationToken).ConfigureAwait(false);
                 if (response.TryGetProperty("value", out var workflowArray) && workflowArray.ValueKind == JsonValueKind.Array)
                 {
                     foreach (var element in workflowArray.EnumerateArray())

--- a/src/CopilotStudio.Sync/Dataverse/SyncDataverseClient.cs
+++ b/src/CopilotStudio.Sync/Dataverse/SyncDataverseClient.cs
@@ -107,7 +107,7 @@ public class SyncDataverseClient : ISyncDataverseClient
 
             var requestBody = CreateWorkflowRequestBody(workflowMetadata);
             var updateUrl = $"{DataverseUrl}/api/data/v9.2/workflows({workflowMetadata.WorkflowId})";
-            await SendAsync<object>(HttpMethod.Patch, updateUrl, requestBody, false, cancellationToken).ConfigureAwait(false);
+            await SendAsync<object>(HttpMethodHelper.Patch, updateUrl, requestBody, false, cancellationToken).ConfigureAwait(false);
         }
         catch (OperationCanceledException)
         {
@@ -245,7 +245,7 @@ public class SyncDataverseClient : ISyncDataverseClient
             ["statuscode"] = 2
         };
 
-        await SendAsync<object>(HttpMethod.Patch, activateUrl, activateBody, false, cancellationToken).ConfigureAwait(false);
+        await SendAsync<object>(HttpMethodHelper.Patch, activateUrl, activateBody, false, cancellationToken).ConfigureAwait(false);
     }
 
     private async Task<List<Guid>> GetAllBotComponentIdsAsync(Guid agentId, CancellationToken cancellationToken)
@@ -380,7 +380,7 @@ public class SyncDataverseClient : ISyncDataverseClient
         string connectionReferenceLogicalName,
         CancellationToken cancellationToken)
     {
-        ArgumentNullException.ThrowIfNull(connectionReferenceLogicalName);
+        if (connectionReferenceLogicalName is null) throw new ArgumentNullException(nameof(connectionReferenceLogicalName));
         var literal = connectionReferenceLogicalName.Replace("'", "''");
         var filterExpr = $"connectionreferencelogicalname eq '{literal}'";
         var baseUri = new Uri(new Uri(DataverseUrl), "/api/data/v9.2/connectionreferences");
@@ -518,7 +518,11 @@ public class SyncDataverseClient : ISyncDataverseClient
 
         using var fileStream = new FileStream(localPath, FileMode.Create, FileAccess.Write, FileShare.None, 81920, useAsync: true);
 
+#if NETSTANDARD2_0
+        await stream.CopyToAsync(fileStream, 81920, cancellationToken).ConfigureAwait(false);
+#else
         await stream.CopyToAsync(fileStream, cancellationToken).ConfigureAwait(false);
+#endif
     }
 
     public async Task UploadKnowledgeFileAsync(string knowledgeFileFolder, Guid botComponentId, string fileName, CancellationToken cancellationToken = default)
@@ -527,7 +531,7 @@ public class SyncDataverseClient : ISyncDataverseClient
         var httpClient = _httpClientAccessor.CreateClient();
         using var fileStream = new FileStream(GetKnowledgeFileLocalPath(knowledgeFileFolder, fileName), FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 81920, useAsync: true);
 
-        using var request = new HttpRequestMessage(HttpMethod.Patch, requestUri)
+        using var request = new HttpRequestMessage(HttpMethodHelper.Patch, requestUri)
         {
             Content = new StreamContent(fileStream, bufferSize: 81920)
         };

--- a/src/CopilotStudio.Sync/Dataverse/SyncDataverseClient.cs
+++ b/src/CopilotStudio.Sync/Dataverse/SyncDataverseClient.cs
@@ -518,11 +518,10 @@ public class SyncDataverseClient : ISyncDataverseClient
 
         using var fileStream = new FileStream(localPath, FileMode.Create, FileAccess.Write, FileShare.None, 81920, useAsync: true);
 
-#if NETSTANDARD2_0
+        // No #if: passing 81920 explicitly is identical to net10's default buffer size
+        // on Stream.CopyToAsync(Stream, CT), and the 3-arg form is what netstandard2.0
+        // exposes -- so the same expression compiles and behaves the same on both TFMs.
         await stream.CopyToAsync(fileStream, 81920, cancellationToken).ConfigureAwait(false);
-#else
-        await stream.CopyToAsync(fileStream, cancellationToken).ConfigureAwait(false);
-#endif
     }
 
     public async Task UploadKnowledgeFileAsync(string knowledgeFileFolder, Guid botComponentId, string fileName, CancellationToken cancellationToken = default)

--- a/src/CopilotStudio.Sync/EnumerableChunkPolyfill.cs
+++ b/src/CopilotStudio.Sync/EnumerableChunkPolyfill.cs
@@ -1,0 +1,36 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+
+#if NETSTANDARD2_0
+using System.Collections.Generic;
+
+namespace System.Linq;
+
+internal static class EnumerableChunkPolyfill
+{
+    public static IEnumerable<TSource[]> Chunk<TSource>(this IEnumerable<TSource> source, int size)
+    {
+        if (source is null) throw new ArgumentNullException(nameof(source));
+        if (size < 1) throw new ArgumentOutOfRangeException(nameof(size));
+
+        TSource[]? buffer = null;
+        var count = 0;
+        foreach (var item in source)
+        {
+            buffer ??= new TSource[size];
+            buffer[count++] = item;
+            if (count == size)
+            {
+                yield return buffer;
+                buffer = null;
+                count = 0;
+            }
+        }
+
+        if (count > 0)
+        {
+            Array.Resize(ref buffer, count);
+            yield return buffer!;
+        }
+    }
+}
+#endif

--- a/src/CopilotStudio.Sync/FileShim.cs
+++ b/src/CopilotStudio.Sync/FileShim.cs
@@ -1,0 +1,33 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.CopilotStudio.Sync;
+
+internal static class FileShim
+{
+    public static async Task<string> ReadAllTextAsync(string path, CancellationToken cancellationToken)
+    {
+#if NETSTANDARD2_0
+        cancellationToken.ThrowIfCancellationRequested();
+        using var sr = new StreamReader(path);
+        return await sr.ReadToEndAsync().ConfigureAwait(false);
+#else
+        return await File.ReadAllTextAsync(path, cancellationToken).ConfigureAwait(false);
+#endif
+    }
+
+    public static async Task<string> ReadAllTextAsync(string path, Encoding encoding, CancellationToken cancellationToken)
+    {
+#if NETSTANDARD2_0
+        cancellationToken.ThrowIfCancellationRequested();
+        using var sr = new StreamReader(path, encoding);
+        return await sr.ReadToEndAsync().ConfigureAwait(false);
+#else
+        return await File.ReadAllTextAsync(path, encoding, cancellationToken).ConfigureAwait(false);
+#endif
+    }
+}

--- a/src/CopilotStudio.Sync/FileShim.cs
+++ b/src/CopilotStudio.Sync/FileShim.cs
@@ -9,25 +9,22 @@ namespace Microsoft.CopilotStudio.Sync;
 
 internal static class FileShim
 {
+    // No #if needed: net10's File.ReadAllTextAsync is itself implemented as a
+    // StreamReader+ReadToEndAsync internally, so this LCD form is functionally
+    // identical. Cancellation is checked at boundary rather than mid-read; the
+    // call sites read small config files (workflow JSON/YAML), where mid-read
+    // cancellation has no practical value.
     public static async Task<string> ReadAllTextAsync(string path, CancellationToken cancellationToken)
     {
-#if NETSTANDARD2_0
         cancellationToken.ThrowIfCancellationRequested();
         using var sr = new StreamReader(path);
         return await sr.ReadToEndAsync().ConfigureAwait(false);
-#else
-        return await File.ReadAllTextAsync(path, cancellationToken).ConfigureAwait(false);
-#endif
     }
 
     public static async Task<string> ReadAllTextAsync(string path, Encoding encoding, CancellationToken cancellationToken)
     {
-#if NETSTANDARD2_0
         cancellationToken.ThrowIfCancellationRequested();
         using var sr = new StreamReader(path, encoding);
         return await sr.ReadToEndAsync().ConfigureAwait(false);
-#else
-        return await File.ReadAllTextAsync(path, encoding, cancellationToken).ConfigureAwait(false);
-#endif
     }
 }

--- a/src/CopilotStudio.Sync/FileShim.cs
+++ b/src/CopilotStudio.Sync/FileShim.cs
@@ -9,22 +9,37 @@ namespace Microsoft.CopilotStudio.Sync;
 
 internal static class FileShim
 {
-    // No #if needed: net10's File.ReadAllTextAsync is itself implemented as a
-    // StreamReader+ReadToEndAsync internally, so this LCD form is functionally
-    // identical. Cancellation is checked at boundary rather than mid-read; the
-    // call sites read small config files (workflow JSON/YAML), where mid-read
-    // cancellation has no practical value.
+    /// <summary>
+    /// Reads a file's text contents asynchronously, with the best async I/O
+    /// available on each target framework.
+    /// </summary>
+    /// <remarks>
+    /// On net10, dispatches to File.ReadAllTextAsync which opens the underlying
+    /// FileStream with useAsync:true and performs real async I/O. On
+    /// netstandard2.0, falls back to a StreamReader-based read because
+    /// File.ReadAllTextAsync is unavailable; cancellation is checked once at
+    /// boundary rather than mid-read, which is acceptable for the small config
+    /// files this shim's call sites read (workflow JSON/YAML).
+    /// </remarks>
     public static async Task<string> ReadAllTextAsync(string path, CancellationToken cancellationToken)
     {
+#if NETSTANDARD2_0
         cancellationToken.ThrowIfCancellationRequested();
         using var sr = new StreamReader(path);
         return await sr.ReadToEndAsync().ConfigureAwait(false);
+#else
+        return await File.ReadAllTextAsync(path, cancellationToken).ConfigureAwait(false);
+#endif
     }
 
     public static async Task<string> ReadAllTextAsync(string path, Encoding encoding, CancellationToken cancellationToken)
     {
+#if NETSTANDARD2_0
         cancellationToken.ThrowIfCancellationRequested();
         using var sr = new StreamReader(path, encoding);
         return await sr.ReadToEndAsync().ConfigureAwait(false);
+#else
+        return await File.ReadAllTextAsync(path, encoding, cancellationToken).ConfigureAwait(false);
+#endif
     }
 }

--- a/src/CopilotStudio.Sync/IsExternalInit.cs
+++ b/src/CopilotStudio.Sync/IsExternalInit.cs
@@ -1,0 +1,7 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+
+#if NETSTANDARD2_0
+namespace System.Runtime.CompilerServices;
+
+internal static class IsExternalInit { }
+#endif

--- a/src/CopilotStudio.Sync/SyncPolyfills.cs
+++ b/src/CopilotStudio.Sync/SyncPolyfills.cs
@@ -9,11 +9,10 @@ namespace Microsoft.CopilotStudio.Sync
 {
     internal static class HttpMethodHelper
     {
-#if NETSTANDARD2_0
+        // No #if needed: `new HttpMethod("PATCH")` produces an HttpMethod
+        // semantically identical to the net10-only HttpMethod.Patch static.
+        // Identity is by Method string, so a single instance suffices on both TFMs.
         public static readonly HttpMethod Patch = new HttpMethod("PATCH");
-#else
-        public static readonly HttpMethod Patch = HttpMethod.Patch;
-#endif
     }
 }
 

--- a/src/CopilotStudio.Sync/SyncPolyfills.cs
+++ b/src/CopilotStudio.Sync/SyncPolyfills.cs
@@ -1,0 +1,65 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+//
+// Sync-local polyfills for APIs added after netstandard2.0. McsCore polyfills
+// for string extensions and ToHashSet are also visible here via InternalsVisibleTo.
+
+using System.Net.Http;
+
+namespace Microsoft.CopilotStudio.Sync
+{
+    internal static class HttpMethodHelper
+    {
+#if NETSTANDARD2_0
+        public static readonly HttpMethod Patch = new HttpMethod("PATCH");
+#else
+        public static readonly HttpMethod Patch = HttpMethod.Patch;
+#endif
+    }
+}
+
+#if NETSTANDARD2_0
+namespace System.Net.Http
+{
+    using System.IO;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    internal static class HttpContentPolyfills
+    {
+        public static async Task<string> ReadAsStringAsync(this HttpContent content, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return await content.ReadAsStringAsync().ConfigureAwait(false);
+        }
+
+        public static async Task<Stream> ReadAsStreamAsync(this HttpContent content, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return await content.ReadAsStreamAsync().ConfigureAwait(false);
+        }
+    }
+}
+
+namespace System.Security.Cryptography
+{
+    internal static class RandomNumberGeneratorPolyfill
+    {
+        public static int GetInt32(int toExclusive)
+        {
+            if (toExclusive <= 0) throw new ArgumentOutOfRangeException(nameof(toExclusive));
+
+            using var rng = RandomNumberGenerator.Create();
+            var bytes = new byte[4];
+            var range = (uint)toExclusive;
+            var mask = uint.MaxValue - (uint.MaxValue % range);
+            uint result;
+            do
+            {
+                rng.GetBytes(bytes);
+                result = BitConverter.ToUInt32(bytes, 0);
+            } while (result >= mask);
+            return (int)(result % range);
+        }
+    }
+}
+#endif

--- a/src/CopilotStudio.Sync/WorkspaceSynchronizer.cs
+++ b/src/CopilotStudio.Sync/WorkspaceSynchronizer.cs
@@ -159,12 +159,10 @@ internal class WorkspaceSynchronizer : IWorkspaceSynchronizer
             {
                 using var file = fileAccessor.OpenRead(ReferencesCollectionPath);
                 using var sr = new StreamReader(file);
-#if NETSTANDARD2_0
+                // No #if: small references file; boundary cancellation matches net10
+                // ReadToEndAsync(CT) for our use case.
                 cancellation.ThrowIfCancellationRequested();
                 var yaml = await sr.ReadToEndAsync().ConfigureAwait(false);
-#else
-                var yaml = await sr.ReadToEndAsync(cancellation).ConfigureAwait(false);
-#endif
                 var refs = CodeSerializer.Deserialize<ReferencesSourceFile>(yaml);
 
                 if (refs == null)
@@ -344,6 +342,10 @@ internal class WorkspaceSynchronizer : IWorkspaceSynchronizer
         if (downloadAllKnowledgeFiles && newSnapshot != null)
         {
             var fileComponents = newSnapshot.Components.OfType<FileAttachmentComponent>().Where(c => !string.IsNullOrEmpty(c.DisplayName)).ToList();
+            // #if kept: net10 uses Parallel.ForEachAsync with MaxDegreeOfParallelism=5
+            // for concurrent knowledge-file downloads. netstandard2.0 has no equivalent
+            // and the LCD foreach loses ~5x throughput when the agent has many knowledge
+            // files. The cost is real, so we preserve the per-TFM behavior.
 #if NETSTANDARD2_0
             foreach (var localComponent in fileComponents)
             {
@@ -595,6 +597,10 @@ internal class WorkspaceSynchronizer : IWorkspaceSynchronizer
                 return 0;
             }
 
+            // #if kept: net10 uses Parallel.ForEachAsync with MaxDegreeOfParallelism=5
+            // for concurrent knowledge-file uploads; netstandard2.0 has no equivalent
+            // and the LCD foreach loses ~5x throughput. Cost is real, so we preserve
+            // per-TFM behavior.
 #if NETSTANDARD2_0
             foreach (var newFileComponent in newFileComponents)
             {
@@ -1732,12 +1738,9 @@ internal class WorkspaceSynchronizer : IWorkspaceSynchronizer
 
             using var stream = fileAccessor.OpenRead(filePath);
             using var reader = new StreamReader(stream, Encoding.UTF8);
-#if NETSTANDARD2_0
+            // No #if: small component file; boundary cancellation is sufficient.
             cancellationToken.ThrowIfCancellationRequested();
             var yaml = await reader.ReadToEndAsync().ConfigureAwait(false);
-#else
-            var yaml = await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
-#endif
 
             var deserialized = CodeSerializer.Deserialize(yaml, component.RootElement?.GetType() ?? typeof(BotElement), null);
             var (parsed, error) = _fileParser.CompileFileModel(component.SchemaNameString, deserialized, component.DisplayName, component.Description);
@@ -1847,12 +1850,9 @@ internal class WorkspaceSynchronizer : IWorkspaceSynchronizer
 
             using var stream = fileAccessor.OpenRead(filePath);
             using var reader = new StreamReader(stream, Encoding.UTF8);
-#if NETSTANDARD2_0
+            // No #if: small env-var file; boundary cancellation is sufficient.
             cancellationToken.ThrowIfCancellationRequested();
             var yaml = await reader.ReadToEndAsync().ConfigureAwait(false);
-#else
-            var yaml = await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
-#endif
 
             if (CodeSerializer.Deserialize(yaml, typeof(EnvironmentVariableDefinition), null) is EnvironmentVariableDefinition envVar)
             {

--- a/src/CopilotStudio.Sync/WorkspaceSynchronizer.cs
+++ b/src/CopilotStudio.Sync/WorkspaceSynchronizer.cs
@@ -1659,22 +1659,51 @@ internal class WorkspaceSynchronizer : IWorkspaceSynchronizer
                     using var jsonDoc = JsonDocument.Parse(workflow.ClientData!);
                     var jsonString = JsonSerializer.Serialize(jsonDoc.RootElement, new JsonSerializerOptions { WriteIndented = true });
 
+                    // net10 uses async disposal so the StreamWriter and FileStream flush
+                    // asynchronously; netstandard2.0's Stream is not IAsyncDisposable, so
+                    // it falls back to sync using. The sync-flush cost on the ns2.0 path
+                    // is bounded (workflow JSON payloads are 1-50 KB on local disk).
+#if NETSTANDARD2_0
                     using (var jsonStream = fileAccessor.OpenWrite(workflowJsonTmp))
                     using (var writer = new StreamWriter(jsonStream, Encoding.UTF8))
                     {
                         await writer.WriteAsync(jsonString).ConfigureAwait(false);
                     }
+#else
+                    var jsonStream = fileAccessor.OpenWrite(workflowJsonTmp);
+                    await using (jsonStream.ConfigureAwait(false))
+                    {
+                        var writer = new StreamWriter(jsonStream, Encoding.UTF8);
+                        await using (writer.ConfigureAwait(false))
+                        {
+                            await writer.WriteAsync(jsonString).ConfigureAwait(false);
+                        }
+                    }
+#endif
                     fileAccessor.Replace(workflowJsonTmp, workflowJson);
 
                     var workflowMetadata = new AgentFilePath($"{workflowFolder}/metadata.yml");
                     var workflowMetadataTmp = new AgentFilePath($"{workflowFolder}/metadata.yml.tmp");
                     var serializer = new SerializerBuilder().WithNamingConvention(CamelCaseNamingConvention.Instance).Build();
 
+                    // Same async-vs-sync disposal split as the workflow.json block above.
+#if NETSTANDARD2_0
                     using (var metaStream = fileAccessor.OpenWrite(workflowMetadataTmp))
                     using (var writer = new StreamWriter(metaStream, Encoding.UTF8))
                     {
                         serializer.Serialize(writer, workflow);
                     }
+#else
+                    var metaStream = fileAccessor.OpenWrite(workflowMetadataTmp);
+                    await using (metaStream.ConfigureAwait(false))
+                    {
+                        var writer = new StreamWriter(metaStream, Encoding.UTF8);
+                        await using (writer.ConfigureAwait(false))
+                        {
+                            serializer.Serialize(writer, workflow);
+                        }
+                    }
+#endif
                     fileAccessor.Replace(workflowMetadataTmp, workflowMetadata);
                 }
             }

--- a/src/CopilotStudio.Sync/WorkspaceSynchronizer.cs
+++ b/src/CopilotStudio.Sync/WorkspaceSynchronizer.cs
@@ -616,10 +616,11 @@ internal class WorkspaceSynchronizer : IWorkspaceSynchronizer
                     continue;
                 }
 
+                // ns2.0 BCL's IsNullOrEmpty lacks NotNullWhen; ! is compile-time only.
                 await dataverseClient.UploadKnowledgeFileAsync(
                     Path.Combine(workspaceFolder.ToString(), componentPath.ParentDirectoryName),
                     newFileComponent.Id.Value,
-                    newFileComponent.DisplayName,
+                    newFileComponent.DisplayName!,
                     cancellationToken
                 ).ConfigureAwait(false);
 
@@ -1654,7 +1655,8 @@ internal class WorkspaceSynchronizer : IWorkspaceSynchronizer
                     var workflowJsonTmp = new AgentFilePath($"{workflowFolder}/workflow.json.tmp");
                     workflow.JsonFileName = workflowJson.ToString();
 
-                    using var jsonDoc = JsonDocument.Parse(workflow.ClientData);
+                    // ns2.0 BCL's IsNullOrWhiteSpace lacks NotNullWhen; ! is compile-time only.
+                    using var jsonDoc = JsonDocument.Parse(workflow.ClientData!);
                     var jsonString = JsonSerializer.Serialize(jsonDoc.RootElement, new JsonSerializerOptions { WriteIndented = true });
 
                     using (var jsonStream = fileAccessor.OpenWrite(workflowJsonTmp))
@@ -2118,7 +2120,8 @@ internal class WorkspaceSynchronizer : IWorkspaceSynchronizer
                 continue;
             }
 
-            using var doc = JsonDocument.Parse(workflow.ClientData);
+            // ns2.0 BCL's IsNullOrWhiteSpace lacks NotNullWhen; ! is compile-time only.
+            using var doc = JsonDocument.Parse(workflow.ClientData!);
             var root = doc.RootElement;
             var names = ExtractConnectionReferenceLogicalNames(root);
 
@@ -2137,12 +2140,13 @@ internal class WorkspaceSynchronizer : IWorkspaceSynchronizer
         {
             try
             {
-                using var doc = JsonDocument.Parse(s.Value);
+                // ns2.0 BCL's IsNullOrEmpty lacks NotNullWhen; ! is compile-time only.
+                using var doc = JsonDocument.Parse(s.Value!);
                 return JsonSerializer.Serialize(doc.RootElement, new JsonSerializerOptions { WriteIndented = true });
             }
             catch (JsonException)
             {
-                return s.Value;
+                return s.Value!;
             }
         }
 
@@ -2156,7 +2160,8 @@ internal class WorkspaceSynchronizer : IWorkspaceSynchronizer
         var workflowConnectionNames = ImmutableArray<string>.Empty;
         if (!string.IsNullOrWhiteSpace(workflow.ClientData))
         {
-            using var document = JsonDocument.Parse(workflow.ClientData);
+            // ns2.0 BCL's IsNullOrWhiteSpace lacks NotNullWhen; ! is compile-time only.
+            using var document = JsonDocument.Parse(workflow.ClientData!);
             var root = document.RootElement;
             inputType = ExtractRecordDataType(
                 root,

--- a/src/CopilotStudio.Sync/WorkspaceSynchronizer.cs
+++ b/src/CopilotStudio.Sync/WorkspaceSynchronizer.cs
@@ -159,7 +159,12 @@ internal class WorkspaceSynchronizer : IWorkspaceSynchronizer
             {
                 using var file = fileAccessor.OpenRead(ReferencesCollectionPath);
                 using var sr = new StreamReader(file);
+#if NETSTANDARD2_0
+                cancellation.ThrowIfCancellationRequested();
+                var yaml = await sr.ReadToEndAsync().ConfigureAwait(false);
+#else
                 var yaml = await sr.ReadToEndAsync(cancellation).ConfigureAwait(false);
+#endif
                 var refs = CodeSerializer.Deserialize<ReferencesSourceFile>(yaml);
 
                 if (refs == null)
@@ -338,7 +343,21 @@ internal class WorkspaceSynchronizer : IWorkspaceSynchronizer
 
         if (downloadAllKnowledgeFiles && newSnapshot != null)
         {
-            await Parallel.ForEachAsync(newSnapshot.Components.OfType<FileAttachmentComponent>().Where(c => !string.IsNullOrEmpty(c.DisplayName)).ToList(), new ParallelOptions
+            var fileComponents = newSnapshot.Components.OfType<FileAttachmentComponent>().Where(c => !string.IsNullOrEmpty(c.DisplayName)).ToList();
+#if NETSTANDARD2_0
+            foreach (var localComponent in fileComponents)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var componentPath = new AgentFilePath(_pathResolver.GetComponentPath(localComponent, newSnapshot));
+                await dataverseClient.DownloadKnowledgeFileAsync(
+                    Path.Combine(workspaceFolder.ToString(), componentPath.ParentDirectoryName),
+                    localComponent.Id,
+                    localComponent.DisplayName ?? localComponent.Id.Value.ToString(),
+                    cancellationToken
+                ).ConfigureAwait(false);
+            }
+#else
+            await Parallel.ForEachAsync(fileComponents, new ParallelOptions
             {
                 MaxDegreeOfParallelism = 5,
                 CancellationToken = cancellationToken
@@ -352,6 +371,7 @@ internal class WorkspaceSynchronizer : IWorkspaceSynchronizer
                     cancellationToken
                 ).ConfigureAwait(false);
             }).ConfigureAwait(false);
+#endif
         }
 
         // persist updated change set on directory
@@ -575,6 +595,31 @@ internal class WorkspaceSynchronizer : IWorkspaceSynchronizer
                 return 0;
             }
 
+#if NETSTANDARD2_0
+            foreach (var newFileComponent in newFileComponents)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (string.IsNullOrEmpty(newFileComponent.DisplayName))
+                {
+                    continue;
+                }
+
+                var componentPath = new AgentFilePath(_pathResolver.GetComponentPath(newFileComponent, snapshot));
+                if (!IsValidFileToUpload(componentPath))
+                {
+                    continue;
+                }
+
+                await dataverseClient.UploadKnowledgeFileAsync(
+                    Path.Combine(workspaceFolder.ToString(), componentPath.ParentDirectoryName),
+                    newFileComponent.Id.Value,
+                    newFileComponent.DisplayName,
+                    cancellationToken
+                ).ConfigureAwait(false);
+
+                numberOfUploadedFiles++;
+            }
+#else
             await Parallel.ForEachAsync(newFileComponents, new ParallelOptions
             {
                 MaxDegreeOfParallelism = 5,
@@ -602,6 +647,7 @@ internal class WorkspaceSynchronizer : IWorkspaceSynchronizer
 
                 numberOfUploadedFiles++;
             }).ConfigureAwait(false);
+#endif
         }
 
         return numberOfUploadedFiles;
@@ -902,7 +948,7 @@ internal class WorkspaceSynchronizer : IWorkspaceSynchronizer
         return new AgentFilePath($"{EnvironmentVariablesFolder}/{schemaName}.mcs.yml");
     }
 
-    private static string GetAgentSchemaName(string fullSchema) => fullSchema[..(fullSchema.IndexOf('.') is var i && i > 0 ? i : fullSchema.Length)];
+    private static string GetAgentSchemaName(string fullSchema) => fullSchema.Substring(0, fullSchema.IndexOf('.') is var i && i > 0 ? i : fullSchema.Length);
     
     private void WriteComponentCollection(IFileAccessor fileAccessor, BotComponentCollection? collection, CancellationToken cancellationToken)
     {
@@ -1497,8 +1543,8 @@ internal class WorkspaceSynchronizer : IWorkspaceSynchronizer
                         continue;
                     }
 
-                    var clientDataJson = await File.ReadAllTextAsync(jsonFile, Encoding.UTF8, cancellationToken).ConfigureAwait(false);
-                    var yamlText = await File.ReadAllTextAsync(metadataFile, Encoding.UTF8, cancellationToken).ConfigureAwait(false);
+                    var clientDataJson = await FileShim.ReadAllTextAsync(jsonFile, Encoding.UTF8, cancellationToken).ConfigureAwait(false);
+                    var yamlText = await FileShim.ReadAllTextAsync(metadataFile, Encoding.UTF8, cancellationToken).ConfigureAwait(false);
                     var deserializer = new DeserializerBuilder().WithNamingConvention(CamelCaseNamingConvention.Instance).Build();
                     var metadata = deserializer.Deserialize<WorkflowMetadata>(yamlText);
                     metadata.ClientData = clientDataJson;
@@ -1605,14 +1651,10 @@ internal class WorkspaceSynchronizer : IWorkspaceSynchronizer
                     using var jsonDoc = JsonDocument.Parse(workflow.ClientData);
                     var jsonString = JsonSerializer.Serialize(jsonDoc.RootElement, new JsonSerializerOptions { WriteIndented = true });
 
-                    var jsonStream = fileAccessor.OpenWrite(workflowJsonTmp);
-                    await using (jsonStream.ConfigureAwait(false))
+                    using (var jsonStream = fileAccessor.OpenWrite(workflowJsonTmp))
+                    using (var writer = new StreamWriter(jsonStream, Encoding.UTF8))
                     {
-                        var writer = new StreamWriter(jsonStream, Encoding.UTF8);
-                        await using (writer.ConfigureAwait(false))
-                        {
-                            await writer.WriteAsync(jsonString).ConfigureAwait(false);
-                        }
+                        await writer.WriteAsync(jsonString).ConfigureAwait(false);
                     }
                     fileAccessor.Replace(workflowJsonTmp, workflowJson);
 
@@ -1620,14 +1662,10 @@ internal class WorkspaceSynchronizer : IWorkspaceSynchronizer
                     var workflowMetadataTmp = new AgentFilePath($"{workflowFolder}/metadata.yml.tmp");
                     var serializer = new SerializerBuilder().WithNamingConvention(CamelCaseNamingConvention.Instance).Build();
 
-                    var metaStream = fileAccessor.OpenWrite(workflowMetadataTmp);
-                    await using (metaStream.ConfigureAwait(false))
+                    using (var metaStream = fileAccessor.OpenWrite(workflowMetadataTmp))
+                    using (var writer = new StreamWriter(metaStream, Encoding.UTF8))
                     {
-                        var writer = new StreamWriter(metaStream, Encoding.UTF8);
-                        await using (writer.ConfigureAwait(false))
-                        {
-                            serializer.Serialize(writer, workflow);
-                        }
+                        serializer.Serialize(writer, workflow);
                     }
                     fileAccessor.Replace(workflowMetadataTmp, workflowMetadata);
                 }
@@ -1694,7 +1732,12 @@ internal class WorkspaceSynchronizer : IWorkspaceSynchronizer
 
             using var stream = fileAccessor.OpenRead(filePath);
             using var reader = new StreamReader(stream, Encoding.UTF8);
+#if NETSTANDARD2_0
+            cancellationToken.ThrowIfCancellationRequested();
+            var yaml = await reader.ReadToEndAsync().ConfigureAwait(false);
+#else
             var yaml = await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
+#endif
 
             var deserialized = CodeSerializer.Deserialize(yaml, component.RootElement?.GetType() ?? typeof(BotElement), null);
             var (parsed, error) = _fileParser.CompileFileModel(component.SchemaNameString, deserialized, component.DisplayName, component.Description);
@@ -1804,7 +1847,12 @@ internal class WorkspaceSynchronizer : IWorkspaceSynchronizer
 
             using var stream = fileAccessor.OpenRead(filePath);
             using var reader = new StreamReader(stream, Encoding.UTF8);
+#if NETSTANDARD2_0
+            cancellationToken.ThrowIfCancellationRequested();
+            var yaml = await reader.ReadToEndAsync().ConfigureAwait(false);
+#else
             var yaml = await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
+#endif
 
             if (CodeSerializer.Deserialize(yaml, typeof(EnvironmentVariableDefinition), null) is EnvironmentVariableDefinition envVar)
             {
@@ -1890,8 +1938,8 @@ internal class WorkspaceSynchronizer : IWorkspaceSynchronizer
                 continue;
             }
 
-            var yaml = await File.ReadAllTextAsync(metadataFile, cancellationToken).ConfigureAwait(false);
-            var json = await File.ReadAllTextAsync(jsonFile, cancellationToken).ConfigureAwait(false);
+            var yaml = await FileShim.ReadAllTextAsync(metadataFile, cancellationToken).ConfigureAwait(false);
+            var json = await FileShim.ReadAllTextAsync(jsonFile, cancellationToken).ConfigureAwait(false);
             var deserializer = new DeserializerBuilder().WithNamingConvention(CamelCaseNamingConvention.Instance).Build();
             var metadata = deserializer.Deserialize<WorkflowMetadata>(yaml);
             metadata.ClientData = json;
@@ -2443,7 +2491,7 @@ internal class WorkspaceSynchronizer : IWorkspaceSynchronizer
         var expectedDefinition = await ReadWorkspaceDefinitionAsync(workspaceFolder, cancellationToken).ConfigureAwait(false);
 
         // Clone to a temp workspace to get the server's current state
-        var tempDir = Path.Combine(Path.GetTempPath(), "mcs-verify-" + Guid.NewGuid().ToString("N")[..8]);
+        var tempDir = Path.Combine(Path.GetTempPath(), "mcs-verify-" + Guid.NewGuid().ToString("N").Substring(0, 8));
         Directory.CreateDirectory(tempDir);
         var tempWorkspace = new DirectoryPath(tempDir.Replace('\\', '/'));
 


### PR DESCRIPTION
  `Microsoft.CopilotStudio.Sync` currently ships a single `net10.0` binary.
  A consumer that needs to support both net48 and net10.0 (PAC copilot
  sync, whose packaging plan targets both) cannot reference Sync from its
  net48 half today, because the net10.0 binary is not loadable on net48.
  Adding a netstandard2.0 lib slot to the nupkg gives PAC, and any other
  multi-targeted consumer, a Sync binary that loads on net48 alongside the
  existing net10.0 binary.l.

  This PR produces that netstandard2.0 build of Sync (and of the bundled
  McsCore) so that downstream packages can include Sync in any
  net48-plus-net10.0 build matrix.

  ## What

  `CopilotStudio.Sync` and the bundled `CopilotStudio.McsCore` now declare
  both `netstandard2.0` and `net10.0` as their target frameworks. The
  bundled `McsCore.dll` lands per target framework in the published nupkg
  via the existing `BuildOutputInPackage` target, so each
  `lib/<target-framework>/` slot in the package carries its own
  `Sync.dll` and `McsCore.dll`.

  Source is shared across both target frameworks. Where the
  netstandard2.0 reference pack lacks an API that net10 uses, one of two
  things happens:

  * The site is rewritten in a netstandard2.0-compatible call shape that
    produces equivalent net10 behavior (the common case).
  * A small polyfill, scoped to the netstandard2.0 build, supplies the
    missing surface.

  Three call sites keep an explicit per-target-framework dispatch because
  the netstandard2.0-compatible form carries a measurable cost on net10:

  * the parallel knowledge-file I/O loops (lose roughly five-way
    parallelism on the netstandard2.0 path),
  * `Path.GetRelativePath` (a Uri-allocation polyfill versus the BCL's
    in-place character walk),
  * `RandomNumberGenerator.GetInt32` (managed-buffer rejection sampling
    versus the BCL's native call).

  Each remaining `#if NETSTANDARD2_0` carries an inline comment
  explaining the specific cost it preserves.

  ## Validation

  Both binaries build clean. The LSP solution (`PowerPlatformLS.sln`),
  which consumes Sync at net10, builds 0 warnings and 0 errors, so
  existing consumers see no behavioral change.

  | Suite | Result |
  |---|---|
  | `CopilotStudio.Sync.UnitTests` | 18/18 |
  | `PowerPlatformLS.UnitTests` | 636/636 |
  | `LspJournalCli.UnitTests` | 12/12 |
  | `CopilotStudio.Sync.E2ETests` (live tenant) | 13/13 in 2:49 |

  Existing test projects target net10.0 only. Runtime validation of the
  netstandard2.0 binary will land on the consumer side at the PR that
  adopts this package.