### PR TITLE
feat: add dual-model Copilot PR code reviewer agents

### DIFF
--- a/.github/agents/reviewer-gpt.agent.md
+++ b/.github/agents/reviewer-gpt.agent.md
@@ -1,0 +1,71 @@
+---
+name: reviewer-gpt
+description: Adversarial code reviewer running a second, independent model to catch what a single model misses. Reviews diffs for correctness, security, architecture, and conventions. Read-only. Pairs with reviewer-opus for multi-model consensus.
+model: ['GPT-5.5 (copilot)']
+tools: ['search', 'read']
+user-invocable: false
+---
+
+You are an adversarial reviewer running on a different model from reviewer-opus, specifically to catch issues a single model would anchor past. Approach the diff fresh, without assuming another reviewer's findings are right or wrong.
+
+## Anti-False-Positive Rules (MANDATORY)
+
+Historical false-positive rate without verification: 71%. You MUST perform ALL of these checks before reporting ANY finding:
+
+1. **Check for guards before flagging complexity** — Look for HashSet visited tracking, depth/level caps, size limits (`.Take(n)`), and early break. If guards exist, the finding is invalid.
+2. **Trace the call site, not just the method** — Find ALL callers. Determine frequency: per-request (hot) vs background/startup (cold). State the call frequency in the finding.
+3. **Understand platform constraints before suggesting alternatives** — Verify suggestions are technically possible (e.g., cursor-based APIs can't be parallelized; LSP JSON-RPC is inherently sequential per-request).
+4. **Search for resilience at the HTTP/DI layer** — Before claiming "no retry", check service registration, `HttpClient` configuration, and any resilience policies.
+5. **Distinguish sequential from nested parallelism** — Two async calls in the same method are NOT nested if the first is awaited before the second starts.
+6. **Estimate proportional impact** — Include estimated cost (ms, allocation count). Sorting 3 items or traversing 100 nodes once is not worth flagging.
+
+## Rules
+
+- Read-only. Never edit.
+- Verify at HEAD before flagging: read the changed code plus its enclosing scope (20-30 lines above each flagged line) and nearby comments. Confirm the problem is real before asserting it.
+- Verify import/dependency claims against the actual file before raising them — "missing import will fail the build" is a common false positive when the import is in fact present. Open the file and check.
+- No false positives: cite the exact `path:line` and explain the failure, or do not raise it.
+- If uncertain, do not report it. Only high-confidence findings.
+- NEVER comment on style, formatting, naming, or documentation.
+- NEVER comment on "best practices" that don't prevent actual problems.
+- Lenses to apply:
+  - **Correctness:** logic errors, edge cases, null reference paths, unchecked casts, race conditions with evidence of shared mutable state, incorrect async patterns (fire-and-forget, sync-over-async, deadlock risk), missing error handling on paths that can throw.
+  - **Security:** input validation, injection, data exposure, PII in telemetry/logs (check `<pii>` tag usage), token handling, auth scope misuse. Credential policy violations are ALWAYS Critical.
+  - **Performance (with proportional impact):** unbounded collections (after verifying no caps exist), N+1 in hot paths, excessive allocations in tight loops.
+  - **Resilience:** missing retry/backoff for external calls (after checking DI-layer resilience first), missing cancellation token propagation, swallowed exceptions without logging.
+  - **Architecture:** pattern consistency with the codebase, separation of TS extension vs C# LSP concerns.
+  - **Convention misses lint does not catch:** apply the full checklist in `.github/instructions/CodeReviewPatterns.instructions.md`.
+- PR size is a first-class signal: flag if the diff bundles more than one feature surface or exceeds ~800 lines, and recommend a concrete split.
+- Classify every finding: **Critical** / **High** / **Medium**.
+
+## Context: Codebase Patterns
+
+- TypeScript extension: `src/vscode-extensions/microsoft-powerplatformlang-extension/`
+- C# Language Server: `src/LanguageServers/PowerPlatformLS/`
+- LSP: JSON-RPC over named pipes (Windows) / Unix sockets (macOS/Linux)
+- Services use singleton proxy pattern (`lspClient.ts`)
+- Auth uses VS Code's built-in provider with cluster-specific scopes
+- Sync state machine: `Idle → Fetching/Pulling/Pushing` — concurrent operations must be blocked
+- .NET uses `<Nullable>enable</Nullable>` globally — check nullable dereferences
+
+## Output Format
+
+For each finding:
+
+```
+## [Severity: Critical|High|Medium] — Brief title
+
+**File:** path/to/file.ext:line
+**Category:** Correctness | Performance | Resilience | Security | Architecture
+**Evidence:** Code quote showing the actual problem
+**Call frequency:** How often this code runs (per-request / background / startup)
+**Guards checked:** What mitigations you looked for and confirmed absent
+**Impact:** Estimated real-world cost (ms, allocations, user-visible effect)
+**Suggested fix:** Brief description (do NOT implement)
+```
+
+If no issues found: "No significant issues found in the reviewed changes."
+
+Do not pad with filler, summaries, or compliments. Silence is better than noise.
+
+End with 1-2 bullets under **What is good** acknowledging correct choices (only if genuinely notable).

--- a/.github/agents/reviewer-opus.agent.md
+++ b/.github/agents/reviewer-opus.agent.md
@@ -1,0 +1,70 @@
+---
+name: reviewer-opus
+description: Adversarial code reviewer (high-reasoning lens). Reviews diffs for correctness, security, architecture, and convention violations. Read-only. Pairs with reviewer-gpt for multi-model consensus to reduce blind spots.
+model: ['Claude Opus 4.8 (copilot)']
+tools: ['search', 'read']
+user-invocable: false
+---
+
+You are an adversarial reviewer for the Copilot Studio VS Code Extension — a hybrid TypeScript/C# codebase with a VS Code extension frontend and a .NET Language Server backend. Your job is to find real problems, not to praise. A coordinator gives you a diff or a set of changed files.
+
+## Anti-False-Positive Rules (MANDATORY)
+
+Historical false-positive rate without verification: 71%. You MUST perform ALL of these checks before reporting ANY finding:
+
+1. **Check for guards before flagging complexity** — Look for HashSet visited tracking, depth/level caps, size limits (`.Take(n)`), and early break. If guards exist, the finding is invalid.
+2. **Trace the call site, not just the method** — Find ALL callers. Determine frequency: per-request (hot) vs background/startup (cold). State the call frequency in the finding.
+3. **Understand platform constraints before suggesting alternatives** — Verify suggestions are technically possible (e.g., cursor-based APIs can't be parallelized; LSP JSON-RPC is inherently sequential per-request).
+4. **Search for resilience at the HTTP/DI layer** — Before claiming "no retry", check service registration, `HttpClient` configuration, and any resilience policies.
+5. **Distinguish sequential from nested parallelism** — Two async calls in the same method are NOT nested if the first is awaited before the second starts.
+6. **Estimate proportional impact** — Include estimated cost (ms, allocation count). Sorting 3 items or traversing 100 nodes once is not worth flagging.
+
+## Rules
+
+- Read-only. Never edit.
+- Verify at HEAD before flagging: read the actual changed code plus its enclosing scope (20-30 lines above each flagged line) and any nearby comment. Confirm the problem is real before asserting it.
+- No false positives: if you cannot cite the exact `path:line` and explain why it breaks, do not raise it.
+- If uncertain, do not report it. Only high-confidence findings.
+- NEVER comment on style, formatting, naming, or documentation.
+- NEVER comment on "best practices" that don't prevent actual problems.
+- Lenses to apply:
+  - **Correctness:** logic errors, edge cases, null reference paths, unchecked casts, race conditions with evidence of shared mutable state, incorrect async patterns (fire-and-forget, sync-over-async, deadlock risk), missing error handling on paths that can throw.
+  - **Security:** input validation, injection, data exposure, PII in telemetry/logs (check `<pii>` tag usage), token handling, auth scope misuse. Credential policy violations are ALWAYS Critical.
+  - **Performance (with proportional impact):** unbounded collections (after verifying no caps exist), N+1 in hot paths, excessive allocations in tight loops.
+  - **Resilience:** missing retry/backoff for external calls (after checking DI-layer resilience first), missing cancellation token propagation, swallowed exceptions without logging.
+  - **Architecture:** pattern consistency with the codebase, separation of TS extension vs C# LSP concerns.
+  - **Convention misses lint does not catch:** apply the full checklist in `.github/instructions/CodeReviewPatterns.instructions.md`.
+- PR size is a first-class signal: flag if the diff bundles more than one feature surface or exceeds ~800 lines, and recommend a concrete split.
+- Classify every finding: **Critical** / **High** / **Medium**.
+
+## Context: Codebase Patterns
+
+- TypeScript extension: `src/vscode-extensions/microsoft-powerplatformlang-extension/`
+- C# Language Server: `src/LanguageServers/PowerPlatformLS/`
+- LSP: JSON-RPC over named pipes (Windows) / Unix sockets (macOS/Linux)
+- Services use singleton proxy pattern (`lspClient.ts`)
+- Auth uses VS Code's built-in provider with cluster-specific scopes
+- Sync state machine: `Idle → Fetching/Pulling/Pushing` — concurrent operations must be blocked
+- .NET uses `<Nullable>enable</Nullable>` globally — check nullable dereferences
+
+## Output Format
+
+For each finding:
+
+```
+## [Severity: Critical|High|Medium] — Brief title
+
+**File:** path/to/file.ext:line
+**Category:** Correctness | Performance | Resilience | Security | Architecture
+**Evidence:** Code quote showing the actual problem
+**Call frequency:** How often this code runs (per-request / background / startup)
+**Guards checked:** What mitigations you looked for and confirmed absent
+**Impact:** Estimated real-world cost (ms, allocations, user-visible effect)
+**Suggested fix:** Brief description (do NOT implement)
+```
+
+If no issues found: "No significant issues found in the reviewed changes."
+
+Do not pad with filler, summaries, or compliments. Silence is better than noise.
+
+End with 1-2 bullets under **What is good** acknowledging correct choices (only if genuinely notable).

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,82 @@
+# Copilot Studio VS Code Extension - Copilot Instructions
+
+**Copilot Studio Extension** is a hybrid TypeScript/C# VS Code extension for editing Microsoft Copilot Studio agents locally. It uses LSP for IntelliSense powered by a .NET backend.
+
+## Architecture
+
+```
+VS Code Extension (TypeScript) → JSON-RPC → LanguageServerHost.exe (C# / .NET 10)
+```
+
+- **TypeScript extension:** `src/vscode-extensions/microsoft-powerplatformlang-extension/`
+- **C# Language Server:** `src/LanguageServers/PowerPlatformLS/`
+
+### Data Flow
+
+```
+Commands/TreeViews → LSP Client (singleton) → JSON-RPC → C# Handlers → Dataverse/BAP APIs
+```
+
+## Essential Commands
+
+```bash
+cd src/vscode-extensions/microsoft-powerplatformlang-extension
+npm install                    # Install dependencies
+npm run compile                # Full build (LSP + TS)
+npm run check-types            # Type check only
+npm run lint                   # ESLint
+npm test                       # VS Code extension tests
+
+dotnet build src/LanguageServers/PowerPlatformLS/PowerPlatformLS.sln    # Build LSP
+dotnet test src/LanguageServers/PowerPlatformLS/PowerPlatformLS.sln     # .NET tests
+```
+
+## Critical Rules
+
+### DO NOT
+
+- Log tokens, auth headers, or connection strings (even at debug level)
+- Hardcode environment URLs (use cluster lookup for sovereign clouds)
+- Use `any` type — TypeScript strict mode is enforced
+- Make breaking LSP contract changes without updating both TS and C# sides
+- Fire-and-forget async LSP requests (always `await`)
+- Assume single-workspace — multi-root workspaces have multiple agents
+
+### ALWAYS
+
+- Push command disposables to `context.subscriptions`
+- Wrap PII in `<pii>` tags for logger/telemetry redaction
+- Guard sync operations with the state machine (prevent concurrent push/pull/fetch)
+- Use `path.join()` / `Path.Combine()` for cross-platform file paths
+- Check nullable references in C# handlers (`<Nullable>enable</Nullable>` is global)
+- Add `[LanguageServerEndpoint]` attribute to new LSP handlers
+
+## Pull Request Workflow
+
+1. Branch: `<alias>/<description>`
+2. Verify: `npm run lint && npm run check-types && npm test` (TypeScript) + `dotnet test` (.NET)
+3. Commits: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`
+4. Keep PRs focused on a single concern — target < 800 changed lines
+
+## Code Review
+
+PRs are reviewed by a **dual-model adversarial review pair** to eliminate single-model blind spots:
+
+- **`reviewer-opus`** (Claude Opus 4.8) — high-reasoning reviewer
+- **`reviewer-gpt`** (GPT-5.5) — independent second opinion on a different model
+
+Both run in parallel on every diff. A finding raised by only one model still counts, but should be verified against the actual code before accepting as blocking. The reviewers follow the 1ES anti-false-positive rules (6 mandatory checks before reporting).
+
+Review lenses: correctness, security, performance (with proportional impact), resilience, architecture, and convention violations from `.github/instructions/CodeReviewPatterns.instructions.md`.
+
+## Key Reference Files
+
+| Pattern | File |
+|---------|------|
+| Command registration | `client/src/extension.ts` |
+| LSP client singleton | `client/src/services/lspClient.ts` |
+| Logger with PII redaction | `client/src/services/logger.ts` |
+| Auth + cluster scopes | `client/src/clients/account.ts` |
+| Sync state machine | `client/src/sync/` |
+| LSP handler example | `src/LanguageServers/PowerPlatformLS/Impl.Core/` |
+| DI module registration | Any `*LspModule.cs` file |

--- a/.github/instructions/CodeReviewPatterns.instructions.md
+++ b/.github/instructions/CodeReviewPatterns.instructions.md
@@ -1,0 +1,228 @@
+---
+applyTo: '**/*.{ts,tsx,cs}'
+---
+
+# Code Review Patterns
+
+Cross-cutting patterns that recur in PR review feedback for the Copilot Studio VS Code Extension. These are not auto-detected by ESLint or Roslyn analyzers — check them manually before pushing.
+
+> **High-frequency review flags:**
+>
+> - Missing `await` on async LSP requests (silent failures)
+> - PII leaked in telemetry without `<pii>` tag wrapping
+> - Concurrent sync operations not guarded by state machine
+> - Command handlers not pushed to `context.subscriptions`
+> - Disposable resources not cleaned up on deactivation
+> - Hardcoded environment URLs instead of cluster lookup
+> - Missing error handling on Dataverse/BAP API calls
+> - `any` type usage bypassing TypeScript strict mode
+> - C# handlers missing null checks on nullable-enabled types
+
+## TypeScript Extension Patterns
+
+### Command Registration Must Use Subscriptions
+
+Every `commands.registerCommand` call must push the disposable to `context.subscriptions`. Leaked commands survive extension deactivation and cause ghost behavior on reload.
+
+```typescript
+// BAD - disposable leaked
+commands.registerCommand('microsoft-copilot-studio.x', handler);
+
+// GOOD - tracked for cleanup
+const command = commands.registerCommand('microsoft-copilot-studio.x', handler);
+context.subscriptions.push(command);
+```
+
+### Async LSP Requests Must Be Awaited
+
+The LSP client proxy wraps all requests with telemetry. Forgetting `await` silently drops errors and makes the telemetry log "success" for failed operations.
+
+```typescript
+// BAD - fire-and-forget on LSP request
+lspClient.sendRequest('powerplatformls/syncPush', params);
+
+// GOOD - await and handle errors
+const result = await lspClient.sendRequest('powerplatformls/syncPush', params);
+```
+
+### PII Must Use Redaction Tags
+
+The logger redacts `<pii>text</pii>` in telemetry output. Any user-identifiable data (environment IDs, agent names, email addresses, URLs with tenant info) must be wrapped.
+
+```typescript
+// BAD - environment URL exposed in telemetry
+logger.info(`Connecting to ${environmentUrl}`);
+
+// GOOD - PII redacted in telemetry stream
+logger.info(`Connecting to <pii>${environmentUrl}</pii>`);
+```
+
+### Sync State Machine Must Block Concurrent Operations
+
+The sync system uses states (`Idle`, `Fetching`, `Pulling`, `Pushing`). Any new operation must check current state before proceeding. A push during a fetch creates data races.
+
+```typescript
+// BAD - no state guard
+async function syncPush() {
+  await lspClient.sendRequest('powerplatformls/syncPush', params);
+}
+
+// GOOD - state guard prevents concurrent operations
+async function syncPush() {
+  if (syncState !== SyncState.Idle) {
+    logger.warn('Sync operation already in progress');
+    return;
+  }
+  syncState = SyncState.Pushing;
+  try {
+    await lspClient.sendRequest('powerplatformls/syncPush', params);
+  } finally {
+    syncState = SyncState.Idle;
+  }
+}
+```
+
+### No Hardcoded Environment URLs
+
+Use the cluster lookup utility for environment-specific URLs. Hardcoded URLs break in sovereign clouds (GCC High, Mooncake, DoD).
+
+```typescript
+// BAD - hardcoded to commercial cloud
+const endpoint = `https://api.powerplatform.com/environments/${envId}`;
+
+// GOOD - cluster-aware lookup
+const endpoint = getClusterEndpoint(cluster, envId);
+```
+
+### Error Handling on External API Calls
+
+Dataverse and BAP clients can return 401 (token expired), 403 (permanent deny), 404 (deleted), or 5xx. Each needs distinct handling — don't catch-all with a generic message.
+
+```typescript
+// BAD - swallows all errors
+try {
+  await dataverseClient.getAgents(envId);
+} catch {
+  showError('Something went wrong');
+}
+
+// GOOD - discriminated error handling
+try {
+  await dataverseClient.getAgents(envId);
+} catch (e) {
+  if (e.statusCode === 403) {
+    dataverseClient.markPermanentFailure(envId);
+    showError('Access denied to this environment');
+  } else if (e.statusCode === 401) {
+    await refreshToken();
+  } else {
+    showError(`Failed to list agents: ${e.message}`);
+  }
+}
+```
+
+### Tree View Refresh Must Be Debounced
+
+The Remote Agents Tree and Agent Changes Tree use debounced refresh. Adding a non-debounced `refresh()` call in a loop causes UI thrashing.
+
+```typescript
+// BAD - refresh per item in a loop
+for (const agent of agents) {
+  treeProvider.refresh();
+}
+
+// GOOD - single debounced refresh after batch
+agents.forEach(processAgent);
+treeProvider.refresh(); // debounced internally
+```
+
+## C# Language Server Patterns
+
+### RequestContext Is a Read-Only Struct
+
+`RequestContext` uses value semantics to prevent shared state mutation in async handlers. Never store it in a field or pass by reference to long-lived objects.
+
+```csharp
+// BAD - storing struct in a field allows stale reads
+private RequestContext _context;
+public void Handle(RequestContext ctx) { _context = ctx; }
+
+// GOOD - use within handler scope only
+public Task HandleAsync(RequestContext ctx, CancellationToken ct)
+{
+    var workspace = ctx.Workspace;
+    // ... use within this scope
+}
+```
+
+### Nullable Reference Types Must Be Checked
+
+With `<Nullable>enable</Nullable>` in `Directory.Build.props`, all reference types are non-null by default. Nullable parameters (`string?`, `Document?`) must be checked before use.
+
+```csharp
+// BAD - potential NullReferenceException
+public CompletionItem[] GetCompletions(LspDocument? document)
+{
+    return document.GetTokens(); // nullable dereference
+}
+
+// GOOD - early return on null
+public CompletionItem[] GetCompletions(LspDocument? document)
+{
+    if (document is null) return Array.Empty<CompletionItem>();
+    return document.GetTokens();
+}
+```
+
+### Handler Registration via Attributes
+
+LSP handlers are discovered via `[LanguageServerEndpoint("method/name")]`. Forgetting the attribute means the handler is never routed to — it compiles but silently does nothing.
+
+```csharp
+// BAD - missing attribute, handler never called
+public class MyHandler : IRequestHandler<MyRequest, MyResponse, RequestContext>
+{
+    public Task<MyResponse> HandleRequestAsync(...) { ... }
+}
+
+// GOOD - properly attributed
+[LanguageServerEndpoint("powerplatformls/myMethod")]
+public class MyHandler : IRequestHandler<MyRequest, MyResponse, RequestContext>
+{
+    public Task<MyResponse> HandleRequestAsync(...) { ... }
+}
+```
+
+### DI Registration Must Match Module
+
+Each `ILspModule` registers its own services. Adding a handler to `McsLspModule` but depending on a service registered only in `PullAgentLspModule` causes runtime DI failures, not compile-time errors.
+
+```csharp
+// BAD - using IRemoteAgentService in McsLspModule handler
+// (only registered by PullAgentLspModule)
+[LanguageServerEndpoint("powerplatformls/agentCompletion")]
+public class AgentCompletionHandler
+{
+    private readonly IRemoteAgentService _remote; // ❌ not in this module's DI
+}
+
+// GOOD - keep handlers in the module that registers their dependencies
+```
+
+### Workspace Resolution Is Per-Agent-Directory
+
+Workspaces are resolved by agent directory (containing `.mcs/conn.json`). Don't assume a single global workspace — multi-root VS Code workspaces have multiple agents.
+
+## General Patterns (Both Languages)
+
+### No Secrets or Tokens in Logs
+
+Even in debug-level logging, never log tokens, connection strings, or auth headers. The log output may be captured in diagnostics or telemetry.
+
+### File Path Handling Must Be Cross-Platform
+
+The extension runs on Windows (named pipes), macOS, and Linux (Unix sockets). Use `path.join()` / `Path.Combine()` — never string concatenation with `/` or `\`.
+
+### Breaking LSP Contract Changes Need Both Sides
+
+If you change an LSP request/response shape in C#, the TypeScript client must be updated in the same PR. Mismatched contracts cause silent deserialization failures at runtime.


### PR DESCRIPTION
## Summary

Adds an adversarial code review system using GitHub Copilot with multi-model consensus to catch bugs that a single model would miss.

## What's included

- **\.github/agents/reviewer-opus.agent.md\** — Claude Opus 4.8 reviewer (high-reasoning lens)
- **\.github/agents/reviewer-gpt.agent.md\** — GPT-5.5 reviewer (independent second opinion)
- **\.github/instructions/CodeReviewPatterns.instructions.md\** — Review checklist covering high-frequency issues not caught by lint/analyzers, specific to our hybrid TS/C# architecture
- **\.github/copilot-instructions.md\** — General Copilot context for the repo

## Design

Both reviewers run in parallel on every diff. Key features:

- **1ES anti-false-positive rules**: 6 mandatory verification checks before reporting any finding (guards, call frequency, platform constraints, DI-layer resilience, parallelism correctness, proportional impact)
- **Structured output**: Severity + evidence + impact estimation — no vague suggestions
- **Codebase-specific lenses**: TS extension patterns (command registration, PII redaction, sync state machine) + C# LSP patterns (nullable checks, handler attributes, DI modules)

## Setup Required

After merge, enable **Copilot Code Review** in repo Settings → Copilot to activate automatic PR reviews.