### PR TITLE
Format logs displayed in the output window

### DIFF
--- a/src/LanguageServers/PowerPlatformLS/Contracts.LSP/Models/LSPMethods.cs
+++ b/src/LanguageServers/PowerPlatformLS/Contracts.LSP/Models/LSPMethods.cs
@@ -30,6 +30,11 @@
         public const string Initialized = "initialized";
         public const string Shutdown = "shutdown";
         public const string Exit = "exit";
+
+        // Standard LSP log notification. Gated on the client's "initialized"
+        // notification so our user-registered handler (LogOutputChannel) wins
+        // over vscode-languageclient's built-in handler.
+        public const string WindowLogMessage = "window/logMessage";
         #endregion
     }
 }

--- a/src/LanguageServers/PowerPlatformLS/Contracts.LSP/Models/LogMessageParams.cs
+++ b/src/LanguageServers/PowerPlatformLS/Contracts.LSP/Models/LogMessageParams.cs
@@ -1,0 +1,13 @@
+namespace Microsoft.PowerPlatformLS.Contracts.Lsp.Models
+{
+    /// <summary>
+    /// Parameters for the LSP <c>window/logMessage</c> notification.
+    /// <see cref="Type"/>: Error=1, Warning=2, Info=3, Trace=4, Debug=5.
+    /// </summary>
+    public class LogMessageParams
+    {
+        public int Type { get; set; }
+
+        public string Message { get; set; } = string.Empty;
+    }
+}

--- a/src/LanguageServers/PowerPlatformLS/Impl.Core/DependencyInjection/HostApplicationBuilderExtensions.cs
+++ b/src/LanguageServers/PowerPlatformLS/Impl.Core/DependencyInjection/HostApplicationBuilderExtensions.cs
@@ -30,6 +30,18 @@ namespace Microsoft.PowerPlatformLS.Impl.Core.DependencyInjection
             return builder;
         }
 
