### PR TITLE
Dev/stevesteiner/fix sync seam vscode pr ready

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -308,6 +308,8 @@ Common Language Server Protocol Framework providing core abstractions:
 | `CopilotStudio.Sync` | Reusable sync implementation for clone, pull, push, diffing, Dataverse access, and workspace projection |
 | `CopilotStudio.Sync.UnitTests` / `CopilotStudio.Sync.E2ETests` / `CopilotStudio.Sync.TestHarness` | Tests and harnesses for the shared sync library |
 
+**Authoring projection ownership:** ObjectModel owns agent primitives and their default file projection. `CopilotStudio.Sync` / `CopilotStudio.McsCore` owns VS Code and agent-specific projection behavior, including CliCopilot authoring-layout paths. Public Sync seams should expose that existing projection narrowly for consumers such as PAC; do not redesign projection or move PAC-owned Dataverse solution package emission into Sync.
+
 **Language Routing:**
 ```
 Request → LspUriFactory.FromJsonElement() → FileLspUri

--- a/src/CopilotStudio.Sync.UnitTests/CliAgentRoundTripReadTests.cs
+++ b/src/CopilotStudio.Sync.UnitTests/CliAgentRoundTripReadTests.cs
@@ -47,6 +47,44 @@ public class CliAgentRoundTripReadTests
     // --- Component-identity round-trip (no spurious deletes) ------------------------
 
     [Fact]
+    public async Task ReadWorkspaceDefinition_CachelessCliSettings_ReturnsBareDefinition()
+    {
+        var (synchronizer, factory, _) = ComponentWriterDefensiveTests.CreateSyncInfrastructure();
+        var workspace = new DirectoryPath($"c:/test/cacheless-cli-read-{Guid.NewGuid():N}/");
+        var accessor = (InMemoryFileAccessor)factory.Create(workspace);
+
+        await accessor.WriteAsync(new AgentFilePath(AgentClassifier.WorkspaceLayoutMarkerFileName),
+            "layoutVersion: 1\n",
+            CancellationToken.None);
+        await accessor.WriteAsync(new AgentFilePath("settings.mcs.yml"),
+            """
+            displayName: Cacheless CLI
+            schemaName: test_CachelessCli
+            configuration:
+              recognizer:
+                kind: CLICopilotRecognizer
+              agentSettings:
+                model:
+                  series: Sonnet46
+                instructions:
+                  segments:
+                    - kind: StaticSegment
+                      value: Cacheless instructions.
+            template: cliagent-1.0.0
+            language: 1033
+            """,
+            CancellationToken.None);
+
+        var read = await synchronizer.ReadWorkspaceDefinitionAsync(workspace, CancellationToken.None, checkKnowledgeFiles: true);
+
+        var bot = Assert.IsType<BotDefinition>(read);
+        Assert.Equal("Cacheless CLI", bot.Entity!.DisplayName);
+        Assert.Equal("test_CachelessCli", bot.Entity.SchemaName.Value);
+        Assert.NotNull(bot.Entity.Configuration?.AgentSettings);
+        Assert.Empty(bot.Components);
+    }
+
+    [Fact]
     public async Task RoundTrip_CliAgent_FoodLogger_AllComponentsSurvivePull()
     {
         // The primary Node E "Done when" criterion: a CLI workspace pulled

--- a/src/CopilotStudio.Sync.UnitTests/CliCopilotProjectionTests.cs
+++ b/src/CopilotStudio.Sync.UnitTests/CliCopilotProjectionTests.cs
@@ -1,0 +1,83 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+
+using Microsoft.Agents.ObjectModel;
+using Microsoft.Agents.ObjectModel.FileProjection;
+using Microsoft.CopilotStudio.McsCore;
+using Xunit;
+
+namespace Microsoft.CopilotStudio.Sync.UnitTests;
+
+public class CliCopilotProjectionTests
+{
+    private static readonly LspComponentPathResolver InternalResolver = new();
+
+    [Fact]
+    public void AuthoredComponentBodyFolders_AreDerivedFromCliProjectionRules()
+    {
+        var expected = LspProjection.CliRules.Values
+            .Select(r => r.Folder.TrimEnd('/'))
+            .Where(f => f.Length > 0)
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(f => f, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal(expected, CliCopilotProjection.AuthoredComponentBodyFolders);
+        Assert.Contains("behaviors", CliCopilotProjection.AuthoredComponentBodyFolders);
+        Assert.Contains("capabilities/tools", CliCopilotProjection.AuthoredComponentBodyFolders);
+        Assert.Contains("capabilities/knowledge", CliCopilotProjection.AuthoredComponentBodyFolders);
+        Assert.Contains("capabilities/knowledge/files", CliCopilotProjection.AuthoredComponentBodyFolders);
+    }
+
+    [Fact]
+    public async Task ComponentProjection_ToolsSkillsKnowledgeAndConnectedAgents_MatchInternalCliResolver()
+    {
+        var (_, definition, _, _, _) = await CliAgentRoundTripReadTests.PushFixtureAsClone("FoodLogger");
+
+        var tool = definition.Components.OfType<DialogComponent>()
+            .First(c => c.Dialog is ConnectorTool or WorkflowTool or McpTool);
+        var skill = definition.Components.OfType<DialogComponent>()
+            .Single(c => c.Dialog is InlineAgentSkill);
+        var knowledge = definition.Components.OfType<KnowledgeSourceComponent>().First();
+        var connectedAgentTool = definition.Components.OfType<DialogComponent>()
+            .Single(c => c.Dialog is ConnectedAgentTool);
+
+        AssertProjectionMatchesInternalResolver(tool, definition, "capabilities/tools/");
+        AssertProjectionMatchesInternalResolver(skill, definition, "behaviors/");
+        AssertProjectionMatchesInternalResolver(knowledge, definition, "capabilities/knowledge/");
+        AssertProjectionMatchesInternalResolver(connectedAgentTool, definition, "capabilities/tools/");
+    }
+
+    [Fact]
+    public async Task ComponentProjection_FileAttachments_ReturnBodyAndPayloadPathsFromInternalCliResolver()
+    {
+        var (_, definition, _, _, _) = await CliAgentRoundTripReadTests.PushFixtureAsClone("FoodLogger");
+        var fileAttachment = definition.Components.OfType<FileAttachmentComponent>().Single();
+
+        var projection = AssertProjectionMatchesInternalResolver(
+            fileAttachment,
+            definition,
+            "capabilities/knowledge/files/");
+
+        Assert.Equal("capabilities/knowledge/files", projection.PayloadFolder);
+        Assert.Equal(
+            $"capabilities/knowledge/files/{fileAttachment.DisplayName}",
+            projection.PayloadPath);
+    }
+
+    private static CliCopilotComponentProjection AssertProjectionMatchesInternalResolver(
+        BotComponentBase component,
+        DefinitionBase definition,
+        string expectedPathPrefix)
+    {
+        var projection = CliCopilotProjection.GetComponentProjection(component, definition);
+        var expectedPath = InternalResolver.GetComponentPath(component, definition, AuthoringShape.CliCopilot);
+
+        Assert.Equal(expectedPath, projection.BodyPath);
+        Assert.Equal(
+            new AgentFilePath(expectedPath).ParentDirectoryName.TrimEnd('/', '\\'),
+            projection.BodyFolder);
+        Assert.StartsWith(expectedPathPrefix, projection.BodyPath, StringComparison.Ordinal);
+
+        return projection;
+    }
+}

--- a/src/CopilotStudio.Sync.UnitTests/CliCopilotProjectionTests.cs
+++ b/src/CopilotStudio.Sync.UnitTests/CliCopilotProjectionTests.cs
@@ -64,6 +64,19 @@ public class CliCopilotProjectionTests
             projection.PayloadPath);
     }
 
+    [Fact]
+    public async Task ComponentProjection_FileAttachmentPayloadPath_UsesFileNameOnly()
+    {
+        var (_, definition, _, _, _) = await CliAgentRoundTripReadTests.PushFixtureAsClone("FoodLogger");
+        var fileAttachment = definition.Components.OfType<FileAttachmentComponent>().Single();
+        var unsafeFileAttachment = fileAttachment.WithDisplayName(@"..\nested/Unsafe.csv");
+
+        var projection = CliCopilotProjection.GetComponentProjection(unsafeFileAttachment, definition);
+
+        Assert.Equal("capabilities/knowledge/files", projection.PayloadFolder);
+        Assert.Equal("capabilities/knowledge/files/Unsafe.csv", projection.PayloadPath);
+    }
+
     private static CliCopilotComponentProjection AssertProjectionMatchesInternalResolver(
         BotComponentBase component,
         DefinitionBase definition,

--- a/src/CopilotStudio.Sync/CliCopilotComponentProjection.cs
+++ b/src/CopilotStudio.Sync/CliCopilotComponentProjection.cs
@@ -1,0 +1,17 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+
+namespace Microsoft.CopilotStudio.Sync;
+
+/// <summary>
+/// Authored CliCopilot workspace paths for a component.
+/// </summary>
+public sealed record CliCopilotComponentProjection
+{
+    public string BodyPath { get; init; } = string.Empty;
+
+    public string BodyFolder { get; init; } = string.Empty;
+
+    public string? PayloadPath { get; init; }
+
+    public string? PayloadFolder { get; init; }
+}

--- a/src/CopilotStudio.Sync/CliCopilotProjection.cs
+++ b/src/CopilotStudio.Sync/CliCopilotProjection.cs
@@ -1,0 +1,80 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+
+using Microsoft.Agents.ObjectModel;
+using Microsoft.Agents.ObjectModel.FileProjection;
+using Microsoft.CopilotStudio.McsCore;
+
+namespace Microsoft.CopilotStudio.Sync;
+
+/// <summary>
+/// Public CliCopilot projection seam for consumers that need authored workspace paths.
+/// </summary>
+public static class CliCopilotProjection
+{
+    private static readonly LspComponentPathResolver PathResolver = new();
+
+    /// <summary>
+    /// Folders that contain authored CliCopilot component bodies.
+    /// </summary>
+    public static IReadOnlyList<string> AuthoredComponentBodyFolders { get; } = Array.AsReadOnly(
+        LspProjection.CliRules.Values
+            .Select(r => r.Folder.TrimEnd('/'))
+            .Where(f => f.Length > 0)
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(f => f, StringComparer.Ordinal)
+            .ToArray());
+
+    /// <summary>
+    /// Gets the authored CliCopilot body path and, for file attachments, payload path.
+    /// </summary>
+    /// <param name="component">Component to project.</param>
+    /// <param name="definition">Definition that provides bot name and parent-agent context.</param>
+    public static CliCopilotComponentProjection GetComponentProjection(BotComponentBase component, DefinitionBase definition)
+    {
+        if (component == null)
+        {
+            throw new ArgumentNullException(nameof(component));
+        }
+
+        if (definition == null)
+        {
+            throw new ArgumentNullException(nameof(definition));
+        }
+
+        var bodyPath = new AgentFilePath(PathResolver.GetComponentPath(component, definition, AuthoringShape.CliCopilot));
+        var bodyFolder = NormalizeFolder(bodyPath.ParentDirectoryName);
+        var projection = new CliCopilotComponentProjection
+        {
+            BodyPath = bodyPath.ToString(),
+            BodyFolder = bodyFolder,
+        };
+
+        if (component is FileAttachmentComponent fileAttachment)
+        {
+            var payloadFileName = fileAttachment.DisplayName;
+            if (!string.IsNullOrEmpty(payloadFileName))
+            {
+                projection = projection with
+                {
+                    PayloadFolder = bodyFolder,
+                    PayloadPath = CombineRelativePath(bodyFolder, payloadFileName!),
+                };
+            }
+        }
+
+        return projection;
+    }
+
+    private static string CombineRelativePath(string folder, string fileName)
+    {
+        if (string.IsNullOrEmpty(folder))
+        {
+            return fileName;
+        }
+
+        return folder + "/" + fileName;
+    }
+
+    private static string NormalizeFolder(string folder)
+        => folder.TrimEnd('/', '\\');
+}

--- a/src/CopilotStudio.Sync/CliCopilotProjection.cs
+++ b/src/CopilotStudio.Sync/CliCopilotProjection.cs
@@ -51,13 +51,13 @@ public static class CliCopilotProjection
 
         if (component is FileAttachmentComponent fileAttachment)
         {
-            var payloadFileName = fileAttachment.DisplayName;
+            var payloadFileName = GetFileNameOnly(fileAttachment.DisplayName);
             if (!string.IsNullOrEmpty(payloadFileName))
             {
                 projection = projection with
                 {
                     PayloadFolder = bodyFolder,
-                    PayloadPath = CombineRelativePath(bodyFolder, payloadFileName!),
+                    PayloadPath = CombineRelativePath(bodyFolder, payloadFileName),
                 };
             }
         }
@@ -77,4 +77,14 @@ public static class CliCopilotProjection
 
     private static string NormalizeFolder(string folder)
         => folder.TrimEnd('/', '\\');
+
+    private static string GetFileNameOnly(string? fileName)
+    {
+        if (string.IsNullOrEmpty(fileName))
+        {
+            return string.Empty;
+        }
+
+        return Path.GetFileName(fileName.Replace('\\', '/')) ?? string.Empty;
+    }
 }

--- a/src/CopilotStudio.Sync/WorkspaceSynchronizer.cs
+++ b/src/CopilotStudio.Sync/WorkspaceSynchronizer.cs
@@ -3238,7 +3238,7 @@ internal class WorkspaceSynchronizer : IWorkspaceSynchronizer
             if (fileAccessor.Exists(AgentSyncMarkerPath))
             {
                 throw new InvalidOperationException(
-                    "CLI settings.mcs.yml could not be read from a cacheless workspace.",
+                    $"CLI settings.mcs.yml could not be read from a cacheless workspace: {ex.Message}.",
                     ex);
             }
 
@@ -3255,7 +3255,7 @@ internal class WorkspaceSynchronizer : IWorkspaceSynchronizer
             if (fileAccessor.Exists(AgentSyncMarkerPath))
             {
                 throw new InvalidOperationException(
-                    "CLI settings.mcs.yml is malformed in a cacheless workspace.",
+                    $"CLI settings.mcs.yml is malformed in a cacheless workspace: {ex.Message}.",
                     ex);
             }
 

--- a/src/CopilotStudio.Sync/WorkspaceSynchronizer.cs
+++ b/src/CopilotStudio.Sync/WorkspaceSynchronizer.cs
@@ -2980,10 +2980,14 @@ internal class WorkspaceSynchronizer : IWorkspaceSynchronizer
     public async Task<DefinitionBase> ReadWorkspaceDefinitionAsync(DirectoryPath workspaceFolder, CancellationToken cancellationToken, bool checkKnowledgeFiles = false)
     {
         var fileAccessor = _fileAccessorFactory.Create(workspaceFolder);
-        var definition = ReadCloudCacheSnapshot(fileAccessor);
+        var definition = ReadCloudCacheSnapshot(fileAccessor, allowMissing: true);
         if (definition == null)
         {
-            throw new FileNotFoundException(".mcs/botdefinition.json was not found. Please resync.");
+            definition = ReadCachelessCliDefinitionOrNull(fileAccessor);
+            if (definition == null)
+            {
+                throw new FileNotFoundException(".mcs/botdefinition.json was not found. Please resync.");
+            }
         }
 
         // CliAgentSyncSupport / Node E: compute kind ONCE per read so every
@@ -3213,6 +3217,57 @@ internal class WorkspaceSynchronizer : IWorkspaceSynchronizer
             .WithComponents(updatedComponents)
             .WithEnvironmentVariables(updatedEnvVars)
             .WithConnectionReferences(updatedConnectionRefs);
+    }
+
+    private static DefinitionBase? ReadCachelessCliDefinitionOrNull(IFileAccessor fileAccessor)
+    {
+        if (!fileAccessor.Exists(SettingsPath))
+        {
+            return null;
+        }
+
+        string yaml;
+        try
+        {
+            using var stream = fileAccessor.OpenRead(SettingsPath);
+            using var reader = new StreamReader(stream, Encoding.UTF8);
+            yaml = reader.ReadToEnd();
+        }
+        catch (Exception ex)
+        {
+            if (fileAccessor.Exists(AgentSyncMarkerPath))
+            {
+                throw new InvalidOperationException(
+                    "CLI settings.mcs.yml could not be read from a cacheless workspace.",
+                    ex);
+            }
+
+            return null;
+        }
+
+        BotEntity? entity;
+        try
+        {
+            entity = CodeSerializer.Deserialize<BotEntity>(yaml);
+        }
+        catch (Exception ex)
+        {
+            if (fileAccessor.Exists(AgentSyncMarkerPath))
+            {
+                throw new InvalidOperationException(
+                    "CLI settings.mcs.yml is malformed in a cacheless workspace.",
+                    ex);
+            }
+
+            return null;
+        }
+
+        if (entity != null && AgentClassifier.DetectAuthoringShape(entity) == AuthoringShape.CliCopilot)
+        {
+            return new BotDefinition(entity: entity);
+        }
+
+        return null;
     }
 
     /// <summary>


### PR DESCRIPTION
This updates Sync to support cacheless CliCopilot workspaces created by local scaffold flows such as PAC copilot init --authoring-mode cli-copilot.

Previously, ReadWorkspaceDefinitionAsync always required .mcs\botdefinition.json, which blocked cacheless CliCopilot packing even when settings.mcs.yml clearly identified a valid CliCopilot layout.

Changes:

 - Allow ReadWorkspaceDefinitionAsync to reconstruct a bare BotDefinition from settings.mcs.yml when: - .mcs\botdefinition.json is absent
 - the workspace deserializes as a BotEntity
 - AgentClassifier identifies it as CliCopilot
 - Preserve the existing missing-cache failure for classic or unknown workspaces.
 - Add unit coverage for cacheless CliCopilot settings reads.

Validation:

 - dotnet test .\src\CopilotStudio.Sync.UnitTests\CopilotStudio.Sync.UnitTests.csproj --no-restore --configuration Debug --filter "FullyQualifiedName~CliAgentRoundTripReadTests.ReadWorkspaceDefinition_CachelessCliSettings_ReturnsBareDefinition" --verbosity minimal
 - dotnet pack .\src\CopilotStudio.Sync\CopilotStudio.Sync.csproj --no-restore --configuration Debug --verbosity minimal

Downstream validation with PAC:

 - Local pac copilot pack succeeded for a cacheless init --authoring-mode cli-copilot workspace.
 - PAC Dev E2E passed all 3 scenarios, including CliCopilot push/pull round-trip.