### PR TITLE
Loading indicator and disable sync operations while a sync is in progress

### DIFF
--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/commands/reattachAgent.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/commands/reattachAgent.ts
@@ -6,7 +6,7 @@ import { switchAccount } from '../clients/account';
 import { pushNewWorkspace } from '../sync/workspaceScm';
 import { lspClient, buildLspRequestPayload } from '../services/lspClient';
 import logger from '../services/logger';
-import { logWorkflowIssues, logNewCustomConnectorsRaw } from '../sync/workspaceSynchronizer';
+import { logWorkflowIssues, logNewCustomConnectorsRaw, withSyncCommandBusy } from '../sync/workspaceSynchronizer';
 
 export const registerReattachAgentCommand = (context: vscode.ExtensionContext) => {
   const reattachAgentCommand = vscode.commands.registerCommand('microsoft-copilot-studio.reattachAgent', async () => {
@@ -46,6 +46,7 @@ export const registerReattachAgentCommand = (context: vscode.ExtensionContext) =
 
       const environmentInfo = pickedEnvironment.environment;
       const workspaceFolder = vscode.workspace.workspaceFolders[0];
+      const workspaceUri = workspaceFolder.uri.toString() + '/'; // Ensure trailing slash for consistency with workspace cache entries
 
       await vscode.window.withProgress(
         {
@@ -54,34 +55,36 @@ export const registerReattachAgentCommand = (context: vscode.ExtensionContext) =
           cancellable: false
         },
         async () => {
-          try {
-            const reattachRequest: ReattachAgentRequest = {
-              ...await buildLspRequestPayload(undefined, environmentInfo),
-              workspaceUri: workspaceFolder.uri.toString()
-            };
-            const reattachResult = await lspClient.sendRequest<ReattachAgentResponse>(LspMethods.REATTACH_AGENT, reattachRequest);
-
-            if (reattachResult.isNewAgent) {
-              const newWorkspace = {
-                workspaceUri: workspaceFolder.uri.toString(),
-                displayName: 'Reattached Agent',
-                description: '',
-                icon: new vscode.ThemeIcon('symbol-key'),
-                type: 0,
-                syncInfo: reattachResult.agentSyncInfo 
+          // For sync buttons to be disabled and loading indicators to be visible during the REATTACH_AGENT call.
+          await withSyncCommandBusy(workspaceUri, async () => {
+            try {
+              const reattachRequest: ReattachAgentRequest = {
+                ...await buildLspRequestPayload(undefined, environmentInfo),
+                workspaceUri
               };
+              const reattachResult = await lspClient.sendRequest<ReattachAgentResponse>(LspMethods.REATTACH_AGENT, reattachRequest);
 
-              await pushNewWorkspace(context, newWorkspace);
-              logger.logInfo(TelemetryEventsKeys.ReattachAgentInfo, `New agent ${reattachResult.agentSyncInfo.agentId} reattached successfully.`);
-            } else {
-              logger.logInfo(TelemetryEventsKeys.ReattachAgentInfo, `Existing agent ${reattachResult.agentSyncInfo.agentId} reattached successfully.`);
+              if (reattachResult.isNewAgent) {
+                const newWorkspace = {
+                  workspaceUri,
+                  displayName: 'Reattached Agent',
+                  description: '',
+                  icon: new vscode.ThemeIcon('symbol-key'),
+                  type: 0,
+                  syncInfo: reattachResult.agentSyncInfo
+                };
+                await pushNewWorkspace(context, newWorkspace);
+                logger.logInfo(TelemetryEventsKeys.ReattachAgentInfo, `New agent ${reattachResult.agentSyncInfo.agentId} reattached successfully.`);
+              } else {
+                logger.logInfo(TelemetryEventsKeys.ReattachAgentInfo, `Existing agent ${reattachResult.agentSyncInfo.agentId} reattached successfully.`);
+              }
+
+              logWorkflowIssues(reattachResult.workflowResponse);
+              logNewCustomConnectorsRaw(reattachResult.newlyCreatedCustomConnectors, workspaceUri);
+            } catch (error) {
+              logger.logError(TelemetryEventsKeys.ReattachAgentError, `Error reattaching agent: ${(error as Error).message}`);
             }
-            
-            logWorkflowIssues(reattachResult.workflowResponse);
-            logNewCustomConnectorsRaw(reattachResult.newlyCreatedCustomConnectors, workspaceFolder.uri.toString());
-          } catch (error) {
-            logger.logError(TelemetryEventsKeys.ReattachAgentError, `Error reattaching agent: ${(error as Error).message}`);
-          }
+          });
         }
       );
     });

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/commands/syncWorkspace.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/commands/syncWorkspace.ts
@@ -1,7 +1,7 @@
 import { commands, DiagnosticSeverity, ExtensionContext, languages, ProgressLocation, RelativePattern, TextDocument, Uri, window, workspace as VSworkspace } from "vscode";
 import { CopilotStudioWorkspace, getAllWorkspaces, hasConnectionFileInWorkspace } from "../sync/localWorkspaces";
 import { selectWorkspace } from "../sync/workspacePicker";
-import { getOrAddSynchronizer, WorkspaceSynchronizer } from "../sync/workspaceSynchronizer";
+import { getOrAddSynchronizer, withSyncCommandBusy, WorkspaceSynchronizer } from "../sync/workspaceSynchronizer";
 import { registerVirtualKnowledgeProvider } from "../knowledgeFiles/virtualKnowledgeFile";
 import { getWorkspaceChanges, refreshAgentChangesAfterFetch } from "../sync/workspaceScm";
 import { TelemetryEventsKeys } from "../constants";
@@ -135,59 +135,61 @@ const registerSyncCommand = (
       }
 
       let errors = { files: 0, count: 0 };
+      // For sync buttons to be disabled and loading indicators to be visible during the entire sync process.
+      await withSyncCommandBusy(selectedWorkspace.workspaceUri, async () => {
+        // For Apply operation, fetch remote changes first then check for conflicts
+        if (id === 'microsoft-copilot-studio.applyChanges') {
+          // First, fetch to get the current remote state
+          await window.withProgress({
+            location: ProgressLocation.Notification,
+            title: 'Checking for remote changes...',
+            cancellable: false
+          }, async () => {
+            const synchronizer = getOrAddSynchronizer(selectedWorkspace);
+            await synchronizer.fetch();
+            // Trigger refresh to update the change stores
+            await refreshAgentChangesAfterFetch(selectedWorkspace.workspaceUri);
+          });
 
-      // For Apply operation, fetch remote changes first then check for conflicts
-      if (id === 'microsoft-copilot-studio.applyChanges') {
-        // First, fetch to get the current remote state
+          // Now check if there are remote changes
+          const changes = getWorkspaceChanges(selectedWorkspace.workspaceUri);
+          // Filter out knowledge file changes - Knowledge file change is optional and do not block ApplyChanges.
+          const changesWithoutKnowledgeFiles =
+            changes?.remoteChanges.filter(
+              r => r.changeKind !== 'knowledge'
+            ) ?? [];
+
+          if (changesWithoutKnowledgeFiles.length > 0) {
+            const remoteCount = changesWithoutKnowledgeFiles.length;
+            const choice = await window.showWarningMessage(
+              `The agent has ${remoteCount} remote change${remoteCount === 1 ? '' : 's'} that must be retrieved before your local changes can be applied.`,
+              { modal: true },
+              'Get Remote Changes'
+            );
+
+            if (choice === 'Get Remote Changes') {
+              // Execute Get command instead
+              await commands.executeCommand('microsoft-copilot-studio.getChanges', { ws: selectedWorkspace });
+            }
+            // Either way, don't proceed with Apply
+            return;
+          }
+        }
+
         await window.withProgress({
           location: ProgressLocation.Notification,
-          title: 'Checking for remote changes...',
+          title: `${displayName} operation in progress. Please wait...`,
           cancellable: false
         }, async () => {
-          const synchronizer = getOrAddSynchronizer(selectedWorkspace);
-          await synchronizer.fetch();
-          // Trigger refresh to update the change stores
-          await refreshAgentChangesAfterFetch(selectedWorkspace.workspaceUri);
-        });
-
-        // Now check if there are remote changes
-        const changes = getWorkspaceChanges(selectedWorkspace.workspaceUri);
-        // Filter out knowledge file changes - Knowledge file change is optional and do not block ApplyChanges.
-        const changesWithoutKnowledgeFiles =
-          changes?.remoteChanges.filter(
-            r => r.changeKind !== 'knowledge'
-          ) ?? [];
-
-        if (changesWithoutKnowledgeFiles.length > 0) {
-          const remoteCount = changesWithoutKnowledgeFiles.length;
-          const choice = await window.showWarningMessage(
-            `The agent has ${remoteCount} remote change${remoteCount === 1 ? '' : 's'} that must be retrieved before your local changes can be applied.`,
-            { modal: true },
-            'Get Remote Changes'
-          );
-
-          if (choice === 'Get Remote Changes') {
-            // Execute Get command instead
-            await commands.executeCommand('microsoft-copilot-studio.getChanges', { ws: selectedWorkspace });
+          // For Push/Apply operations, check for errors before proceeding
+          if (id === 'microsoft-copilot-studio.syncPush' || id === 'microsoft-copilot-studio.applyChanges') {
+            errors = await getDiagnosticsErrors(selectedWorkspace);
           }
-          // Either way, don't proceed with Apply
-          return;
-        }
-      }
-
-      await window.withProgress({
-        location: ProgressLocation.Notification,
-        title: `${displayName} operation in progress. Please wait...`,
-        cancellable: false
-      }, async () => {
-        // For Push/Apply operations, check for errors before proceeding
-        if (id === 'microsoft-copilot-studio.syncPush' || id === 'microsoft-copilot-studio.applyChanges') {
-          errors = await getDiagnosticsErrors(selectedWorkspace);
-        }
-        if (errors.count === 0) {
-          const synchronizer = getOrAddSynchronizer(selectedWorkspace);
-          await action(synchronizer);
-        }
+          if (errors.count === 0) {
+            const synchronizer = getOrAddSynchronizer(selectedWorkspace);
+            await action(synchronizer);
+          }
+        });
       });
 
       if ((id === 'microsoft-copilot-studio.syncPush' || id === 'microsoft-copilot-studio.applyChanges') && errors.count > 0) {

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/commands/syncWorkspace.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/commands/syncWorkspace.ts
@@ -168,8 +168,17 @@ const registerSyncCommand = (
             );
 
             if (choice === 'Get Remote Changes') {
-              // Execute Get command instead
-              await commands.executeCommand('microsoft-copilot-studio.getChanges', { ws: selectedWorkspace });
+              // Run the Get logic directly rather than dispatching the Get
+              // command, to avoid re-entering withSyncCommandBusy.
+              await window.withProgress({
+                location: ProgressLocation.Notification,
+                title: 'Getting remote changes...',
+                cancellable: false
+              }, async () => {
+                const virtualKnowledgeProvider = await registerVirtualKnowledgeProvider(context, selectedWorkspace);
+                const synchronizer = getOrAddSynchronizer(selectedWorkspace);
+                await synchronizer.pull(virtualKnowledgeProvider);
+              });
             }
             // Either way, don't proceed with Apply
             return;

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/sync/agentChangesTreeProvider.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/sync/agentChangesTreeProvider.ts
@@ -3,6 +3,7 @@ import { addWorkspaceChangeSubscription, CopilotStudioWorkspace, getAllWorkspace
 import { Resource } from "./changeTracking";
 import { getWorkspaceChanges } from "./workspaceScm";
 import { ChangeType } from "../types";
+import { getActiveSyncUri, getSyncStateFor, onAnySyncStateChanged, SyncState } from "./workspaceSynchronizer";
 
 /**
  * Tree item types for the Agent Changes view hierarchy:
@@ -78,7 +79,16 @@ class AgentChangesTreeDataProvider implements TreeDataProvider<AgentChangesTreeI
           : TreeItemCollapsibleState.Collapsed;
         
         const item = new TreeItem(label, collapsibleState);
-        item.iconPath = new ThemeIcon(element.groupType === 'local' ? 'file-code' : 'cloud');
+        // Spinner mapping for the active sync workspace:
+        //   Fetching / Pulling -> Remote Changes
+        //   Pushing            -> Local Changes
+        const syncState = getSyncStateFor(element.workspace.workspaceUri);
+        const isBusy =
+          (element.groupType === 'remote' && (syncState === SyncState.Fetching || syncState === SyncState.Pulling)) ||
+          (element.groupType === 'local' && syncState === SyncState.Pushing);
+        item.iconPath = isBusy
+          ? new ThemeIcon('loading~spin')
+          : new ThemeIcon(element.groupType === 'local' ? 'file-code' : 'cloud');
         item.contextValue = `changeGroup-${element.groupType}`;
         return item;
       }
@@ -128,6 +138,11 @@ class AgentChangesTreeDataProvider implements TreeDataProvider<AgentChangesTreeI
       default:
         return new ThemeIcon('diff-modified', new ThemeColor('gitDecoration.modifiedResourceForeground'));
     }
+  }
+
+  /** Root agents have no parent; required for `treeView.reveal` to work. */
+  getParent(): AgentChangesTreeItemUnion | undefined {
+    return undefined;
   }
 
   getChildren(element?: AgentChangesTreeItemUnion): AgentChangesTreeItemUnion[] {
@@ -251,9 +266,18 @@ export function initializeAgentChangesTree(context: ExtensionContext): void {
   });
   context.subscriptions.push(treeChangeSubscription);
 
+  // Update the `mcs.isSyncing` context key and ensure the active agent is expanded so its loading state is visible.
+  const syncStateSubscription = onAnySyncStateChanged(() => {
+    treeDataProvider?.refresh();
+    updateSyncInProgressContextKey();
+    revealActiveAgent();
+  });
+  context.subscriptions.push(syncStateSubscription);
+
   // Initial badge update
   updateViewBadge();
   updateContextKeys();
+  updateSyncInProgressContextKey();
 }
 
 /**
@@ -303,6 +327,27 @@ function updateContextKeys(): void {
 }
 
 /**
+ * Set the `mcs.isSyncing` context key so command enablement clauses can
+ * disable sync buttons (Preview / Get / Apply) while any sync is running.
+ */
+function updateSyncInProgressContextKey(): void {
+  void commands.executeCommand('setContext', 'mcs.isSyncing', getActiveSyncUri() !== undefined);
+}
+
+/** Reveal and expand the active sync agent so its loading state is visible. */
+function revealActiveAgent(): void {
+  const activeUri = getActiveSyncUri();
+  if (!activeUri || !treeView || !treeDataProvider) {
+    return;
+  }
+  const activeAgent = treeDataProvider.getChildren()
+    .find((c): c is AgentTreeItem => c.kind === AgentChangesItemKind.Agent && c.workspace.workspaceUri === activeUri);
+  if (activeAgent) {
+    void treeView.reveal(activeAgent, { expand: true, focus: false, select: false });
+  }
+}
+
+/**
  * Refresh the Agent Changes tree view.
  * Call this after sync operations complete.
  */
@@ -312,4 +357,5 @@ export function refreshAgentChangesTree(): void {
   // This handles cases where the tree view might not be visible yet
   updateViewBadge();
   updateContextKeys();
+  updateSyncInProgressContextKey();
 }

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/sync/agentChangesTreeProvider.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/sync/agentChangesTreeProvider.ts
@@ -57,6 +57,7 @@ class AgentChangesTreeDataProvider implements TreeDataProvider<AgentChangesTreeI
     switch (element.kind) {
       case AgentChangesItemKind.Agent: {
         const item = new TreeItem(element.workspace.displayName, TreeItemCollapsibleState.Expanded);
+        item.id = `agent:${element.workspace.workspaceUri}`;
         item.iconPath = element.workspace.icon;
         item.description = element.workspace.description;
         item.contextValue = 'agent';
@@ -79,6 +80,7 @@ class AgentChangesTreeDataProvider implements TreeDataProvider<AgentChangesTreeI
           : TreeItemCollapsibleState.Collapsed;
         
         const item = new TreeItem(label, collapsibleState);
+        item.id = `changeGroup:${element.workspace.workspaceUri}:${element.groupType}`;
         // Spinner mapping for the active sync workspace:
         //   Fetching / Pulling -> Remote Changes
         //   Pushing            -> Local Changes
@@ -96,6 +98,7 @@ class AgentChangesTreeDataProvider implements TreeDataProvider<AgentChangesTreeI
         const resource = element.resource;
         const fileName = resource.resourceUri.path.split('/').pop() || resource.resourceUri.path;
         const item = new TreeItem(fileName, TreeItemCollapsibleState.None);
+        item.id = `changeItem:${element.workspace.workspaceUri}:${element.groupType}:${resource.resourceUri.toString()}`;
         
         // Set icon based on change type
         item.iconPath = this.getChangeTypeIcon(resource.type);
@@ -140,9 +143,24 @@ class AgentChangesTreeDataProvider implements TreeDataProvider<AgentChangesTreeI
     }
   }
 
-  /** Root agents have no parent; required for `treeView.reveal` to work. */
-  getParent(): AgentChangesTreeItemUnion | undefined {
-    return undefined;
+  /**
+   * Return the parent of an element so `treeView.reveal` can locate it.
+   * Hierarchy: Agent (root) -> ChangeGroup -> ChangeItem.
+   */
+  getParent(element: AgentChangesTreeItemUnion): AgentChangesTreeItemUnion | undefined {
+    switch (element.kind) {
+      case AgentChangesItemKind.Agent:
+        return undefined;
+      case AgentChangesItemKind.ChangeGroup:
+        return { kind: AgentChangesItemKind.Agent, workspace: element.workspace };
+      case AgentChangesItemKind.ChangeItem:
+        return {
+          kind: AgentChangesItemKind.ChangeGroup,
+          workspace: element.workspace,
+          groupType: element.groupType,
+          label: element.groupType === 'local' ? 'Local Changes' : 'Remote Changes',
+        };
+    }
   }
 
   getChildren(element?: AgentChangesTreeItemUnion): AgentChangesTreeItemUnion[] {

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/sync/localWorkspaces.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/sync/localWorkspaces.ts
@@ -60,7 +60,7 @@ export const findWorkspaceForUri = (uri: string): CopilotStudioWorkspace | undef
 
 // Finds a workspace that contains the specified URI.
 export const getWorkspaceByUri = (uri: Uri): CopilotStudioWorkspace | undefined => {
-  const uriString = uri.scheme === 'mcs' ? decodeURIComponent(uri.query) : uri.toString();
+  const uriString = uri.scheme === 'mcs' ? decodeURIComponent(uri.query) : uri.toString(true);
   return workspaceCache.find(workspace => uriString.startsWith(decodeURI(workspace.workspaceUri)));
 };
 

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/sync/workspaceScm.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/sync/workspaceScm.ts
@@ -1,5 +1,5 @@
 import { unescape } from "querystring";
-import { CancellationToken, commands, EventEmitter, ExtensionContext, scm, SourceControlResourceGroup, Uri, window, workspace } from "vscode";
+import { CancellationToken, commands, EventEmitter, ExtensionContext, scm, SourceControlResourceGroup, Uri, window } from "vscode";
 import { addWorkspaceChangeSubscription, CopilotStudioWorkspace, getAllWorkspaces, updateWorkspaceCache, hasConnectionFileInWorkspace } from "./localWorkspaces";
 import { LocalChangeResourceCommandResolver, RemoteChangeResourceCommandResolver, Resource, ResourceCommandResolver } from "./changeTracking";
 import { SyncResponse, Change, SyncRequest, DiffRequest } from "../types";
@@ -165,8 +165,9 @@ export async function pushNewWorkspace(context: ExtensionContext, ws: CopilotStu
   const updatedCache = await updateWorkspaceCache(ws);
   await refreshWorkspaces(updatedCache, context);
 
-  const synchronizer = getOrAddSynchronizer(ws);
-  const virtualKnowledgeProvider = await registerVirtualKnowledgeProvider(context, ws);
+  const workspace = updatedCache.find(w =>  Uri.parse(w.workspaceUri).toString() === Uri.parse(ws.workspaceUri).toString());
+  const synchronizer = getOrAddSynchronizer(workspace ?? ws);
+  const virtualKnowledgeProvider = await registerVirtualKnowledgeProvider(context, workspace ?? ws);
   await synchronizer.pull(virtualKnowledgeProvider);
   await synchronizer.push();
   await synchronizer.pull(virtualKnowledgeProvider);

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/sync/workspaceSynchronizer.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/sync/workspaceSynchronizer.ts
@@ -42,8 +42,16 @@ export function getSyncStateFor(workspaceUri: string): SyncState {
  * across multiple fetch/pull/push steps. Surfaces a native progress bar at
  * the top of the Agent Changes tree view and disables sync buttons via the
  * `mcs.isSyncing` context key.
+ *
+ * Reentrancy is not supported: if a sync is already running, this throws.
+ * UI entry points are gated by `!mcs.isSyncing`, so re-entry can only happen
+ * from extension code calling `commands.executeCommand` for a sync command
+ * while another sync is in flight -- which is always a bug.
  */
 export async function withSyncCommandBusy<T>(workspaceUri: string, body: () => Promise<T>): Promise<T> {
+  if (_activeSyncUri !== undefined) {
+    throw new Error(`A sync is already in progress for ${_activeSyncUri}; cannot start another for ${workspaceUri}.`);
+  }
   _activeSyncUri = workspaceUri;
   _onAnySyncStateChanged.fire();
   try {

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/sync/workspaceSynchronizer.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/sync/workspaceSynchronizer.ts
@@ -88,6 +88,7 @@ function getSynchronizer(ws: CopilotStudioWorkspace): WorkspaceSynchronizer {
   function updateSyncState(newState: SyncState) {
     currentState = newState;
     listeners.forEach(listener => listener(newState));
+    _onAnySyncStateChanged.fire();
   }
 
   async function executeSyncOperation<T>(operation: () => Promise<T>, newState: SyncState): Promise<T> {

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/sync/workspaceSynchronizer.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/sync/workspaceSynchronizer.ts
@@ -20,6 +20,43 @@ export enum SyncState {
   Pushing,
 }
 
+/** Global event fired whenever sync activity changes. Used to refresh UI. */
+const _onAnySyncStateChanged = new vscode.EventEmitter<void>();
+export const onAnySyncStateChanged = _onAnySyncStateChanged.event;
+
+/** workspaceUri of the workspace currently inside `withSyncCommandBusy`. */
+let _activeSyncUri: string | undefined;
+
+/** Returns the workspaceUri of the workspace currently being synced, or undefined. */
+export function getActiveSyncUri(): string | undefined {
+  return _activeSyncUri;
+}
+
+/** Returns the synchronizer's current SyncState for `workspaceUri`, or Idle if none. */
+export function getSyncStateFor(workspaceUri: string): SyncState {
+  return map.get(workspaceUri)?.syncState ?? SyncState.Idle;
+}
+
+/**
+ * Wrap a sync command's body so the busy state is held for the full duration
+ * across multiple fetch/pull/push steps. Surfaces a native progress bar at
+ * the top of the Agent Changes tree view and disables sync buttons via the
+ * `mcs.isSyncing` context key.
+ */
+export async function withSyncCommandBusy<T>(workspaceUri: string, body: () => Promise<T>): Promise<T> {
+  _activeSyncUri = workspaceUri;
+  _onAnySyncStateChanged.fire();
+  try {
+    return await vscode.window.withProgress(
+      { location: { viewId: 'agent-changes' } },
+      body
+    );
+  } finally {
+    _activeSyncUri = undefined;
+    _onAnySyncStateChanged.fire();
+  }
+}
+
 export interface WorkspaceSynchronizer {
     workspace: CopilotStudioWorkspace;
     syncState: SyncState;
@@ -50,12 +87,11 @@ function getSynchronizer(ws: CopilotStudioWorkspace): WorkspaceSynchronizer {
 
   function updateSyncState(newState: SyncState) {
     currentState = newState;
-    // Notify all listeners about state change
     listeners.forEach(listener => listener(newState));
   }
 
   async function executeSyncOperation<T>(operation: () => Promise<T>, newState: SyncState): Promise<T> {
-    // prevComponentent concurrent operations
+    // Prevent concurrent operations
     if (currentState !== SyncState.Idle) {
       throw new Error('Another sync operation is in progress');
     }

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/tests/host/agentChangesTreeProvider.test.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/tests/host/agentChangesTreeProvider.test.ts
@@ -10,6 +10,7 @@ import {
 } from '../../sync/agentChangesTreeProvider';
 import { Resource } from '../../sync/changeTracking';
 import { ChangeType } from '../../types';
+import { SyncState } from '../../sync/workspaceSynchronizer';
 
 /**
  * Type guard tests for AgentChangesTreeItemUnion discriminated union.
@@ -251,5 +252,46 @@ describe('Apply Gating Logic', () => {
 		const remoteCount = 5 as number;
 		const message = `The agent has ${remoteCount} remote change${remoteCount === 1 ? '' : 's'} that must be retrieved before your local changes can be applied.`;
 		assert.ok(message.includes('5 remote changes that'));
+	});
+});
+
+describe('Sync Spinner Group Mapping', () => {
+	// Mirrors the per-state spinner mapping in
+	// AgentChangesTreeDataProvider.getTreeItem for the ChangeGroup case:
+	//   Fetching / Pulling -> spinner on Remote group
+	//   Pushing            -> spinner on Local group
+	//   Idle               -> no spinner anywhere
+	//
+	// Keep this helper in lock-step with the production code.
+	type GroupType = 'local' | 'remote';
+	const isBusy = (groupType: GroupType, syncState: SyncState): boolean =>
+		(groupType === 'remote' && (syncState === SyncState.Fetching || syncState === SyncState.Pulling)) ||
+		(groupType === 'local' && syncState === SyncState.Pushing);
+
+	test('Idle: neither group spins', () => {
+		assert.strictEqual(isBusy('local', SyncState.Idle), false);
+		assert.strictEqual(isBusy('remote', SyncState.Idle), false);
+	});
+
+	test('Fetching: only remote group spins', () => {
+		assert.strictEqual(isBusy('remote', SyncState.Fetching), true);
+		assert.strictEqual(isBusy('local', SyncState.Fetching), false);
+	});
+
+	test('Pulling: only remote group spins', () => {
+		assert.strictEqual(isBusy('remote', SyncState.Pulling), true);
+		assert.strictEqual(isBusy('local', SyncState.Pulling), false);
+	});
+
+	test('Pushing: only local group spins', () => {
+		assert.strictEqual(isBusy('local', SyncState.Pushing), true);
+		assert.strictEqual(isBusy('remote', SyncState.Pushing), false);
+	});
+
+	test('Each non-Idle state activates exactly one group', () => {
+		for (const state of [SyncState.Fetching, SyncState.Pulling, SyncState.Pushing]) {
+			const spinning = (['local', 'remote'] as GroupType[]).filter(g => isBusy(g, state));
+			assert.strictEqual(spinning.length, 1, `expected one spinning group for state ${SyncState[state]}, got ${spinning.length}`);
+		}
 	});
 });

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/tests/host/workspaceSynchronizer.test.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/tests/host/workspaceSynchronizer.test.ts
@@ -63,6 +63,30 @@ describe('workspaceSynchronizer: withSyncCommandBusy', () => {
 		assert.ok(events.includes('file:///test/agent-event'), `expected start event, got ${JSON.stringify(events)}`);
 		assert.strictEqual(events[events.length - 1], undefined, 'last event should observe cleared state');
 	});
+
+	test('throws when re-entered while another sync is in progress', async () => {
+		const outerUri = 'file:///test/agent-outer';
+		const innerUri = 'file:///test/agent-inner';
+		await assert.rejects(
+			withSyncCommandBusy(outerUri, async () => {
+				await withSyncCommandBusy(innerUri, async () => { /* unreachable */ });
+			}),
+			/sync is already in progress/i,
+		);
+		// Outer's finally still runs, clearing the state.
+		assert.strictEqual(getActiveSyncUri(), undefined);
+	});
+
+	test('same-uri re-entry also throws (no implicit reuse)', async () => {
+		const uri = 'file:///test/agent-same';
+		await assert.rejects(
+			withSyncCommandBusy(uri, async () => {
+				await withSyncCommandBusy(uri, async () => { /* unreachable */ });
+			}),
+			/sync is already in progress/i,
+		);
+		assert.strictEqual(getActiveSyncUri(), undefined);
+	});
 });
 
 describe('workspaceSynchronizer: getSyncStateFor', () => {

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/tests/host/workspaceSynchronizer.test.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/tests/host/workspaceSynchronizer.test.ts
@@ -1,0 +1,92 @@
+import * as assert from 'node:assert';
+import { describe, test } from 'node:test';
+import {
+	getActiveSyncUri,
+	getSyncStateFor,
+	onAnySyncStateChanged,
+	SyncState,
+	withSyncCommandBusy,
+} from '../../sync/workspaceSynchronizer';
+
+/**
+ * Tests for the command-level busy tracking exposed by workspaceSynchronizer.
+ *
+ * Covers the "isSyncing" model that drives the `mcs.isSyncing` context key
+ * and the per-workspace spinner / auto-expand behavior in the Agent Changes
+ * tree view.
+ */
+describe('workspaceSynchronizer: withSyncCommandBusy', () => {
+
+	test('getActiveSyncUri is undefined when no sync is running', () => {
+		assert.strictEqual(getActiveSyncUri(), undefined);
+	});
+
+	test('getActiveSyncUri returns the workspace uri while body runs, undefined after', async () => {
+		const uri = 'file:///test/agent-a';
+		assert.strictEqual(getActiveSyncUri(), undefined);
+
+		let observedDuringBody: string | undefined;
+		await withSyncCommandBusy(uri, async () => {
+			observedDuringBody = getActiveSyncUri();
+		});
+
+		assert.strictEqual(observedDuringBody, uri);
+		assert.strictEqual(getActiveSyncUri(), undefined);
+	});
+
+	test('getActiveSyncUri is cleared when body throws', async () => {
+		const uri = 'file:///test/agent-throws';
+		await assert.rejects(
+			withSyncCommandBusy(uri, async () => {
+				assert.strictEqual(getActiveSyncUri(), uri);
+				throw new Error('boom');
+			}),
+			/boom/,
+		);
+		assert.strictEqual(getActiveSyncUri(), undefined);
+	});
+
+	test('withSyncCommandBusy returns the body result', async () => {
+		const result = await withSyncCommandBusy('file:///test/agent-result', async () => 42);
+		assert.strictEqual(result, 42);
+	});
+
+	test('onAnySyncStateChanged fires at start and end of withSyncCommandBusy', async () => {
+		const events: (string | undefined)[] = [];
+		const sub = onAnySyncStateChanged(() => events.push(getActiveSyncUri()));
+		try {
+			await withSyncCommandBusy('file:///test/agent-event', async () => { /* no-op */ });
+		} finally {
+			sub.dispose();
+		}
+		// Expect at least one "start" event with the uri set, then a "clear" event.
+		assert.ok(events.includes('file:///test/agent-event'), `expected start event, got ${JSON.stringify(events)}`);
+		assert.strictEqual(events[events.length - 1], undefined, 'last event should observe cleared state');
+	});
+});
+
+describe('workspaceSynchronizer: getSyncStateFor', () => {
+
+	test('returns Idle for an unknown workspace uri', () => {
+		assert.strictEqual(getSyncStateFor('file:///nonexistent/workspace'), SyncState.Idle);
+	});
+
+	test('returns Idle for a workspace not currently syncing', () => {
+		// withSyncCommandBusy alone does not create a per-workspace synchronizer
+		// entry; that only happens via getOrAddSynchronizer. So a workspace that
+		// has only been wrapped by withSyncCommandBusy should still report Idle.
+		assert.strictEqual(getSyncStateFor('file:///test/agent-never-synced'), SyncState.Idle);
+	});
+});
+
+describe('workspaceSynchronizer: SyncState enum', () => {
+
+	test('SyncState.Idle is the default / zero value', () => {
+		assert.strictEqual(SyncState.Idle, 0);
+	});
+
+	test('SyncState has distinct values for each operation', () => {
+		const values = new Set([SyncState.Idle, SyncState.Fetching, SyncState.Pulling, SyncState.Pushing]);
+		assert.strictEqual(values.size, 4, 'all SyncState values must be distinct');
+	});
+});

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/package.json
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/package.json
@@ -237,18 +237,20 @@
       {
         "command": "microsoft-copilot-studio.previewChanges",
         "title": "Copilot Studio: Preview changes",
-        "icon": "$(eye)"
+        "icon": "$(eye)",
+        "enablement": "!mcs.isSyncing"
       },
       {
         "command": "microsoft-copilot-studio.getChanges",
         "title": "Copilot Studio: Get changes",
-        "icon": "$(cloud-download)"
+        "icon": "$(cloud-download)",
+        "enablement": "!mcs.isSyncing"
       },
       {
         "command": "microsoft-copilot-studio.applyChanges",
         "title": "Copilot Studio: Apply changes",
         "icon": "$(cloud-upload)",
-        "enablement": "!mcs.agentChangesView.hasRemoteChanges"
+        "enablement": "!mcs.agentChangesView.hasRemoteChanges && !mcs.isSyncing"
       },
       {
         "command": "microsoft-copilot-studio.cloneAgent",


### PR DESCRIPTION
[Issue #199 ](https://github.com/microsoft/vscode-copilotstudio/issues/199)

Sync commands are now disabled while any sync operation is running. 
A progress bar is shown at the top of the Agent Changes view, and the active agent auto-expands so progress is always visible.
A loading spinner is shown on the affected change group (Local for **Push**, Remote for **Fetch/Pull**).