+        /// <summary>
+        /// Forwards MEL entries to the LSP client via <c>window/logMessage</c> so the
+        /// extension renders them in its LogOutputChannel with <c>[error]/[warning]/[info]</c>
+        /// prefix and timestamp. Also disables the default Console provider.
+        /// </summary>
+        public static IHostApplicationBuilder UseLspWindowLogMessageLogging(this IHostApplicationBuilder builder)
+        {
+            builder.Logging.ClearProviders();
+            builder.Logging.Services.AddSingleton<ILoggerProvider, LspWindowLogMessageLoggerProvider>();
+            return builder;
+        }
+
         private static void AddLspCommandLine(this IConfigurationManager configuration, string[] args)
         {
             var switchMappings = new Dictionary<string, string>

--- a/src/LanguageServers/PowerPlatformLS/Impl.Core/JsonRpcStream.cs
+++ b/src/LanguageServers/PowerPlatformLS/Impl.Core/JsonRpcStream.cs
@@ -57,6 +57,12 @@ namespace Microsoft.PowerPlatformLS.Impl.Core
                 {
                     _logger.LogInformation($"Received Message: method={lspMessage.Method}, id={lspMessage.Id}");
 
+                    // Release the LSP log-forwarding pump once the client is initialized.
+                    if (string.Equals(lspMessage.Method, LspMethods.Initialized, StringComparison.Ordinal))
+                    {
+                        Lsp.LspWindowLogMessageLoggerProvider.SignalClientReady();
+                    }
+
                     // Don't await processing task and let them run in parallel.
                     // Scheduling is done in the server queue.
                     _ = ProcessJsonRpcMessageAsync(lspMessage, stoppingToken);

--- a/src/LanguageServers/PowerPlatformLS/Impl.Core/LSP/LspWindowLogMessageLoggerProvider.cs
+++ b/src/LanguageServers/PowerPlatformLS/Impl.Core/LSP/LspWindowLogMessageLoggerProvider.cs
@@ -107,6 +107,7 @@ namespace Microsoft.PowerPlatformLS.Impl.Core.Lsp
                 {
                     while (_queue.Reader.TryRead(out var entry))
                     {
+                        if (!transport.IsActive) return;
                         await SendAsync(transport, entry, token).ConfigureAwait(false);
                     }
                 }

--- a/src/LanguageServers/PowerPlatformLS/Impl.Core/LSP/LspWindowLogMessageLoggerProvider.cs
+++ b/src/LanguageServers/PowerPlatformLS/Impl.Core/LSP/LspWindowLogMessageLoggerProvider.cs
@@ -1,0 +1,245 @@
+namespace Microsoft.PowerPlatformLS.Impl.Core.Lsp
+{
+    using Microsoft.Extensions.Logging;
+    using Microsoft.PowerPlatformLS.Contracts.Internal;
+    using Microsoft.PowerPlatformLS.Contracts.Lsp.Models;
+    using System;
+    using System.Collections.Concurrent;
+    using System.Text.Json;
+    using System.Threading;
+    using System.Threading.Channels;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Forwards <see cref="ILogger"/> entries to the LSP client via
+    /// <c>window/logMessage</c>, rendered by the extension's LogOutputChannel
+    /// with <c>[error]/[warning]/[info]</c> prefix and timestamp.
+    /// </summary>
+    /// <remarks>
+    /// Entries are queued on an unbounded <see cref="Channel{T}"/> and drained by
+    /// a single background pump, keeping the logger call path free of I/O. The pump
+    /// waits for both the transport to connect and the client's <c>initialized</c>
+    /// notification (<see cref="ClientReadyTcs"/>) before flushing, so the extension's
+    /// custom handler is wired and takes precedence over vscode-languageclient's
+    /// built-in default (which would otherwise prepend a duplicate
+    /// <c>[Error|Warning|Info - h:mm:ss AM/PM]</c>).
+    /// </remarks>
+    [ProviderAlias("LspWindowLogMessage")]
+    internal sealed class LspWindowLogMessageLoggerProvider : ILoggerProvider
+    {
+        private readonly IServiceProvider _serviceProvider;
+        private readonly ConcurrentDictionary<string, ForwardingLogger> _loggers = new();
+
+        // Unbounded MPSC: many loggers write, one pump reads.
+        private readonly Channel<QueuedEntry> _queue = Channel.CreateUnbounded<QueuedEntry>(
+            new UnboundedChannelOptions
+            {
+                SingleReader = true,
+                SingleWriter = false,
+                AllowSynchronousContinuations = false,
+            });
+
+        private readonly CancellationTokenSource _shutdownCts = new();
+
+        // Signaled by JsonRpcStream on the client's "initialized" notification.
+        // Not readonly so tests can reset between cases.
+        internal static TaskCompletionSource<bool> ClientReadyTcs =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        internal static void SignalClientReady() => ClientReadyTcs.TrySetResult(true);
+
+        public LspWindowLogMessageLoggerProvider(IServiceProvider serviceProvider)
+        {
+            _serviceProvider = serviceProvider;
+
+            // Dedicated long-running thread; the pump otherwise parks in WaitToReadAsync.
+            _ = Task.Factory.StartNew(
+                PumpAsync,
+                _shutdownCts.Token,
+                TaskCreationOptions.LongRunning | TaskCreationOptions.DenyChildAttach,
+                TaskScheduler.Default).Unwrap();
+        }
+
+        public ILogger CreateLogger(string categoryName)
+        {
+            return _loggers.GetOrAdd(categoryName, name => new ForwardingLogger(ShortenCategory(name), this));
+        }
+
+        public void Dispose()
+        {
+            _shutdownCts.Cancel();
+            _queue.Writer.TryComplete();
+            _loggers.Clear();
+            _shutdownCts.Dispose();
+        }
+
+        // TryWrite never blocks on an unbounded channel.
+        private void Enqueue(QueuedEntry entry) => _queue.Writer.TryWrite(entry);
+
+        private async Task PumpAsync()
+        {
+            var token = _shutdownCts.Token;
+            try
+            {
+                // Poll until the transport is registered and connected. Entries
+                // accumulate in the channel meanwhile.
+                ILspTransport? transport = null;
+                while (!token.IsCancellationRequested)
+                {
+                    transport = _serviceProvider.GetService(typeof(ILspTransport)) as ILspTransport;
+                    if (transport is { IsActive: true })
+                    {
+                        break;
+                    }
+
+                    await Task.Delay(50, token).ConfigureAwait(false);
+                }
+
+                if (transport == null)
+                {
+                    return;
+                }
+
+                // Wait for client "initialized" so our user handler wins over the built-in.
+                await ClientReadyTcs.Task.WaitAsync(token).ConfigureAwait(false);
+
+                while (await _queue.Reader.WaitToReadAsync(token).ConfigureAwait(false))
+                {
+                    while (_queue.Reader.TryRead(out var entry))
+                    {
+                        await SendAsync(transport, entry, token).ConfigureAwait(false);
+                    }
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // Shutdown.
+            }
+            catch
+            {
+                // Logging must never crash the host.
+            }
+        }
+
+        private static async Task SendAsync(ILspTransport transport, QueuedEntry entry, CancellationToken cancellationToken)
+        {
+            var rpcMessage = new LspJsonRpcMessage
+            {
+                Method = LspMethods.WindowLogMessage,
+                Params = JsonSerializer.SerializeToElement(
+                    new LogMessageParams { Type = entry.MessageType, Message = entry.Message },
+                    Constants.DefaultSerializationOptions),
+            };
+
+            try
+            {
+                await transport.SendAsync(rpcMessage, cancellationToken).ConfigureAwait(false);
+            }
+            catch
+            {
+                // Transport may have closed underneath us. Drop and keep pumping.
+            }
+        }
+
+        private static string ShortenCategory(string categoryName)
+        {
+            if (string.IsNullOrEmpty(categoryName))
+            {
+                return categoryName;
+            }
+
+            // Strip generic arity / generic args so e.g. "Foo`1[[Bar]]" → "Foo".
+            int tick = categoryName.IndexOf('`');
+            if (tick >= 0)
+            {
+                categoryName = categoryName.Substring(0, tick);
+            }
+
+            int lastDot = categoryName.LastIndexOf('.');
+            return lastDot >= 0 && lastDot < categoryName.Length - 1
+                ? categoryName.Substring(lastDot + 1)
+                : categoryName;
+        }
+
+        private readonly struct QueuedEntry
+        {
+            public QueuedEntry(int messageType, string message)
+            {
+                MessageType = messageType;
+                Message = message;
+            }
+
+            public int MessageType { get; }
+
+            public string Message { get; }
+        }
+
+        private sealed class ForwardingLogger : ILogger
+        {
+            private readonly string _category;
+            private readonly LspWindowLogMessageLoggerProvider _owner;
+
+            public ForwardingLogger(string category, LspWindowLogMessageLoggerProvider owner)
+            {
+                _category = category;
+                _owner = owner;
+            }
+
+            public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+            // Accept everything; MEL's filter layer decides what to forward.
+            public bool IsEnabled(LogLevel logLevel) => logLevel != LogLevel.None;
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+            {
+                if (!IsEnabled(logLevel) || formatter == null)
+                {
+                    return;
+                }
+
+                string message;
+                try
+                {
+                    message = formatter(state, exception);
+                }
+                catch
+                {
+                    return;
+                }
+
+                if (exception != null)
+                {
+                    message = string.IsNullOrEmpty(message)
+                        ? exception.ToString()
+                        : $"{message}\n{exception}";
+                }
+
+                if (string.IsNullOrEmpty(message))
+                {
+                    return;
+                }
+
+                // LSP MessageType: Error = 1, Warning = 2, Info = 3, Trace = 4, Debug = 5.
+                int messageType = logLevel switch
+                {
+                    LogLevel.Critical    => 1,
+                    LogLevel.Error       => 1,
+                    LogLevel.Warning     => 2,
+                    LogLevel.Information => 3,
+                    LogLevel.Debug       => 5,
+                    LogLevel.Trace       => 4,
+                    _                    => 4,
+                };
+
+                _owner.Enqueue(new QueuedEntry(messageType, $"[{_category}] {message}"));
+            }
+
+            private sealed class NullScope : IDisposable
+            {
+                public static NullScope Instance { get; } = new NullScope();
+
+                public void Dispose() { }
+            }
+        }
+    }
+}

--- a/src/LanguageServers/PowerPlatformLS/LanguageServerHost/Program.cs
+++ b/src/LanguageServers/PowerPlatformLS/LanguageServerHost/Program.cs
@@ -31,12 +31,17 @@ try
     builder.Services.AddSingleton<ILspModule, McsLspModule>();
     builder.Services.AddSingleton<ILspModule>(sp => new PullAgentLspModule(sp.GetRequiredService<BuildVersionInfo>()));
 
+    // Forward MEL entries to the LSP client via window/logMessage so the
+    // extension renders them in its LogOutputChannel with [error]/[warning]/[info]
+    // prefix and timestamp. Also disables the default Console provider.
+    builder.UseLspWindowLogMessageLogging();
+
     var isTelemetryEnabled = ParseTelemetryEnabledFromArgs(args);
     Console.WriteLine($"Telemetry Status: {(isTelemetryEnabled ? "Enabled" : "Disabled")}");
     builder.Services.ConfigureAppInsightsLogging(channel, isTelemetryEnabled);
 
     var sessionId = ParseSessionIdFromArgs(args);
-    Console.WriteLine($"Registering Session Information: {sessionId}");
+    Console.WriteLine($"Session Id: {sessionId}");
     var sessionInfo = new SessionInformation
     {
         SessionId = sessionId

--- a/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.Core/JsonRpcStreamTests.cs
+++ b/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.Core/JsonRpcStreamTests.cs
@@ -4,12 +4,16 @@ namespace Microsoft.PowerPlatformLS.UnitTests.Impl.Core
     using Microsoft.PowerPlatformLS.Contracts.Internal;
     using Microsoft.PowerPlatformLS.Contracts.Lsp.Models;
     using Microsoft.PowerPlatformLS.Impl.Core;
+    using Microsoft.PowerPlatformLS.Impl.Core.Lsp;
     using System.IO;
     using System.Net.Sockets;
+    using System.Reflection;
     using System.Threading;
     using System.Threading.Tasks;
     using Xunit;
 
+    // Same collection as the provider tests: both touch the static ClientReadyTcs.
+    [Collection(nameof(LspWindowLogMessageCollection))]
     public class JsonRpcStreamTests
     {
         // Regression: client-disconnect during SendAsync must not escape RunAsync. Without the
@@ -64,6 +68,62 @@ namespace Microsoft.PowerPlatformLS.UnitTests.Impl.Core
                     "Unable to write data to the transport connection: Broken pipe.",
                     new SocketException()));
             }
+
+            public void Dispose() { }
+        }
+
+        // The LSP window/logMessage forwarding pump (LspWindowLogMessageLoggerProvider)
+        // is gated on the client's "initialized" notification. JsonRpcStream is the
+        // single place that observes that notification and releases the gate.
+        [Fact]
+        public async Task RunAsync_Signals_ClientReady_On_Initialized_Notification()
+        {
+            ResetClientReadyTcs();
+            Assert.False(LspWindowLogMessageLoggerProvider.ClientReadyTcs.Task.IsCompleted);
+
+            var transport = new InitializedThenStopTransport();
+            var stream = new JsonRpcStream(transport, NullLogger<JsonRpcStream>.Instance);
+
+            await stream.RunAsync(CancellationToken.None);
+
+            Assert.True(LspWindowLogMessageLoggerProvider.ClientReadyTcs.Task.IsCompletedSuccessfully);
+
+            ResetClientReadyTcs();
+        }
+
+        private static void ResetClientReadyTcs()
+        {
+            var field = typeof(LspWindowLogMessageLoggerProvider).GetField(
+                nameof(LspWindowLogMessageLoggerProvider.ClientReadyTcs),
+                BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public);
+            Assert.NotNull(field);
+            field!.SetValue(null, new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously));
+        }
+
+        private sealed class InitializedThenStopTransport : ILspTransport
+        {
+            private int _readCount;
+            private bool _active = true;
+
+            public bool IsActive => _active;
+
+            public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+            public Task<BaseJsonRpcMessage> GetNextMessageAsync(CancellationToken cancellationToken)
+            {
+                if (_readCount++ == 0)
+                {
+                    BaseJsonRpcMessage init = new LspJsonRpcMessage { Method = LspMethods.Initialized };
+                    return Task.FromResult(init);
+                }
+
+                _active = false;
+                BaseJsonRpcMessage sentinel = new LspJsonRpcMessage { Method = "_stop" };
+                return Task.FromResult(sentinel);
+            }
+
+            public Task SendAsync<T>(T response, CancellationToken cancellationToken) where T : BaseJsonRpcMessage
+                => Task.CompletedTask;
 
             public void Dispose() { }
         }

