### PR TITLE
Cleanup npm lockfile registry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,11 @@ cd src/vscode-extensions/microsoft-powerplatformlang-extension
 # Install dependencies
 npm install
 
+# The parent src/vscode-extensions/.npmrc intentionally omits registry-resolved
+# URLs from lockfiles. Do not add registry or feed URLs to committed .npmrc or
+# package-lock.json files; registry/feed/auth configuration belongs in user
+# npm config or CI restore-time configuration.
+
 # Build everything (LSP + type check + esbuild bundle)
 npm run compile
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,10 +38,11 @@ cd src/vscode-extensions/microsoft-powerplatformlang-extension
 # Install dependencies
 npm install
 
-# The parent src/vscode-extensions/.npmrc intentionally omits registry-resolved
-# URLs from lockfiles. Do not add registry or feed URLs to committed .npmrc or
-# package-lock.json files; registry/feed/auth configuration belongs in user
-# npm config or CI restore-time configuration.
+# The parent src/vscode-extensions/.npmrc sets omit-lockfile-registry-resolved=true
+# so lockfile updates omit registry/feed-specific resolved URLs. Do not add
+# registry or feed URLs to committed .npmrc or package-lock.json files;
+# registry/feed/auth configuration belongs in user npm config or CI restore-time
+# configuration.
 
 # Build everything (LSP + type check + esbuild bundle)
 npm run compile

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,10 +127,22 @@ dotnet test  src/LanguageServers/PowerPlatformLS/PowerPlatformLS.sln
 ### 3. Build the VS Code extension
 
 ```sh
-cd src/vscode-extensions
+cd src/vscode-extensions/microsoft-powerplatformlang-extension
 npm install
-npm run build
+npm run check-types
+node esbuild.js --production
 ```
+
+### npm lockfile and registry policy
+
+The committed npm lockfiles must be independent of the registry or feed used for
+restore. The repository-level npm config at `src/vscode-extensions/.npmrc`
+therefore sets `omit-lockfile-registry-resolved=true` and intentionally does not
+set `registry`.
+
+If you need a private registry or feed for restore, configure it in your user
+npm config or in CI restore-time configuration. Do not add registry or feed URLs
+to committed `.npmrc` or `package-lock.json` files.
 
 ### Working toward external buildability
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,9 +140,15 @@ restore. The repository-level npm config at `src/vscode-extensions/.npmrc`
 therefore sets `omit-lockfile-registry-resolved=true` and intentionally does not
 set `registry`.
 
-If you need a private registry or feed for restore, configure it in your user
-npm config or in CI restore-time configuration. Do not add registry or feed URLs
-to committed `.npmrc` or `package-lock.json` files.
+That `.npmrc` setting is what prevents `npm install`, `npm uninstall`, and
+dependency updates from adding registry/feed-specific `resolved` URLs to
+committed `package-lock.json` files.
+
+If you need a private registry or feed for restore, configure it in your user npm
+config or in CI restore-time configuration. Do not add registry or feed URLs to
+committed `.npmrc` or `package-lock.json` files. When npm commands update a
+lockfile, review the resulting diff to verify registry/feed URLs were not
+introduced.
 
 ### Working toward external buildability
 

