### PR TITLE
Update resolved URL for @types/node in package-lock.json

### DIFF
--- a/src/vscode-extensions/package-lock.json
+++ b/src/vscode-extensions/package-lock.json
@@ -770,7 +770,7 @@
     },
     "node_modules/@types/node": {
       "version": "22.19.17",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@types/node/-/node-22.19.17.tgz",
       "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "dev": true,
       "license": "MIT",


### PR DESCRIPTION
Version `22.19.17` was also added to the internal feed.