--- a/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.Core/LspWindowLogMessageLoggerProviderTests.cs
+++ b/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.Core/LspWindowLogMessageLoggerProviderTests.cs
@@ -1,0 +1,323 @@
+namespace Microsoft.PowerPlatformLS.UnitTests.Impl.Core
+{
+    using global::Microsoft.Extensions.Logging;
+    using global::Microsoft.Extensions.Logging.Abstractions;
+    using global::Microsoft.PowerPlatformLS.Contracts.Internal;
+    using global::Microsoft.PowerPlatformLS.Contracts.Lsp.Models;
+    using global::Microsoft.PowerPlatformLS.Impl.Core;
+    using global::Microsoft.PowerPlatformLS.Impl.Core.Lsp;
+    using System;
+    using System.Collections.Concurrent;
+    using System.Reflection;
+    using System.Text.Json;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Xunit;
+
+    // Serialized: ClientReadyTcs is a process-global static; running these in parallel
+    // with each other (or with JsonRpcStream tests that trigger it) would race.
+    [Collection(nameof(LspWindowLogMessageCollection))]
+    public class LspWindowLogMessageLoggerProviderTests : IDisposable
+    {
+        private readonly StubTransport _transport = new();
+        private readonly StubServiceProvider _services;
+        private readonly LspWindowLogMessageLoggerProvider _provider;
+
+        public LspWindowLogMessageLoggerProviderTests()
+        {
+            ResetClientReadyTcs();
+            _services = new StubServiceProvider(_transport);
+            _provider = new LspWindowLogMessageLoggerProvider(_services);
+        }
+
+        public void Dispose()
+        {
+            _provider.Dispose();
+            ResetClientReadyTcs();
+        }
+
+        [Fact]
+        public async Task Log_Forwards_WindowLogMessage_With_Category_Prefix_After_ClientReady()
+        {
+            _transport.Activate();
+            LspWindowLogMessageLoggerProvider.SignalClientReady();
+
+            var logger = _provider.CreateLogger("My.Namespace.Foo");
+            logger.LogInformation("hello world");
+
+            var sent = await _transport.WaitForOneAsync();
+
+            Assert.Equal(LspMethods.WindowLogMessage, sent.Method);
+            var payload = sent.Params!.Value.Deserialize<LogMessageParams>(Constants.DefaultSerializationOptions)!;
+            Assert.Equal(3, payload.Type); // Information => 3
+            Assert.Equal("[Foo] hello world", payload.Message);
+        }
+
+        [Fact]
+        public async Task Pump_Buffers_Until_Transport_Becomes_Active()
+        {
+            // Transport not active yet, but client is "ready".
+            LspWindowLogMessageLoggerProvider.SignalClientReady();
+
+            var logger = _provider.CreateLogger("Cat");
+            logger.LogInformation("before transport");
+
+            // Nothing should be sent yet.
+            await Task.Delay(200);
+            Assert.Empty(_transport.Sent);
+
+            // Activating the transport unblocks the pump.
+            _transport.Activate();
+
+            var sent = await _transport.WaitForOneAsync();
+            Assert.Equal("[Cat] before transport", DeserializeMessage(sent));
+        }
+
+        [Fact]
+        public async Task Pump_Buffers_Until_ClientReady_Is_Signaled()
+        {
+            _transport.Activate();
+
+            var logger = _provider.CreateLogger("Cat");
+            logger.LogInformation("before initialized");
+
+            // Even with an active transport, nothing flushes before the gate opens.
+            await Task.Delay(200);
+            Assert.Empty(_transport.Sent);
+
+            LspWindowLogMessageLoggerProvider.SignalClientReady();
+
+            var sent = await _transport.WaitForOneAsync();
+            Assert.Equal("[Cat] before initialized", DeserializeMessage(sent));
+        }
+
+        [Theory]
+        [InlineData(LogLevel.Critical, 1)]
+        [InlineData(LogLevel.Error, 1)]
+        [InlineData(LogLevel.Warning, 2)]
+        [InlineData(LogLevel.Information, 3)]
+        [InlineData(LogLevel.Trace, 4)]
+        [InlineData(LogLevel.Debug, 5)]
+        public async Task Log_Maps_LogLevel_To_Lsp_MessageType(LogLevel level, int expectedType)
+        {
+            _transport.Activate();
+            LspWindowLogMessageLoggerProvider.SignalClientReady();
+
+            var logger = _provider.CreateLogger("Cat");
+            logger.Log(level, "msg");
+
+            var sent = await _transport.WaitForOneAsync();
+            var payload = sent.Params!.Value.Deserialize<LogMessageParams>(Constants.DefaultSerializationOptions)!;
+            Assert.Equal(expectedType, payload.Type);
+        }
+
+        [Fact]
+        public async Task Log_With_Empty_Message_And_No_Exception_Is_Dropped()
+        {
+            _transport.Activate();
+            LspWindowLogMessageLoggerProvider.SignalClientReady();
+
+            var logger = _provider.CreateLogger("Cat");
+            logger.LogInformation(string.Empty);
+            // Follow up with a real message so we can prove the empty one wasn't sent.
+            logger.LogInformation("real");
+
+            var sent = await _transport.WaitForOneAsync();
+            Assert.Equal("[Cat] real", DeserializeMessage(sent));
+            await Task.Delay(100);
+            Assert.Single(_transport.Sent);
+        }
+
+        [Fact]
+        public async Task Log_Appends_Exception_When_Provided()
+        {
+            _transport.Activate();
+            LspWindowLogMessageLoggerProvider.SignalClientReady();
+
+            var logger = _provider.CreateLogger("Cat");
+            var ex = new InvalidOperationException("boom");
+            logger.LogError(ex, "failed");
+
+            var sent = await _transport.WaitForOneAsync();
+            var message = DeserializeMessage(sent);
+            Assert.StartsWith("[Cat] failed", message);
+            Assert.Contains("InvalidOperationException", message);
+            Assert.Contains("boom", message);
+        }
+
+        [Fact]
+        public async Task Log_With_Only_Exception_Uses_Exception_String()
+        {
+            _transport.Activate();
+            LspWindowLogMessageLoggerProvider.SignalClientReady();
+
+            var logger = _provider.CreateLogger("Cat");
+            var ex = new InvalidOperationException("only");
+            logger.LogError(ex, string.Empty);
+
+            var sent = await _transport.WaitForOneAsync();
+            var message = DeserializeMessage(sent);
+            Assert.Contains("InvalidOperationException", message);
+            Assert.Contains("only", message);
+        }
+
+        [Theory]
+        [InlineData("A.B.C", "[C] msg")]
+        [InlineData("OnlyOne", "[OnlyOne] msg")]
+        [InlineData("Generic`1[[X]]", "[Generic] msg")]
+        [InlineData("Ns.Generic`2[[X],[Y]]", "[Generic] msg")]
+        public async Task CreateLogger_Shortens_Category(string fullName, string expectedPrefixedMessage)
+        {
+            _transport.Activate();
+            LspWindowLogMessageLoggerProvider.SignalClientReady();
+
+            var logger = _provider.CreateLogger(fullName);
+            logger.LogInformation("msg");
+
+            var sent = await _transport.WaitForOneAsync();
+            Assert.Equal(expectedPrefixedMessage, DeserializeMessage(sent));
+        }
+
+        [Fact]
+        public void CreateLogger_Returns_Same_Instance_For_Same_Category()
+        {
+            var a = _provider.CreateLogger("X.Y");
+            var b = _provider.CreateLogger("X.Y");
+            Assert.Same(a, b);
+        }
+
+        [Fact]
+        public async Task Pump_Continues_After_Transport_SendAsync_Throws()
+        {
+            _transport.ThrowOnNextSend = true;
+            _transport.Activate();
+            LspWindowLogMessageLoggerProvider.SignalClientReady();
+
+            var logger = _provider.CreateLogger("Cat");
+            logger.LogInformation("first");  // will throw inside SendAsync
+            logger.LogInformation("second"); // must still go through
+
+            var sent = await _transport.WaitForOneAsync();
+            Assert.Equal("[Cat] second", DeserializeMessage(sent));
+        }
+
+        [Fact]
+        public void SignalClientReady_Is_Idempotent()
+        {
+            LspWindowLogMessageLoggerProvider.SignalClientReady();
+            // Second call must not throw (TrySetResult).
+            LspWindowLogMessageLoggerProvider.SignalClientReady();
+            Assert.True(LspWindowLogMessageLoggerProvider.ClientReadyTcs.Task.IsCompletedSuccessfully);
+        }
+
+        [Fact]
+        public void IsEnabled_Returns_True_For_All_Levels_Except_None()
+        {
+            var logger = _provider.CreateLogger("Cat");
+            foreach (LogLevel level in Enum.GetValues<LogLevel>())
+            {
+                Assert.Equal(level != LogLevel.None, logger.IsEnabled(level));
+            }
+        }
+
+        private static string DeserializeMessage(LspJsonRpcMessage rpc)
+        {
+            var payload = rpc.Params!.Value.Deserialize<LogMessageParams>(Constants.DefaultSerializationOptions)!;
+            return payload.Message;
+        }
+
+        private static void ResetClientReadyTcs()
+        {
+            var field = typeof(LspWindowLogMessageLoggerProvider).GetField(
+                nameof(LspWindowLogMessageLoggerProvider.ClientReadyTcs),
+                BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public);
+            Assert.NotNull(field);
+            field!.SetValue(null, new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously));
+        }
+
+        private sealed class StubTransport : ILspTransport
+        {
+            private readonly object _gate = new();
+            private TaskCompletionSource<LspJsonRpcMessage> _next = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            private bool _active;
+
+            public ConcurrentQueue<LspJsonRpcMessage> Sent { get; } = new();
+
+            public bool ThrowOnNextSend { get; set; }
+
+            public bool IsActive => _active;
+
+            public void Activate() => _active = true;
+
+            public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+            public Task<BaseJsonRpcMessage> GetNextMessageAsync(CancellationToken cancellationToken)
+            {
+                // Park forever; the provider doesn't read from the transport.
+                var tcs = new TaskCompletionSource<BaseJsonRpcMessage>();
+                cancellationToken.Register(() => tcs.TrySetCanceled(cancellationToken));
+                return tcs.Task;
+            }
+
+            public Task SendAsync<T>(T response, CancellationToken cancellationToken) where T : BaseJsonRpcMessage
+            {
+                if (ThrowOnNextSend)
+                {
+                    ThrowOnNextSend = false;
+                    return Task.FromException(new InvalidOperationException("simulated transport failure"));
+                }
+
+                if (response is LspJsonRpcMessage rpc)
+                {
+                    Sent.Enqueue(rpc);
+                    TaskCompletionSource<LspJsonRpcMessage> toComplete;
+                    lock (_gate)
+                    {
+                        toComplete = _next;
+                        _next = new TaskCompletionSource<LspJsonRpcMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
+                    }
+                    toComplete.TrySetResult(rpc);
+                }
+
+                return Task.CompletedTask;
+            }
+
+            public async Task<LspJsonRpcMessage> WaitForOneAsync(int timeoutMs = 5000)
+            {
+                // If something was sent before the wait was set up, return it immediately.
+                if (Sent.TryPeek(out var existing))
+                {
+                    return existing;
+                }
+
+                Task<LspJsonRpcMessage> wait;
+                lock (_gate)
+                {
+                    wait = _next.Task;
+                }
+
+                using var cts = new CancellationTokenSource(timeoutMs);
+                var completed = await Task.WhenAny(wait, Task.Delay(Timeout.Infinite, cts.Token));
+                if (completed != wait)
+                {
+                    throw new TimeoutException($"No message sent within {timeoutMs}ms.");
+                }
+
+                return await wait;
+            }
+
+            public void Dispose() { }
+        }
+
+        private sealed class StubServiceProvider : IServiceProvider
+        {
+            private readonly ILspTransport _transport;
+            public StubServiceProvider(ILspTransport transport) => _transport = transport;
+            public object? GetService(Type serviceType) =>
+                serviceType == typeof(ILspTransport) ? _transport : null;
+        }
+    }
+
+    [CollectionDefinition(nameof(LspWindowLogMessageCollection), DisableParallelization = true)]
+    public sealed class LspWindowLogMessageCollection { }
+}

