### PR TITLE
Fix file type properties for Workflow

### DIFF
--- a/src/CopilotStudio.Sync/WorkspaceSynchronizer.cs
+++ b/src/CopilotStudio.Sync/WorkspaceSynchronizer.cs
@@ -3154,12 +3154,24 @@ internal class WorkspaceSynchronizer : IWorkspaceSynchronizer
     {
         DataType type = DataType.String;
 
-        if (propValue.TryGetProperty("type", out var typeNode))
+        var schemaType = propValue.TryGetProperty("type", out var typeNode) ? typeNode.GetString() : null;
+
+        if (schemaType != null)
         {
-            type = MapFlowType(typeNode.GetString() ?? "string");
+            type = MapFlowType(schemaType);
         }
 
-        if (propValue.TryGetProperty("x-ms-content-hint", out var hintNode) && string.Equals(hintNode.GetString(), "FILE", StringComparison.OrdinalIgnoreCase))
+        if (string.Equals(schemaType, "object", StringComparison.OrdinalIgnoreCase) && propValue.TryGetProperty("properties", out var nestedProps) && nestedProps.ValueKind == JsonValueKind.Object)
+        {
+            var fields = new Dictionary<string, PropertyInfo>(StringComparer.OrdinalIgnoreCase);
+            foreach (var nested in nestedProps.EnumerateObject())
+            {
+                fields[nested.Name] = CreatePropertyInfoFromJson(nested.Value, nested.Name);
+            }
+
+            type = fields.Count == 0 ? DataType.EmptyRecord : new RecordDataType(fields.ToImmutableDictionary(StringComparer.OrdinalIgnoreCase));
+        }
+        else if (propValue.TryGetProperty("x-ms-content-hint", out var hintNode) && string.Equals(hintNode.GetString(), "FILE", StringComparison.OrdinalIgnoreCase))
         {
             type = DataType.File;
         }

--- a/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.PullAgent/AgentWriterTests.cs
+++ b/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.PullAgent/AgentWriterTests.cs
@@ -1375,6 +1375,74 @@ beginDialog:
         }
 
         [Fact]
+        public async Task GetWorkflowsAsync_FileInputWithNestedProperties_BuildsRecordType()
+        {
+            using var tempWorkspace = new TempDirectory();
+            var workspaceFolder = new DirectoryPath(tempWorkspace.Path.Replace("\\", "/"));
+            var workflowId = Guid.NewGuid();
+            var agentId = Guid.NewGuid();
+
+            var clientData = @"
+            {
+                ""properties"": {
+                    ""definition"": {
+                        ""triggers"": {
+                            ""manual"": {
+                                ""inputs"": {
+                                    ""schema"": {
+                                        ""properties"": {
+                                            ""file"": {
+                                                ""type"": ""object"",
+                                                ""x-ms-content-hint"": ""FILE"",
+                                                ""title"": ""File Input"",
+                                                ""properties"": {
+                                                    ""name"": { ""type"": ""string"", ""title"": ""File Name"" },
+                                                    ""contentBytes"": { ""type"": ""string"", ""format"": ""byte"", ""title"": ""File Content"" }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        ""actions"": {}
+                    }
+                }
+            }";
+
+            var mockDataverse = new MockDataverseClient();
+            mockDataverse.SetWorkflowsForAgent(new[]
+            {
+                new WorkflowMetadata
+                {
+                    WorkflowId = workflowId,
+                    Name = "FileWorkflow",
+                    ClientData = clientData,
+                    StateCode = 1
+                }
+            });
+
+            var filesystem = new InMemoryFileWriter();
+            var synchronizer = new WorkspaceSynchronizer(
+                new SyncMcsFileParser(Microsoft.CopilotStudio.McsCore.LspProjectorService.Instance),
+                (Microsoft.CopilotStudio.McsCore.IFileAccessorFactory)filesystem,
+                Mock.Of<IIslandControlPlaneService>(),
+                Mock.Of<ISyncProgress>(),
+                new Microsoft.CopilotStudio.McsCore.LspComponentPathResolver());
+
+            var workflows = await synchronizer.GetWorkflowsAsync(workspaceFolder, mockDataverse, new AgentSyncInfo { AgentId = agentId }, filesystem, CancellationToken.None);
+
+            var workflow = Assert.Single(workflows.Workflows);
+
+            Assert.NotNull(workflow.InputType);
+
+            var fileType = workflow.InputType!.Properties["file"].Type;
+            var fileRecord = Assert.IsAssignableFrom<RecordDataType>(fileType);
+            Assert.Equal(DataType.String, fileRecord.GetPropertyType("name"));
+            Assert.Equal(DataType.String, fileRecord.GetPropertyType("contentBytes"));
+        }
+
+        [Fact]
         public async Task GetWorkflowsAsync_OutputType_NestedInScope()
         {
             using var tempWorkspace = new TempDirectory();


### PR DESCRIPTION
Fix file type properties for Workflow.
Fix: https://github.com/microsoft/vscode-copilotstudio/issues/259

This pull request enhances the handling of nested object properties in workflow input schemas, particularly for file inputs, and adds a new unit test to verify this functionality. The main focus is on correctly building record types for nested object properties and ensuring that file-type hints are only applied at the appropriate schema level.

**Improvements to schema parsing and type inference:**

- Improved the `CreatePropertyInfoFromJson` method in `WorkspaceSynchronizer.cs` to recursively build `RecordDataType` instances for nested object properties, ensuring that complex input schemas (such as file inputs with sub-properties) are properly represented. The file-type hint (`x-ms-content-hint: FILE`) is now only applied at the correct schema level, preventing incorrect type assignments for nested properties.

**Testing enhancements:**

- Added a new unit test, `GetWorkflowsAsync_FileInputWithNestedProperties_BuildsRecordType`, in `AgentWriterTests.cs` to verify that workflows with file inputs containing nested properties are correctly parsed into a record type, and that sub-properties (e.g., `name` and `contentBytes`) are assigned the appropriate types.