--- a/src/vscode-extensions/.npmrc
+++ b/src/vscode-extensions/.npmrc
@@ -1,3 +1,2 @@
-# Split repo: use public npm registry (no ADO auth required).
-# All devDependencies and dependencies are published to npmjs.org.
-registry=https://registry.npmjs.org/
+# Keep committed package-lock.json files independent of the restore registry.
+omit-lockfile-registry-resolved=true

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/package-lock.json
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/package-lock.json
@@ -22,7 +22,6 @@
 		},
 		"node_modules/brace-expansion": {
 			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
 			"integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
 			"license": "MIT",
 			"dependencies": {
@@ -31,7 +30,6 @@
 		},
 		"node_modules/minimatch": {
 			"version": "5.1.9",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
 			"integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
 			"license": "ISC",
 			"dependencies": {

--- a/src/vscode-extensions/package-lock.json
+++ b/src/vscode-extensions/package-lock.json
@@ -37,7 +37,6 @@
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.2",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz",
       "integrity": "sha1-Uhy9lo3PNiCUA0lH92+hsY0tQDw=",
       "cpu": [
         "ppc64"
@@ -54,7 +53,6 @@
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.27.2",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@esbuild/android-arm/-/android-arm-0.27.2.tgz",
       "integrity": "sha1-VUiHgh4AndbYU/ly/ebFFD8d4UI=",
       "cpu": [
         "arm"
@@ -71,7 +69,6 @@
     },
     "node_modules/@esbuild/android-arm64": {
       "version": "0.27.2",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz",
       "integrity": "sha1-YepVCWLYqhKpszGUOU4Adlem31c=",
       "cpu": [
         "arm64"
@@ -88,7 +85,6 @@
     },
     "node_modules/@esbuild/android-x64": {
       "version": "0.27.2",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@esbuild/android-x64/-/android-x64-0.27.2.tgz",
       "integrity": "sha1-p86dByGCX8V4+SkqdtnlMzRIC6I=",
       "cpu": [
         "x64"
@@ -105,7 +101,6 @@
     },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.27.2",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz",
       "integrity": "sha1-LLdlm9XRCYA8WTz8QURQ1UMMglY=",
       "cpu": [
         "arm64"
@@ -122,7 +117,6 @@
     },
     "node_modules/@esbuild/darwin-x64": {
       "version": "0.27.2",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz",
       "integrity": "sha1-50H6axq7DNA2QSa6NMoX/V579Qk=",
       "cpu": [
         "x64"
@@ -139,7 +133,6 @@
     },
     "node_modules/@esbuild/freebsd-arm64": {
       "version": "0.27.2",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz",
       "integrity": "sha1-K2TnEWhlyhctTOA0EUwh88k+OXw=",
       "cpu": [
         "arm64"
@@ -156,7 +149,6 @@
     },
     "node_modules/@esbuild/freebsd-x64": {
       "version": "0.27.2",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz",
       "integrity": "sha1-5SUlUeZvSZ5JNO+2EYEvOCDpkLs=",
       "cpu": [
         "x64"
@@ -173,7 +165,6 @@
     },
     "node_modules/@esbuild/linux-arm": {
       "version": "0.27.2",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz",
       "integrity": "sha1-VqkA45JA19XR0nO8BT2qKVyS4yI=",
       "cpu": [
         "arm"
@@ -190,7 +181,6 @@
     },
     "node_modules/@esbuild/linux-arm64": {
       "version": "0.27.2",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz",
       "integrity": "sha1-3ErPI1UxzWmE9dbDsT2/t92zA8s=",
       "cpu": [
         "arm64"
@@ -207,7 +197,6 @@
     },
     "node_modules/@esbuild/linux-ia32": {
       "version": "0.27.2",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz",
       "integrity": "sha1-1KNtRzNg9ocO/NGdUrv/9Zou0cw=",
       "cpu": [
         "ia32"
@@ -224,7 +213,6 @@
     },
     "node_modules/@esbuild/linux-loong64": {
       "version": "0.27.2",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz",
       "integrity": "sha1-/PCrjD6q9FiR0BldSWHLGLV5cWo=",
       "cpu": [
         "loong64"
@@ -241,7 +229,6 @@
     },
     "node_modules/@esbuild/linux-mips64el": {
       "version": "0.27.2",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz",
       "integrity": "sha1-WYtn00BIu37hkByxLioKQ0w4HBA=",
       "cpu": [
         "mips64el"
@@ -258,7 +245,6 @@
     },
     "node_modules/@esbuild/linux-ppc64": {
       "version": "0.27.2",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz",
       "integrity": "sha1-OEbF32sgFtq5vJXd4mxA8R5DtMA=",
       "cpu": [
         "ppc64"
@@ -275,7 +261,6 @@
     },
     "node_modules/@esbuild/linux-riscv64": {
       "version": "0.27.2",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz",
       "integrity": "sha1-Fz1EdbN8jSw+FwfgaMF0uz9T0H0=",
       "cpu": [
         "riscv64"
@@ -292,7 +277,6 @@
     },
     "node_modules/@esbuild/linux-s390x": {
       "version": "0.27.2",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz",
       "integrity": "sha1-96R5AQXtyrilox3yb7+sGqPaz6s=",
       "cpu": [
         "s390x"
@@ -309,7 +293,6 @@
     },
     "node_modules/@esbuild/linux-x64": {
       "version": "0.27.2",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz",
       "integrity": "sha1-LswShLGQSutB5Uyd3H/NNJsY9lA=",
       "cpu": [
         "x64"
@@ -326,7 +309,6 @@
     },
     "node_modules/@esbuild/netbsd-arm64": {
       "version": "0.27.2",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz",
       "integrity": "sha1-4oY8LNFQGEWZXLEa3yb3/kvlJ7A=",
       "cpu": [
         "arm64"
@@ -343,7 +325,6 @@
     },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.27.2",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz",
       "integrity": "sha1-k/dgniiF0cC1oUF4hfuo0fzEEnI=",
       "cpu": [
         "x64"
@@ -360,7 +341,6 @@
     },
     "node_modules/@esbuild/openbsd-arm64": {
       "version": "0.27.2",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz",
       "integrity": "sha1-oZhWBKIDzcMl/UdULhBvr9aY8C4=",
       "cpu": [
         "arm64"
@@ -377,7 +357,6 @@
     },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.27.2",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz",
       "integrity": "sha1-ggnkbELx/75uTvd6MuH0fUBK1Co=",
       "cpu": [
         "x64"
@@ -394,7 +373,6 @@
     },
     "node_modules/@esbuild/openharmony-arm64": {
       "version": "0.27.2",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz",
       "integrity": "sha1-j63kRBiT2cxEy9fc83dvUIq2+y8=",
       "cpu": [
         "arm64"
@@ -411,7 +389,6 @@
     },
     "node_modules/@esbuild/sunos-x64": {
       "version": "0.27.2",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz",
       "integrity": "sha1-mA1LlwOhbw8HAWYyQk/G2aeJ38I=",
       "cpu": [
         "x64"
@@ -428,7 +405,6 @@
     },
     "node_modules/@esbuild/win32-arm64": {
       "version": "0.27.2",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz",
       "integrity": "sha1-HAmjYzyUnq09gIujcnaIPnH2ERo=",
       "cpu": [
         "arm64"
@@ -445,7 +421,6 @@
     },
     "node_modules/@esbuild/win32-ia32": {
       "version": "0.27.2",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz",
       "integrity": "sha1-Gx46Y61L74IgD+9ONp4P/3AJ7uU=",
       "cpu": [
         "ia32"
@@ -462,7 +437,6 @@
     },
     "node_modules/@esbuild/win32-x64": {
       "version": "0.27.2",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz",
       "integrity": "sha1-nlhatghr75lMbopbOgSBIZrahis=",
       "cpu": [
         "x64"
@@ -479,7 +453,6 @@
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
       "integrity": "sha1-TpCvZ7xR3e5s3vUoTt9XLsN2tZU=",
       "dev": true,
       "license": "MIT",
@@ -498,7 +471,6 @@
     },
     "node_modules/@eslint-community/regexpp": {
       "version": "4.12.2",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
       "integrity": "sha1-vM32Fbz3tujbgw7AuNIcmiXeWXs=",
       "dev": true,
       "license": "MIT",
@@ -508,7 +480,6 @@
     },
     "node_modules/@eslint/config-array": {
       "version": "0.23.3",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@eslint/config-array/-/config-array-0.23.3.tgz",
       "integrity": "sha1-P0qT3VRhacCRMMvRDyQVsTogohk=",
       "dev": true,
       "license": "Apache-2.0",
@@ -523,7 +494,6 @@
     },
     "node_modules/@eslint/config-helpers": {
       "version": "0.5.3",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@eslint/config-helpers/-/config-helpers-0.5.3.tgz",
       "integrity": "sha1-ch/mu7kNdLDIDW/yQo5bvLACvss=",
       "dev": true,
       "license": "Apache-2.0",
@@ -536,7 +506,6 @@
     },
     "node_modules/@eslint/core": {
       "version": "1.1.1",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@eslint/core/-/core-1.1.1.tgz",
       "integrity": "sha1-RQ89K+LUY8zVERlUQJIla06I3zI=",
       "dev": true,
       "license": "Apache-2.0",
@@ -549,7 +518,6 @@
     },
     "node_modules/@eslint/object-schema": {
       "version": "3.0.3",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@eslint/object-schema/-/object-schema-3.0.3.tgz",
       "integrity": "sha1-W/Zx5S44LkrcR6mQbyaZN0Y322s=",
       "dev": true,
       "license": "Apache-2.0",
@@ -559,7 +527,6 @@
     },
     "node_modules/@eslint/plugin-kit": {
       "version": "0.6.1",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@eslint/plugin-kit/-/plugin-kit-0.6.1.tgz",
       "integrity": "sha1-655mibVs6LwYVbszCQ5j8/wRXo4=",
       "dev": true,
       "license": "Apache-2.0",
@@ -573,7 +540,6 @@
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@humanfs/core/-/core-0.19.1.tgz",
       "integrity": "sha1-F8Vcp9Qmcz/jxWGQa4Fzwza0Cnc=",
       "dev": true,
       "license": "Apache-2.0",
@@ -583,7 +549,6 @@
     },
     "node_modules/@humanfs/node": {
       "version": "0.16.7",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@humanfs/node/-/node-0.16.7.tgz",
       "integrity": "sha1-giy3s6EsWiQKJPYhtaJBPiekXyY=",
       "dev": true,
       "license": "Apache-2.0",
@@ -597,7 +562,6 @@
     },
     "node_modules/@humanwhocodes/module-importer": {
       "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
       "integrity": "sha1-r1smkaIrRL6EewyoFkHF+2rQFyw=",
       "dev": true,
       "license": "Apache-2.0",
@@ -611,7 +575,6 @@
     },
     "node_modules/@humanwhocodes/retry": {
       "version": "0.4.3",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@humanwhocodes/retry/-/retry-0.4.3.tgz",
       "integrity": "sha1-wrnS43TuYsWG062+qHGZsdenpro=",
       "dev": true,
       "license": "Apache-2.0",
@@ -625,7 +588,6 @@
     },
     "node_modules/@microsoft/1ds-core-js": {
       "version": "4.3.11",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@microsoft/1ds-core-js/-/1ds-core-js-4.3.11.tgz",
       "integrity": "sha1-UjxgDSXgBDecWUBLDXXuAAQ2Jc0=",
       "license": "MIT",
       "dependencies": {
@@ -638,7 +600,6 @@
     },
     "node_modules/@microsoft/1ds-post-js": {
       "version": "4.3.11",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@microsoft/1ds-post-js/-/1ds-post-js-4.3.11.tgz",
       "integrity": "sha1-iOwI5LSrWWmwAiglT1MD1gO/8J4=",
       "license": "MIT",
       "dependencies": {
@@ -651,7 +612,6 @@
     },
     "node_modules/@microsoft/applicationinsights-channel-js": {
       "version": "3.3.11",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-3.3.11.tgz",
       "integrity": "sha1-eZGzFbKVIZpD6FyWqwTrBwpeE/Y=",
       "license": "MIT",
       "dependencies": {
@@ -668,7 +628,6 @@
     },
     "node_modules/@microsoft/applicationinsights-common": {
       "version": "3.3.11",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@microsoft/applicationinsights-common/-/applicationinsights-common-3.3.11.tgz",
       "integrity": "sha1-Gtdkowgz+A+soacq9Lj6K3w7KLo=",
       "license": "MIT",
       "dependencies": {
@@ -683,7 +642,6 @@
     },
     "node_modules/@microsoft/applicationinsights-core-js": {
       "version": "3.3.11",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.3.11.tgz",
       "integrity": "sha1-ks6WCSSxYSH4aBSpteo11canuOA=",
       "license": "MIT",
       "dependencies": {
@@ -698,7 +656,6 @@
     },
     "node_modules/@microsoft/applicationinsights-shims": {
       "version": "3.0.1",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@microsoft/applicationinsights-shims/-/applicationinsights-shims-3.0.1.tgz",
       "integrity": "sha1-OGW3Os6EBbnEYYzFxXHy/jh28G8=",
       "license": "MIT",
       "dependencies": {
@@ -707,7 +664,6 @@
     },
     "node_modules/@microsoft/applicationinsights-web-basic": {
       "version": "3.3.11",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@microsoft/applicationinsights-web-basic/-/applicationinsights-web-basic-3.3.11.tgz",
       "integrity": "sha1-NT0VkSfCtWuC3Vd396NVYmQR+O8=",
       "license": "MIT",
       "dependencies": {
@@ -725,7 +681,6 @@
     },
     "node_modules/@microsoft/dynamicproto-js": {
       "version": "2.0.3",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@microsoft/dynamicproto-js/-/dynamicproto-js-2.0.3.tgz",
       "integrity": "sha1-ritAgGHj/wGpcHhCn8doMx4jklY=",
       "license": "MIT",
       "dependencies": {
@@ -734,7 +689,6 @@
     },
     "node_modules/@nevware21/ts-async": {
       "version": "0.5.5",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@nevware21/ts-async/-/ts-async-0.5.5.tgz",
       "integrity": "sha1-UJZI48PDqpq2E8AMce7k/pvYo8M=",
       "license": "MIT",
       "dependencies": {
@@ -743,34 +697,29 @@
     },
     "node_modules/@nevware21/ts-utils": {
       "version": "0.13.0",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@nevware21/ts-utils/-/ts-utils-0.13.0.tgz",
       "integrity": "sha1-CxaZWX9zbRYiIcGSIXKSSzjO9Uw=",
       "license": "MIT"
     },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@types/esrecurse/-/esrecurse-4.3.1.tgz",
       "integrity": "sha1-b2Nq+WL75hkbgwvWdrpZhpJrzOw=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha1-lYuRyZGxhnztMYvt6g4hXuBQcm4=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha1-WWoXRyM2lNUPatinhp/Lb1bPWEE=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "22.19.17",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@types/node/-/node-22.19.17.tgz",
       "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "dev": true,
       "license": "MIT",
@@ -780,20 +729,17 @@
     },
     "node_modules/@types/semver": {
       "version": "7.7.1",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@types/semver/-/semver-7.7.1.tgz",
       "integrity": "sha1-POOvGlUk7zJ9Lank/YttlcjXBSg=",
       "license": "MIT"
     },
     "node_modules/@types/vscode": {
       "version": "1.110.0",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@types/vscode/-/vscode-1.110.0.tgz",
       "integrity": "sha1-tiEMfV4EkAMTi7FzEWRP6LF53Is=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.57.1",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.57.1.tgz",
       "integrity": "sha1-3f37MPi1zO5/PCF5izd8UTcO3VU=",
       "dev": true,
       "license": "MIT",
@@ -822,7 +768,6 @@
     },
     "node_modules/@typescript-eslint/parser": {
       "version": "8.57.1",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@typescript-eslint/parser/-/parser-8.57.1.tgz",
       "integrity": "sha1-1SPlWbFIJkBVwKSaKdX1DH3mWcI=",
       "dev": true,
       "license": "MIT",
@@ -847,7 +792,6 @@
     },
     "node_modules/@typescript-eslint/project-service": {
       "version": "8.57.1",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@typescript-eslint/project-service/-/project-service-8.57.1.tgz",
       "integrity": "sha1-Fq+f4W7tvXCF5P3Cm6pzcVwMVcU=",
       "dev": true,
       "license": "MIT",
@@ -869,7 +813,6 @@
     },
     "node_modules/@typescript-eslint/scope-manager": {
       "version": "8.57.1",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@typescript-eslint/scope-manager/-/scope-manager-8.57.1.tgz",
       "integrity": "sha1-RSTX57Qgy1AYB0mWhNQ1rhKarzU=",
       "dev": true,
       "license": "MIT",
@@ -887,7 +830,6 @@
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
       "version": "8.57.1",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.57.1.tgz",
       "integrity": "sha1-kjNEPscWiCpvniQP2QCnPwI189c=",
       "dev": true,
       "license": "MIT",
@@ -904,7 +846,6 @@
     },
     "node_modules/@typescript-eslint/type-utils": {
       "version": "8.57.1",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@typescript-eslint/type-utils/-/type-utils-8.57.1.tgz",
       "integrity": "sha1-xJrxNHtYacqFFVVHqPNPhKs4b9k=",
       "dev": true,
       "license": "MIT",
@@ -929,7 +870,6 @@
     },
     "node_modules/@typescript-eslint/types": {
       "version": "8.57.1",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@typescript-eslint/types/-/types-8.57.1.tgz",
       "integrity": "sha1-VLJ6iiWntFtPl4w/jgDEx48RFCw=",
       "dev": true,
       "license": "MIT",
@@ -943,7 +883,6 @@
     },
     "node_modules/@typescript-eslint/typescript-estree": {
       "version": "8.57.1",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@typescript-eslint/typescript-estree/-/typescript-estree-8.57.1.tgz",
       "integrity": "sha1-qf0o1KDsiWqpqafgzq1i6iT5nnY=",
       "dev": true,
       "license": "MIT",
@@ -971,7 +910,6 @@
     },
     "node_modules/@typescript-eslint/utils": {
       "version": "8.57.1",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@typescript-eslint/utils/-/utils-8.57.1.tgz",
       "integrity": "sha1-5A9af8/wL9JAkqe1K9bsAp+1BGU=",
       "dev": true,
       "license": "MIT",
@@ -995,7 +933,6 @@
     },
     "node_modules/@typescript-eslint/visitor-keys": {
       "version": "8.57.1",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@typescript-eslint/visitor-keys/-/visitor-keys-8.57.1.tgz",
       "integrity": "sha1-OvT4gRiSTTvpg9S4roSAPxH+RWM=",
       "dev": true,
       "license": "MIT",
@@ -1013,7 +950,6 @@
     },
     "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
       "version": "5.0.1",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
       "integrity": "sha1-njyUiWl4JNLUzjqK0SYo+R6fWb4=",
       "dev": true,
       "license": "Apache-2.0",
@@ -1026,7 +962,6 @@
     },
     "node_modules/@vscode/extension-telemetry": {
       "version": "1.5.1",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@vscode/extension-telemetry/-/extension-telemetry-1.5.1.tgz",
       "integrity": "sha1-4zbEBLFCSTlRa5E+X3I6nfcOkHs=",
       "license": "MIT",
       "dependencies": {
@@ -1040,7 +975,6 @@
     },
     "node_modules/@vscode/test-electron": {
       "version": "2.5.2",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/@vscode/test-electron/-/test-electron-2.5.2.tgz",
       "integrity": "sha1-99QHjoIwzpyUMi8qKcwWwXlUCF0=",
       "dev": true,
       "license": "MIT",
@@ -1057,7 +991,6 @@
     },
     "node_modules/acorn": {
       "version": "8.16.0",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha1-TOecib5Ar+ev6POtuQKh8c6awIo=",
       "dev": true,
       "license": "MIT",
@@ -1070,7 +1003,6 @@
     },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha1-ftW7VZCLOy8bxVxq8WU7rafweTc=",
       "dev": true,
       "license": "MIT",
@@ -1080,7 +1012,6 @@
     },
     "node_modules/agent-base": {
       "version": "7.1.4",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha1-48121MVI7oldPD/Y3B9sW5Ay56g=",
       "dev": true,
       "license": "MIT",
@@ -1090,7 +1021,6 @@
     },
     "node_modules/ansi-regex": {
       "version": "6.2.2",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha1-YCFu6kZNhkWXzigyAAc4oFiWUME=",
       "dev": true,
       "license": "MIT",
@@ -1103,7 +1033,6 @@
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
       "dev": true,
       "license": "MIT",
@@ -1119,7 +1048,6 @@
     },
     "node_modules/balanced-match": {
       "version": "4.0.4",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha1-v7EGYv7tgZaixi58aOF3IMJ0F5o=",
       "dev": true,
       "license": "MIT",
@@ -1129,7 +1057,6 @@
     },
     "node_modules/brace-expansion": {
       "version": "5.0.5",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/brace-expansion/-/brace-expansion-5.0.5.tgz",
       "integrity": "sha1-3MOjcRa3nz4bRtuZTO1dVw6TD9s=",
       "dev": true,
       "license": "MIT",
@@ -1142,7 +1069,6 @@
     },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/cli-cursor/-/cli-cursor-5.0.0.tgz",
       "integrity": "sha1-JKSDHs9aawHd6zL7caSyCIsNzjg=",
       "dev": true,
       "license": "MIT",
@@ -1158,7 +1084,6 @@
     },
     "node_modules/cli-spinners": {
       "version": "2.9.2",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/cli-spinners/-/cli-spinners-2.9.2.tgz",
       "integrity": "sha1-F3Oo9LnE1qwxVj31Oz/B15Ri/kE=",
       "dev": true,
       "license": "MIT",
@@ -1171,7 +1096,6 @@
     },
     "node_modules/cliui": {
       "version": "8.0.1",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha1-DASwddsCy/5g3I5s8vVIaxo2CKo=",
       "dev": true,
       "license": "ISC",
@@ -1186,7 +1110,6 @@
     },
     "node_modules/cliui/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
       "dev": true,
       "license": "MIT",
@@ -1196,7 +1119,6 @@
     },
     "node_modules/cliui/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
       "dev": true,
       "license": "MIT",
@@ -1209,7 +1131,6 @@
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
       "dev": true,
       "license": "MIT",
@@ -1222,21 +1143,18 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha1-pgQtNjTCsn6TKPg3uWX6yDgI24U=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha1-ilj+ePANzXDDcEUXWd+/rwPo7p8=",
       "dev": true,
       "license": "MIT",
@@ -1251,7 +1169,6 @@
     },
     "node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/debug/-/debug-4.4.3.tgz",
       "integrity": "sha1-xq5DLZvZZiWC/OCHCbA4xY6ePWo=",
       "dev": true,
       "license": "MIT",
@@ -1269,21 +1186,18 @@
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha1-pvLc5hL63S7x9Rm3NVHxfoUZmDE=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.27.2",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/esbuild/-/esbuild-0.27.2.tgz",
       "integrity": "sha1-2D7SFU1YE6U2c3a7IpKpKW/INxc=",
       "dev": true,
       "hasInstallScript": true,
@@ -1325,7 +1239,6 @@
     },
     "node_modules/escalade": {
       "version": "3.2.0",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha1-ARo/aYVroYnf+n3I/M6Z0qh5A+U=",
       "dev": true,
       "license": "MIT",
@@ -1335,7 +1248,6 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha1-FLqDpdNz49MR5a/KKc9b+tllvzQ=",
       "dev": true,
       "license": "MIT",
@@ -1348,7 +1260,6 @@
     },
     "node_modules/eslint": {
       "version": "10.0.3",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/eslint/-/eslint-10.0.3.tgz",
       "integrity": "sha1-Ngp95/JwbrijLKoXypg/AInv5pQ=",
       "dev": true,
       "license": "MIT",
@@ -1404,7 +1315,6 @@
     },
     "node_modules/eslint-scope": {
       "version": "9.1.2",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/eslint-scope/-/eslint-scope-9.1.2.tgz",
       "integrity": "sha1-ud5qzi+rHP8k0uWNhbdMj86jmAI=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -1423,7 +1333,6 @@
     },
     "node_modules/eslint-visitor-keys": {
       "version": "3.4.3",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
       "integrity": "sha1-DNcv6FUOPC6uFWqWpN3c0cisWAA=",
       "dev": true,
       "license": "Apache-2.0",
@@ -1436,7 +1345,6 @@
     },
     "node_modules/eslint/node_modules/ajv": {
       "version": "6.14.0",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/ajv/-/ajv-6.14.0.tgz",
       "integrity": "sha1-/QZ3E+IoIQY267CMYL03Zdbb5zo=",
       "dev": true,
       "license": "MIT",
@@ -1453,7 +1361,6 @@
     },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
       "version": "5.0.1",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
       "integrity": "sha1-njyUiWl4JNLUzjqK0SYo+R6fWb4=",
       "dev": true,
       "license": "Apache-2.0",
@@ -1466,7 +1373,6 @@
     },
     "node_modules/eslint/node_modules/glob-parent": {
       "version": "6.0.2",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha1-bSN9mQg5UMeSkPJMdkKj3poo+eM=",
       "dev": true,
       "license": "ISC",
@@ -1479,7 +1385,6 @@
     },
     "node_modules/eslint/node_modules/ignore": {
       "version": "5.3.2",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha1-PNQOcp82Q/2HywTlC/DrcivFlvU=",
       "dev": true,
       "license": "MIT",
@@ -1489,14 +1394,12 @@
     },
     "node_modules/eslint/node_modules/json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/espree": {
       "version": "11.2.0",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/espree/-/espree-11.2.0.tgz",
       "integrity": "sha1-AdXkfcMyqrowWQCDYkVKjMNMyqU=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -1514,7 +1417,6 @@
     },
     "node_modules/espree/node_modules/eslint-visitor-keys": {
       "version": "5.0.1",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
       "integrity": "sha1-njyUiWl4JNLUzjqK0SYo+R6fWb4=",
       "dev": true,
       "license": "Apache-2.0",
@@ -1527,7 +1429,6 @@
     },
     "node_modules/esquery": {
       "version": "1.7.0",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/esquery/-/esquery-1.7.0.tgz",
       "integrity": "sha1-CNBI8mHw3e21uulfRoCUY9nJSW0=",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -1540,7 +1441,6 @@
     },
     "node_modules/esrecurse": {
       "version": "4.3.0",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha1-eteWTWeauyi+5yzsY3WLHF0smSE=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -1553,7 +1453,6 @@
     },
     "node_modules/estraverse": {
       "version": "5.3.0",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha1-LupSkHAvJquP5TcDcP+GyWXSESM=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -1563,7 +1462,6 @@
     },
     "node_modules/esutils": {
       "version": "2.0.3",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha1-dNLrTeC42hKTcRkQ1Qd1ubcQ72Q=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -1573,28 +1471,24 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha1-h0v2nG9ATCtdmcSBNBOZ/VWJJjM=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
       "integrity": "sha1-d4e93PETG/+5JjbGlFe7wO3W2B8=",
       "dev": true,
       "license": "MIT",
@@ -1607,7 +1501,6 @@
     },
     "node_modules/find-up": {
       "version": "5.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha1-TJKBnstwg1YeT0okCoa+UZj1Nvw=",
       "dev": true,
       "license": "MIT",
@@ -1624,7 +1517,6 @@
     },
     "node_modules/flat-cache": {
       "version": "4.0.1",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/flat-cache/-/flat-cache-4.0.1.tgz",
       "integrity": "sha1-Ds45/LFO4BL0sEEL0z3ZwfAREnw=",
       "dev": true,
       "license": "MIT",
@@ -1638,14 +1530,12 @@
     },
     "node_modules/flatted": {
       "version": "3.4.2",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/flatted/-/flatted-3.4.2.tgz",
       "integrity": "sha1-9cI8EH8PN96NvfJPE3IrO5jVJyY=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34=",
       "dev": true,
       "license": "ISC",
@@ -1655,7 +1545,6 @@
     },
     "node_modules/get-east-asian-width": {
       "version": "1.5.0",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
       "integrity": "sha1-znAI/jRe3PVJem9VfPpUvDGKnOc=",
       "dev": true,
       "license": "MIT",
@@ -1668,7 +1557,6 @@
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha1-mosfJGhmwChQlIZYX2K48sGMJw4=",
       "dev": true,
       "license": "MIT",
@@ -1682,7 +1570,6 @@
     },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha1-2o3+rH2hMLBcK6S1nJts1mYRprk=",
       "dev": true,
       "license": "MIT",
@@ -1696,7 +1583,6 @@
     },
     "node_modules/ignore": {
       "version": "7.0.5",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/ignore/-/ignore-7.0.5.tgz",
       "integrity": "sha1-TLX2zX1MerA2VzjHrqiIuqbX79k=",
       "dev": true,
       "license": "MIT",
@@ -1706,14 +1592,12 @@
     },
     "node_modules/immediate": {
       "version": "3.0.6",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/immediate/-/immediate-3.0.6.tgz",
       "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true,
       "license": "MIT",
@@ -1723,14 +1607,12 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true,
       "license": "MIT",
@@ -1740,7 +1622,6 @@
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
       "dev": true,
       "license": "MIT",
@@ -1750,7 +1631,6 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha1-ZPYeQsu7LuwgcanawLKLoeZdUIQ=",
       "dev": true,
       "license": "MIT",
@@ -1763,7 +1643,6 @@
     },
     "node_modules/is-interactive": {
       "version": "2.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/is-interactive/-/is-interactive-2.0.0.tgz",
       "integrity": "sha1-QMV2FFk4JtoRAK3mBZd41ZfxbpA=",
       "dev": true,
       "license": "MIT",
@@ -1776,28 +1655,24 @@
     },
     "node_modules/isarray": {
       "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha1-kziAKjDTtmBfvgYT4JQAjKjAWhM=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "4.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/json-parse-even-better-errors/-/json-parse-even-better-errors-4.0.0.tgz",
       "integrity": "sha1-0/Z71ZJegdPjGqRmrMghyDdc7EM=",
       "dev": true,
       "license": "MIT",
@@ -1807,14 +1682,12 @@
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/jszip": {
       "version": "3.10.1",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/jszip/-/jszip-3.10.1.tgz",
       "integrity": "sha1-NK7nDrGOofrsL1iSCKFX0f6wkcI=",
       "dev": true,
       "license": "(MIT OR GPL-3.0-or-later)",
@@ -1827,7 +1700,6 @@
     },
     "node_modules/keyv": {
       "version": "4.5.4",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha1-qHmpnilFL5QkOfKkBeOvizHU3pM=",
       "dev": true,
       "license": "MIT",
@@ -1837,7 +1709,6 @@
     },
     "node_modules/levn": {
       "version": "0.4.1",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/levn/-/levn-0.4.1.tgz",
       "integrity": "sha1-rkViwAdHO5MqYgDUAyaN0v/8at4=",
       "dev": true,
       "license": "MIT",
@@ -1851,7 +1722,6 @@
     },
     "node_modules/lie": {
       "version": "3.3.0",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/lie/-/lie-3.3.0.tgz",
       "integrity": "sha1-3Pgt7lRfRgdNryAMfBxaCOD0D2o=",
       "dev": true,
       "license": "MIT",
@@ -1861,7 +1731,6 @@
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha1-VTIeswn+u8WcSAHZMackUqaB0oY=",
       "dev": true,
       "license": "MIT",
@@ -1877,7 +1746,6 @@
     },
     "node_modules/memorystream": {
       "version": "0.3.1",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/memorystream/-/memorystream-0.3.1.tgz",
       "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
       "dev": true,
       "engines": {
@@ -1886,7 +1754,6 @@
     },
     "node_modules/mimic-function": {
       "version": "5.0.1",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/mimic-function/-/mimic-function-5.0.1.tgz",
       "integrity": "sha1-rL4rM0n5m53qyn+3Dki4PpTmcHY=",
       "dev": true,
       "license": "MIT",
@@ -1899,7 +1766,6 @@
     },
     "node_modules/minimatch": {
       "version": "10.2.4",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/minimatch/-/minimatch-10.2.4.tgz",
       "integrity": "sha1-Rls6zL0CGLgoH1MB4nztxpf5b94=",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -1915,21 +1781,18 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/ms/-/ms-2.1.3.tgz",
       "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/nerdbank-gitversioning": {
       "version": "3.9.50",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/nerdbank-gitversioning/-/nerdbank-gitversioning-3.9.50.tgz",
       "integrity": "sha1-dwp3MN8SV6RD15qm3x269BWtg3o=",
       "dev": true,
       "license": "MIT",
@@ -1940,7 +1803,6 @@
     },
     "node_modules/npm-normalize-package-bin": {
       "version": "4.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/npm-normalize-package-bin/-/npm-normalize-package-bin-4.0.0.tgz",
       "integrity": "sha1-33nnDNChE7d8AtH+JDyWuOYYrLE=",
       "dev": true,
       "license": "ISC",
@@ -1950,7 +1812,6 @@
     },
     "node_modules/npm-run-all2": {
       "version": "7.0.2",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/npm-run-all2/-/npm-run-all2-7.0.2.tgz",
       "integrity": "sha1-JhVcFAtePxFV79f11nISyAJ7OXw=",
       "dev": true,
       "license": "MIT",
@@ -1977,7 +1838,6 @@
     },
     "node_modules/npm-run-all2/node_modules/ansi-styles": {
       "version": "6.2.3",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/ansi-styles/-/ansi-styles-6.2.3.tgz",
       "integrity": "sha1-wETV3MUhoHZBNHJZehrLHxA8QEE=",
       "dev": true,
       "license": "MIT",
@@ -1990,7 +1850,6 @@
     },
     "node_modules/npm-run-all2/node_modules/isexe": {
       "version": "3.1.5",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/isexe/-/isexe-3.1.5.tgz",
       "integrity": "sha1-QuNo9o1eENrf7k/ae1ULwtiJLck=",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -2000,7 +1859,6 @@
     },
     "node_modules/npm-run-all2/node_modules/which": {
       "version": "5.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/which/-/which-5.0.0.tgz",
       "integrity": "sha1-2T8tk/eYNNQ2PH0MI+ANB8RmyNY=",
       "dev": true,
       "license": "ISC",
@@ -2016,7 +1874,6 @@
     },
     "node_modules/onetime": {
       "version": "7.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/onetime/-/onetime-7.0.0.tgz",
       "integrity": "sha1-nxbJLYye9RIOOs2d2ZV8zuzBq2A=",
       "dev": true,
       "license": "MIT",
@@ -2032,7 +1889,6 @@
     },
     "node_modules/optionator": {
       "version": "0.9.4",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/optionator/-/optionator-0.9.4.tgz",
       "integrity": "sha1-fqHBpdkddk+yghOciP4R4YKjpzQ=",
       "dev": true,
       "license": "MIT",
@@ -2050,7 +1906,6 @@
     },
     "node_modules/ora": {
       "version": "8.2.0",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/ora/-/ora-8.2.0.tgz",
       "integrity": "sha1-j7u3FRr+M7VA3RU/Fx/6i9OOmGE=",
       "dev": true,
       "license": "MIT",
@@ -2074,7 +1929,6 @@
     },
     "node_modules/ora/node_modules/chalk": {
       "version": "5.6.2",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/chalk/-/chalk-5.6.2.tgz",
       "integrity": "sha1-sSOLbiPqM3r3HH+KKV21rwwViuo=",
       "dev": true,
       "license": "MIT",
@@ -2087,14 +1941,12 @@
     },
     "node_modules/ora/node_modules/emoji-regex": {
       "version": "10.6.0",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha1-vz1uj3+P0ipl2XA0dbwBRzV6aw0=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/ora/node_modules/is-unicode-supported": {
       "version": "2.1.0",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
       "integrity": "sha1-CfCrDebTdE1I0mXruY9l0R8qmzo=",
       "dev": true,
       "license": "MIT",
@@ -2107,7 +1959,6 @@
     },
     "node_modules/ora/node_modules/log-symbols": {
       "version": "6.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/log-symbols/-/log-symbols-6.0.0.tgz",
       "integrity": "sha1-u5Xl8FMiZRysMMD+tkBPnyqKlDk=",
       "dev": true,
       "license": "MIT",
@@ -2124,7 +1975,6 @@
     },
     "node_modules/ora/node_modules/log-symbols/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
       "integrity": "sha1-2CSYS2FsKSouGYIH1KYJmDhC9xQ=",
       "dev": true,
       "license": "MIT",
@@ -2137,7 +1987,6 @@
     },
     "node_modules/ora/node_modules/string-width": {
       "version": "7.2.0",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/string-width/-/string-width-7.2.0.tgz",
       "integrity": "sha1-tbuOIWXOJ11NQ0dt0nAK2Qkdttw=",
       "dev": true,
       "license": "MIT",
@@ -2155,7 +2004,6 @@
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha1-4drMvnjQ0TiMoYxk/qOOPlfjcGs=",
       "dev": true,
       "license": "MIT",
@@ -2171,7 +2019,6 @@
     },
     "node_modules/p-locate": {
       "version": "5.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha1-g8gxXGeFAF470CGDlBHJ4RDm2DQ=",
       "dev": true,
       "license": "MIT",
@@ -2187,14 +2034,12 @@
     },
     "node_modules/pako": {
       "version": "1.0.11",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/pako/-/pako-1.0.11.tgz",
       "integrity": "sha1-bJWZ00DVTf05RjgCUqNXBaa5kr8=",
       "dev": true,
       "license": "(MIT AND Zlib)"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM=",
       "dev": true,
       "license": "MIT",
@@ -2204,7 +2049,6 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha1-WB9q3mWMu6ZaDTOA3ndTKVBU83U=",
       "dev": true,
       "license": "MIT",
@@ -2214,7 +2058,6 @@
     },
     "node_modules/pidtree": {
       "version": "0.6.0",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/pidtree/-/pidtree-0.6.0.tgz",
       "integrity": "sha1-kK17bULVhB5p4KJBnvOPiIOqBXw=",
       "dev": true,
       "license": "MIT",
@@ -2227,7 +2070,6 @@
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha1-3rxkidem5rDnYRiIzsiAM30xY5Y=",
       "dev": true,
       "license": "MIT",
@@ -2237,14 +2079,12 @@
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha1-AnQi4vrsCyXhVJw+G9gwm5EztuU=",
       "dev": true,
       "license": "MIT",
@@ -2254,7 +2094,6 @@
     },
     "node_modules/read-package-json-fast": {
       "version": "4.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/read-package-json-fast/-/read-package-json-fast-4.0.0.tgz",
       "integrity": "sha1-jMvAV0C7n1gmT0AKzAtLTu6NGzk=",
       "dev": true,
       "license": "ISC",
@@ -2268,7 +2107,6 @@
     },
     "node_modules/readable-stream": {
       "version": "2.3.8",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/readable-stream/-/readable-stream-2.3.8.tgz",
       "integrity": "sha1-kRJegEK7obmIf0k0X2J3Anzovps=",
       "dev": true,
       "license": "MIT",
@@ -2284,14 +2122,12 @@
     },
     "node_modules/readable-stream/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true,
       "license": "MIT",
@@ -2301,7 +2137,6 @@
     },
     "node_modules/restore-cursor": {
       "version": "5.1.0",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/restore-cursor/-/restore-cursor-5.1.0.tgz",
       "integrity": "sha1-B2bZVpnvrLFBUJk/VbrwlT6h6+c=",
       "dev": true,
       "license": "MIT",
@@ -2318,7 +2153,6 @@
     },
     "node_modules/semver": {
       "version": "7.7.4",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/semver/-/semver-7.7.4.tgz",
       "integrity": "sha1-KEZONgYOmR+noR0CedLT87V6foo=",
       "license": "ISC",
       "bin": {
@@ -2330,7 +2164,6 @@
     },
     "node_modules/setimmediate": {
       "version": "1.0.5",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
       "dev": true,
       "license": "MIT"
@@ -2341,7 +2174,6 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha1-zNCvT4g1+9wmW4JGGq8MNmY/NOo=",
       "dev": true,
       "license": "MIT",
@@ -2354,7 +2186,6 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha1-rhbxZE2HPsrYQ7AwexQzYtTEIXI=",
       "dev": true,
       "license": "MIT",
@@ -2364,7 +2195,6 @@
     },
     "node_modules/shell-quote": {
       "version": "1.8.3",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/shell-quote/-/shell-quote-1.8.3.tgz",
       "integrity": "sha1-VeQO8zz1xomQI1Oj2M0aZyXwi0s=",
       "dev": true,
       "license": "MIT",
@@ -2377,7 +2207,6 @@
     },
     "node_modules/signal-exit": {
       "version": "4.1.0",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha1-lSGIwcvVRgcOLdIND0HArgUwywQ=",
       "dev": true,
       "license": "ISC",
@@ -2390,7 +2219,6 @@
     },
     "node_modules/stdin-discarder": {
       "version": "0.2.2",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
       "integrity": "sha1-OQA39ExK4aGuU1xf443Dq6jZl74=",
       "dev": true,
       "license": "MIT",
@@ -2403,7 +2231,6 @@
     },
     "node_modules/string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
       "dev": true,
       "license": "MIT",
@@ -2413,14 +2240,12 @@
     },
     "node_modules/string_decoder/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "4.2.3",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
       "dev": true,
       "license": "MIT",
@@ -2435,7 +2260,6 @@
     },
     "node_modules/string-width/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
       "dev": true,
       "license": "MIT",
@@ -2445,7 +2269,6 @@
     },
     "node_modules/string-width/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
       "dev": true,
       "license": "MIT",
@@ -2458,7 +2281,6 @@
     },
     "node_modules/strip-ansi": {
       "version": "7.2.0",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/strip-ansi/-/strip-ansi-7.2.0.tgz",
       "integrity": "sha1-0iomlSKDamJ6+NBLXD/Sx/o+MuM=",
       "dev": true,
       "license": "MIT",
@@ -2474,7 +2296,6 @@
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha1-4ijdHmOM6pk9L9tPzS1GAqeZUcI=",
       "dev": true,
       "license": "MIT",
@@ -2491,7 +2312,6 @@
     },
     "node_modules/tinyglobby/node_modules/fdir": {
       "version": "6.5.0",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha1-7Sq5Z6MxreYvGNB32uGSaE1Q01A=",
       "dev": true,
       "license": "MIT",
@@ -2509,7 +2329,6 @@
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
       "version": "4.0.4",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha1-/W9eAKFDCG4HTf/kySS4+yk7BYk=",
       "dev": true,
       "license": "MIT",
@@ -2522,7 +2341,6 @@
     },
     "node_modules/ts-api-utils": {
       "version": "2.4.0",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
       "integrity": "sha1-JpBXn5bSeQJTvc8co11WmtePmtg=",
       "dev": true,
       "license": "MIT",
@@ -2535,14 +2353,12 @@
     },
     "node_modules/tslib": {
       "version": "2.8.1",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha1-YS7+TtI11Wfoq6Xypfq3AoCt6D8=",
       "license": "0BSD",
       "peer": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/type-check/-/type-check-0.4.0.tgz",
       "integrity": "sha1-B7ggO/pwVsBlcFDjzNLDdzC6uPE=",
       "dev": true,
       "license": "MIT",
@@ -2555,7 +2371,6 @@
     },
     "node_modules/typescript": {
       "version": "5.9.3",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha1-W09Z4VMQqxeiFvXWz1PuR27eZw8=",
       "dev": true,
       "license": "Apache-2.0",
@@ -2569,14 +2384,12 @@
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha1-aR0ArzkJvpOn+qE75hs6W1DvEss=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha1-mxpSWVIlhZ5V9mnZKPiMbFfyp34=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -2586,7 +2399,6 @@
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true,
       "license": "MIT"
@@ -2597,7 +2409,6 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/which/-/which-2.0.2.tgz",
       "integrity": "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=",
       "dev": true,
       "license": "ISC",
@@ -2613,7 +2424,6 @@
     },
     "node_modules/word-wrap": {
       "version": "1.2.5",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/word-wrap/-/word-wrap-1.2.5.tgz",
       "integrity": "sha1-0sRcbdT7zmIaZvE2y+Mor9BBCzQ=",
       "dev": true,
       "license": "MIT",
@@ -2623,7 +2433,6 @@
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
       "dev": true,
       "license": "MIT",
@@ -2641,7 +2450,6 @@
     },
     "node_modules/wrap-ansi/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
       "dev": true,
       "license": "MIT",
@@ -2651,7 +2459,6 @@
     },
     "node_modules/wrap-ansi/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
       "dev": true,
       "license": "MIT",
@@ -2664,7 +2471,6 @@
     },
     "node_modules/y18n": {
       "version": "5.0.8",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha1-f0k00PfKjFb5UxSTndzS3ZHOHVU=",
       "dev": true,
       "license": "ISC",
@@ -2674,7 +2480,6 @@
     },
     "node_modules/yargs": {
       "version": "17.7.2",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha1-mR3zmspnWhkrgW4eA2P5110qomk=",
       "dev": true,
       "license": "MIT",
@@ -2693,7 +2498,6 @@
     },
     "node_modules/yargs-parser": {
       "version": "21.1.1",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha1-kJa87r+ZDSG7MfqVFuDt4pSnfTU=",
       "dev": true,
       "license": "ISC",
@@ -2703,7 +2507,6 @@
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
-      "resolved": "https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/npm/registry/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha1-ApTrPe4FAo0x7hpfosVWpqrxChs=",
       "dev": true,
       "license": "MIT",


### PR DESCRIPTION
- Configure npm lockfile generation to omit registry-resolved URLs.
- Regenerate npm lockfiles without Azure Artifacts or public registry `resolved` URLs.
- Document the repository policy that registry/feed/auth configuration belongs outside committed npm config and lockfiles.
  
 This PR updates `src/vscode-extensions/.npmrc` to set:
 
 ```ini
 omit-lockfile-registry-resolved=true

That setting keeps committed package-lock.json files independent of whichever registry or feed is used during restore or dependency updates.

The committed .npmrc intentionally does not set registry. If a developer or CI environment needs a private registry/feed, that configuration should come from user npm config or restore-time CI configuration, not from committed .npmrc or package-lock.json file