--- a/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.Core/LspWindowLogMessageLoggerProviderTests.cs
+++ b/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.Core/LspWindowLogMessageLoggerProviderTests.cs
@@ -125,7 +125,7 @@ namespace Microsoft.PowerPlatformLS.UnitTests.Impl.Core
             var sent = await _transport.WaitForOneAsync();
             Assert.Equal("[Cat] real", DeserializeMessage(sent));
             await Task.Delay(100);
-            Assert.Single(_transport.Sent);
+            Assert.Empty(_transport.Sent);
         }
 
         [Fact]
@@ -284,8 +284,8 @@ namespace Microsoft.PowerPlatformLS.UnitTests.Impl.Core
 
             public async Task<LspJsonRpcMessage> WaitForOneAsync(int timeoutMs = 5000)
             {
-                // If something was sent before the wait was set up, return it immediately.
-                if (Sent.TryPeek(out var existing))
+                // If something was sent before the wait was set up, consume and return it.
+                if (Sent.TryDequeue(out var existing))
                 {
                     return existing;
                 }
@@ -303,6 +303,8 @@ namespace Microsoft.PowerPlatformLS.UnitTests.Impl.Core
                     throw new TimeoutException($"No message sent within {timeoutMs}ms.");
                 }
 
+                // Dequeue to stay consistent with the peek-first path above.
+                Sent.TryDequeue(out _);
                 return await wait;
             }
 

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/extension.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/extension.ts
@@ -40,8 +40,10 @@ export async function activate(context: vscode.ExtensionContext) {
   registerResetAccountCommand(context);
   registerReportIssueCommand(context, sessionId);
 
-  // Create output channel for LSP logs
-  const outputChannel = vscode.window.createOutputChannel("Copilot Studio Language Server");
+  // Create output channel for LSP logs.
+  // Using `createLogOutputChannel` gives each line a timestamp and a color-coded
+  // [error]/[warning]/[info] prefix.
+  const outputChannel = vscode.window.createOutputChannel("Copilot Studio Language Server", { log: true });
   if (isDebugging) {
     outputChannel.show();
   }

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/services/lspClient.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/services/lspClient.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import { spawnSync } from 'child_process';
-import { ServerOptions, TransportKind, LanguageClient, LanguageClientOptions, Trace, State } from "vscode-languageclient/node";
+import { ServerOptions, TransportKind, LanguageClient, LanguageClientOptions, Trace, State, LogMessageNotification } from "vscode-languageclient/node";
 import { TELEMETRY_CONNECTION_STRING, TelemetryEventsKeys } from '../constants';
 import { AccountInfo, AgentSyncInfo, EnvironmentInfo, RemoteApiRequest } from '../types';
 import { getAccessTokenByAccountId, getCopilotStudioAccessTokenByAccountId } from '../clients/account';
@@ -193,6 +193,33 @@ class LspClientService {
       });
     });
 
+    // Route window/logMessage into the LogOutputChannel for native
+    // [error]/[warning]/[info] color + timestamp. The .NET side gates sending on
+    // the client's "initialized" notification (see LspWindowLogMessageLoggerProvider)
+    // so this handler is wired first and takes precedence over vscode-languageclient's
+    // built-in default, which would otherwise prepend a duplicate
+    // "[Error|Warning|Info - h:mm:ss AM/PM]" prefix.
+    const logChannel = outputChannel as Partial<vscode.LogOutputChannel>;
+    const writeLog = (level: 'error' | 'warn' | 'info' | 'trace' | 'debug', message: string) => {
+      const fn = logChannel[level];
+      if (typeof fn === 'function') {
+        fn.call(logChannel, message);
+      } else {
+        outputChannel.appendLine(message);
+      }
+    };
+    this._client.onNotification(LogMessageNotification.type, (params: { type: number; message: string }) => {
+      const message = params?.message ?? '';
+      switch (params?.type) {
+        case 1: writeLog('error', message); break;
+        case 2: writeLog('warn', message); break;
+        case 3: writeLog('info', message); break;
+        case 4: writeLog('trace', message); break;
+        case 5: writeLog('debug', message); break;
+        default: outputChannel.appendLine(message); break;
+      }
+    });
+
     try {
       await vscode.window.withProgress(
         {
@@ -205,6 +232,7 @@ class LspClientService {
         }
       );
       logger.logInfo(TelemetryEventsKeys.LanguageServerInfo, "Copilot Studio Language Server has started");
+
       context.subscriptions.push(this._client);
     } catch (error) {
       logger.logError(TelemetryEventsKeys.LanguageServerError, `Copilot Studio Language Server failed to start: ${(error as Error).message}`);


### PR DESCRIPTION
[Issue #198](https://github.com/microsoft/vscode-copilotstudio/issues/198)

This PR improves LSP output window readability. It Formats LSP logs in the output panel to show timestamps and color-coded severity.
