### PR TITLE
Auto create connections for reattach/push via connection creation page

### DIFF
--- a/src/CopilotStudio.Sync.TestHarness/Program.cs
+++ b/src/CopilotStudio.Sync.TestHarness/Program.cs
@@ -1,7 +1,7 @@
 // Copyright (C) Microsoft Corporation. All rights reserved.
 
 using Microsoft.CopilotStudio.McsCore;
-    using Microsoft.CopilotStudio.Sync;
+using Microsoft.CopilotStudio.Sync;
 using Microsoft.CopilotStudio.Sync.Dataverse;
 using Microsoft.CopilotStudio.Sync.TestHarness;
 using Microsoft.Extensions.DependencyInjection;
@@ -179,13 +179,6 @@ pushCommand.SetHandler(async (string workspace) =>
             syncInfo, cloudFlowMetadata, CancellationToken.None);
 
         Console.WriteLine($"Push complete. {localChanges.Length} change(s) pushed, {uploadedFiles.UploadedKnowledgeFileCount} file(s) uploaded.");
-        if (uploadedFiles.NewlyCreatedCustomConnectors.Count > 0)
-        {
-            foreach (var connectorName in uploadedFiles.NewlyCreatedCustomConnectors)
-            {
-                Console.WriteLine($"New custom connector created in Dataverse: {connectorName}");
-            }
-        }
 
         Console.WriteLine("Verifying push...");
         var verification = await synchronizer.VerifyPushAsync(

--- a/src/CopilotStudio.Sync.UnitTests/AgentConnectionReferencesTests.cs
+++ b/src/CopilotStudio.Sync.UnitTests/AgentConnectionReferencesTests.cs
@@ -1,0 +1,180 @@
+using Microsoft.Agents.ObjectModel;
+using Microsoft.CopilotStudio.Sync.Dataverse;
+using Moq;
+using Xunit;
+
+namespace Microsoft.CopilotStudio.Sync.UnitTests;
+
+public class AgentConnectionReferencesTests
+{
+    private static ConnectionReference MakeConnectionRef(string logicalName, string connectorId) =>
+        new ConnectionReference.Builder
+        {
+            ConnectionReferenceLogicalName = logicalName,
+            ConnectorId = connectorId,
+        }.Build();
+
+    [Fact]
+    public async Task GetAgentConnectionReferencesAsync_NoConnectionReferences_ReturnsEmpty()
+    {
+        var (synchronizer, _, _) = ComponentWriterDefensiveTests.CreateSyncInfrastructure();
+        var dataverse = new Mock<ISyncDataverseClient>();
+
+        var result = await synchronizer.GetAgentConnectionReferencesAsync(
+            new BotDefinition(), dataverse.Object, CancellationToken.None);
+
+        Assert.Empty(result);
+        dataverse.Verify(
+            c => c.GetConnectionReferencesByLogicalNamesAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task GetAgentConnectionReferencesAsync_AnnotatesBoundConnectionAndDeduplicates()
+    {
+        var (synchronizer, _, _) = ComponentWriterDefensiveTests.CreateSyncInfrastructure();
+        var refs = new List<ConnectionReference>
+        {
+            MakeConnectionRef("cr_bound", "/providers/Microsoft.PowerApps/apis/shared_office365"),
+            MakeConnectionRef("cr_unbound", "/providers/Microsoft.PowerApps/apis/shared_sharepointonline"),
+            MakeConnectionRef("cr_bound", "/providers/Microsoft.PowerApps/apis/shared_office365"),
+        };
+        var definition = new BotDefinition().WithConnectionReferences(refs);
+
+        var dataverse = new Mock<ISyncDataverseClient>();
+        dataverse
+            .Setup(c => c.GetConnectionReferencesByLogicalNamesAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[]
+            {
+                new SyncDataverseClient.ConnectionReferenceInfo
+                {
+                    ConnectionReferenceLogicalName = "cr_bound",
+                    ConnectionId = "connection-123",
+                },
+            });
+
+        var result = await synchronizer.GetAgentConnectionReferencesAsync(
+            definition, dataverse.Object, CancellationToken.None);
+
+        Assert.Equal(2, result.Count);
+
+        var bound = Assert.Single(result, r => r.ConnectionReferenceLogicalName == "cr_bound");
+        Assert.Equal("connection-123", bound.BoundConnectionId);
+        Assert.Equal("shared_office365", bound.ConnectorName);
+
+        var unbound = Assert.Single(result, r => r.ConnectionReferenceLogicalName == "cr_unbound");
+        Assert.Equal(string.Empty, unbound.BoundConnectionId);
+        Assert.Equal("shared_sharepointonline", unbound.ConnectorName);
+    }
+
+    [Fact]
+    public async Task GetAgentConnectionReferencesAsync_SharedConnector_DoesNotQueryConnectorPrefix()
+    {
+        var (synchronizer, _, _) = ComponentWriterDefensiveTests.CreateSyncInfrastructure();
+        var definition = new BotDefinition().WithConnectionReferences(new List<ConnectionReference>
+        {
+            MakeConnectionRef("cr_shared", "/providers/Microsoft.PowerApps/apis/shared_office365"),
+        });
+
+        var dataverse = new Mock<ISyncDataverseClient>();
+        dataverse
+            .Setup(c => c.GetConnectionReferencesByLogicalNamesAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<SyncDataverseClient.ConnectionReferenceInfo>());
+
+        var result = await synchronizer.GetAgentConnectionReferencesAsync(
+            definition, dataverse.Object, CancellationToken.None);
+
+        var single = Assert.Single(result);
+        Assert.Equal("/providers/Microsoft.PowerApps/apis/shared_office365", single.ConnectorId);
+        Assert.Equal("shared_office365", single.ConnectorName);
+        dataverse.Verify(
+            c => c.GetConnectorsByInternalIdPrefixAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task GetAgentConnectionReferencesAsync_EnvironmentSpecificConnector_NoExactMatch_RewritesToNewest()
+    {
+        var (synchronizer, _, _) = ComponentWriterDefensiveTests.CreateSyncInfrastructure();
+        const string originalConnectorId = "/providers/Microsoft.PowerApps/apis/cr1a2_myconnector-5f1234567890abcdef";
+        var definition = new BotDefinition().WithConnectionReferences(new List<ConnectionReference>
+        {
+            MakeConnectionRef("cr_custom", originalConnectorId),
+        });
+
+        var dataverse = new Mock<ISyncDataverseClient>();
+        dataverse
+            .Setup(c => c.GetConnectionReferencesByLogicalNamesAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<SyncDataverseClient.ConnectionReferenceInfo>());
+        dataverse
+            .Setup(c => c.GetConnectorsByInternalIdPrefixAsync("cr1a2_myconnector-5f", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[]
+            {
+                new CustomConnectorMetadata { ConnectorInternalId = "cr1a2_myconnector-5faaaaaaaaaaaaaaaa", ModifiedOn = new DateTime(2024, 1, 1) },
+                new CustomConnectorMetadata { ConnectorInternalId = "cr1a2_myconnector-5fbbbbbbbbbbbbbbbb", ModifiedOn = new DateTime(2024, 6, 1) },
+            });
+
+        var result = await synchronizer.GetAgentConnectionReferencesAsync(
+            definition, dataverse.Object, CancellationToken.None);
+
+        var single = Assert.Single(result);
+        Assert.Equal("/providers/Microsoft.PowerApps/apis/cr1a2_myconnector-5fbbbbbbbbbbbbbbbb", single.ConnectorId);
+        Assert.Equal("cr1a2_myconnector-5fbbbbbbbbbbbbbbbb", single.ConnectorName);
+    }
+
+    [Fact]
+    public async Task GetAgentConnectionReferencesAsync_EnvironmentSpecificConnector_ExactMatch_KeepsOriginal()
+    {
+        var (synchronizer, _, _) = ComponentWriterDefensiveTests.CreateSyncInfrastructure();
+        const string originalConnectorId = "/providers/Microsoft.PowerApps/apis/cr1a2_myconnector-5f1234567890abcdef";
+        var definition = new BotDefinition().WithConnectionReferences(new List<ConnectionReference>
+        {
+            MakeConnectionRef("cr_custom", originalConnectorId),
+        });
+
+        var dataverse = new Mock<ISyncDataverseClient>();
+        dataverse
+            .Setup(c => c.GetConnectionReferencesByLogicalNamesAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<SyncDataverseClient.ConnectionReferenceInfo>());
+        dataverse
+            .Setup(c => c.GetConnectorsByInternalIdPrefixAsync("cr1a2_myconnector-5f", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[]
+            {
+                new CustomConnectorMetadata { ConnectorInternalId = "cr1a2_myconnector-5f1234567890abcdef", ModifiedOn = new DateTime(2024, 1, 1) },
+                new CustomConnectorMetadata { ConnectorInternalId = "cr1a2_myconnector-5fbbbbbbbbbbbbbbbb", ModifiedOn = new DateTime(2024, 6, 1) },
+            });
+
+        var result = await synchronizer.GetAgentConnectionReferencesAsync(
+            definition, dataverse.Object, CancellationToken.None);
+
+        var single = Assert.Single(result);
+        Assert.Equal(originalConnectorId, single.ConnectorId);
+        Assert.Equal("cr1a2_myconnector-5f1234567890abcdef", single.ConnectorName);
+    }
+
+    [Fact]
+    public async Task GetAgentConnectionReferencesAsync_EnvironmentSpecificConnector_NoPrefixMatches_KeepsOriginal()
+    {
+        var (synchronizer, _, _) = ComponentWriterDefensiveTests.CreateSyncInfrastructure();
+        const string originalConnectorId = "/providers/Microsoft.PowerApps/apis/cr1a2_myconnector-5f1234567890abcdef";
+        var definition = new BotDefinition().WithConnectionReferences(new List<ConnectionReference>
+        {
+            MakeConnectionRef("cr_custom", originalConnectorId),
+        });
+
+        var dataverse = new Mock<ISyncDataverseClient>();
+        dataverse
+            .Setup(c => c.GetConnectionReferencesByLogicalNamesAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<SyncDataverseClient.ConnectionReferenceInfo>());
+        dataverse
+            .Setup(c => c.GetConnectorsByInternalIdPrefixAsync("cr1a2_myconnector-5f", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<CustomConnectorMetadata>());
+
+        var result = await synchronizer.GetAgentConnectionReferencesAsync(
+            definition, dataverse.Object, CancellationToken.None);
+
+        var single = Assert.Single(result);
+        Assert.Equal(originalConnectorId, single.ConnectorId);
+        Assert.Equal("cr1a2_myconnector-5f1234567890abcdef", single.ConnectorName);
+    }
+}

--- a/src/CopilotStudio.Sync.UnitTests/CdsBotIdPreservationTests.cs
+++ b/src/CopilotStudio.Sync.UnitTests/CdsBotIdPreservationTests.cs
@@ -61,6 +61,68 @@ public class CdsBotIdPreservationTests
     }
 
     [Fact]
+    public async Task Pull_WhenAgentHasAIPrompt_PreservesAIModelDefinitionInSnapshot()
+    {
+        var (synchronizer, fileAccessorFactory, mockIsland) = ComponentWriterDefensiveTests.CreateSyncInfrastructure();
+        var workspaceRoot = Path.Combine(Path.GetTempPath(), "aibpull-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(workspaceRoot);
+        var workspace = new DirectoryPath(workspaceRoot.Replace('\\', '/') + "/");
+        var agentId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+        var modelId = Guid.Parse("3b5436b4-d7b4-4389-96e8-107446c9094a");
+
+        try
+        {
+            var aiPrompts = Array.Empty<AIPromptMetadata>();
+            var mockDataverse = new Mock<ISyncDataverseClient>();
+            mockDataverse
+                .Setup(x => x.DownloadAllWorkflowsForAgentAsync(It.IsAny<AgentSyncInfo>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Array.Empty<WorkflowMetadata>());
+            mockDataverse
+                .Setup(x => x.DownloadAllAIPromptsForAgentAsync(It.IsAny<AgentSyncInfo>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(() => aiPrompts);
+
+            var opContext = ComponentWriterDefensiveTests.CreateMockOperationContext();
+            var syncInfo = new AgentSyncInfo { AgentId = agentId };
+
+            var clonedBot = new BotEntity.Builder
+            {
+                SchemaName = new BotEntitySchemaName("cr123"),
+                CdsBotId = agentId,
+            }.Build();
+
+            mockIsland
+                .Setup(x => x.GetComponentsAsync(It.IsAny<AuthoringOperationContextBase>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new PvaComponentChangeSet(null, clonedBot, "token-1"));
+
+            await synchronizer.CloneChangesAsync(workspace, new ReferenceTracker(), opContext, mockDataverse.Object, syncInfo, CancellationToken.None);
+
+            var fileAccessor = (InMemoryFileAccessor)fileAccessorFactory.Create(workspace);
+
+            Assert.DoesNotContain(modelId.ToString(), ReadText(fileAccessor, ".mcs/botdefinition.json"));
+
+            var previousDefinition = ReadDefinition(fileAccessor);
+
+            aiPrompts = new[] { new AIPromptMetadata { AIModelId = modelId, Name = "MyPrompt" } };
+
+            var remoteBot = CodeSerializer.Deserialize<BotEntity>("kind: Bot\nschemaName: cr123")!;
+            mockIsland
+                .Setup(x => x.GetComponentsAsync(It.IsAny<AuthoringOperationContextBase>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new PvaComponentChangeSet(null, remoteBot, "token-2"));
+
+            await synchronizer.PullExistingChangesAsync(workspace, opContext, previousDefinition, mockDataverse.Object, syncInfo, CancellationToken.None);
+
+            Assert.Contains(modelId.ToString(), ReadText(fileAccessor, ".mcs/botdefinition.json"));
+        }
+        finally
+        {
+            if (Directory.Exists(workspaceRoot))
+            {
+                Directory.Delete(workspaceRoot, true);
+            }
+        }
+    }
+
+    [Fact]
     public async Task Clone_WhenRemoteBotEntityNeverHasCdsBotId_PopulatesCdsBotIdFromAgentId()
     {
         var (synchronizer, fileAccessorFactory, mockIsland) = ComponentWriterDefensiveTests.CreateSyncInfrastructure();

--- a/src/CopilotStudio.Sync.UnitTests/CustomConnectorTests.cs
+++ b/src/CopilotStudio.Sync.UnitTests/CustomConnectorTests.cs
@@ -1,7 +1,5 @@
 namespace Microsoft.CopilotStudio.Sync.UnitTests
 {
-    using Microsoft.Agents.ObjectModel;
-    using Microsoft.Agents.Platform.Content;
     using Microsoft.CopilotStudio.McsCore;
     using Microsoft.CopilotStudio.Sync;
     using Microsoft.CopilotStudio.Sync.Dataverse;
@@ -50,7 +48,6 @@ namespace Microsoft.CopilotStudio.Sync.UnitTests
             var result = await synchronizer.PushCustomConnectorsAsync(workspace, dataverse.Object, CancellationToken.None);
 
             Assert.Empty(result.PushedRowIds);
-            Assert.Empty(result.NewlyCreatedConnectorNames);
             dataverse.Verify(d => d.UpsertConnectorAsync(It.IsAny<CustomConnectorMetadata>(), It.IsAny<CancellationToken>()), Times.Never);
         }
 
@@ -65,85 +62,7 @@ namespace Microsoft.CopilotStudio.Sync.UnitTests
             var result = await synchronizer.PushCustomConnectorsAsync(workspace, dataverse.Object, CancellationToken.None);
 
             Assert.Empty(result.PushedRowIds);
-            Assert.Empty(result.NewlyCreatedConnectorNames);
             dataverse.Verify(d => d.UpsertConnectorAsync(It.IsAny<CustomConnectorMetadata>(), It.IsAny<CancellationToken>()), Times.Never);
-        }
-
-        [Fact]
-        public async Task PushCustomConnectorsAsync_NewlyCreatedConnector_IsReportedByDisplayName()
-        {
-            var (synchronizer, _, _) = ComponentWriterDefensiveTests.CreateSyncInfrastructure();
-            var workspace = NewWorkspace();
-            var connectorId = Guid.NewGuid();
-            WriteConnectorMetadata(workspace, "MyConn", connectorId, displayName: "My Display", name: "myconn", internalId: "myconn-internal");
-
-            var dataverse = new Mock<ISyncDataverseClient>();
-            dataverse
-                .Setup(d => d.UpsertConnectorAsync(It.IsAny<CustomConnectorMetadata>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(true);
-
-            var result = await synchronizer.PushCustomConnectorsAsync(workspace, dataverse.Object, CancellationToken.None);
-
-            Assert.Single(result.NewlyCreatedConnectorNames);
-            Assert.Equal("My Display", result.NewlyCreatedConnectorNames.Single());
-            Assert.Single(result.PushedRowIds);
-            Assert.Equal(connectorId, result.PushedRowIds["myconn-internal"]);
-        }
-
-        [Fact]
-        public async Task PushCustomConnectorsAsync_UpdatedConnector_IsNotInNewlyCreatedNames()
-        {
-            var (synchronizer, _, _) = ComponentWriterDefensiveTests.CreateSyncInfrastructure();
-            var workspace = NewWorkspace();
-            var connectorId = Guid.NewGuid();
-            WriteConnectorMetadata(workspace, "Existing", connectorId, displayName: "Existing Display", name: "existing", internalId: "existing-internal");
-
-            var dataverse = new Mock<ISyncDataverseClient>();
-            dataverse
-                .Setup(d => d.UpsertConnectorAsync(It.IsAny<CustomConnectorMetadata>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(false);
-
-            var result = await synchronizer.PushCustomConnectorsAsync(workspace, dataverse.Object, CancellationToken.None);
-
-            Assert.Empty(result.NewlyCreatedConnectorNames);
-            Assert.Single(result.PushedRowIds);
-            Assert.Equal(connectorId, result.PushedRowIds["existing-internal"]);
-        }
-
-        [Fact]
-        public async Task PushCustomConnectorsAsync_FallsBackToName_WhenDisplayNameMissing()
-        {
-            var (synchronizer, _, _) = ComponentWriterDefensiveTests.CreateSyncInfrastructure();
-            var workspace = NewWorkspace();
-            var connectorId = Guid.NewGuid();
-            WriteConnectorMetadata(workspace, "OnlyName", connectorId, displayName: null, name: "fallback-name", internalId: "fallback-internal");
-
-            var dataverse = new Mock<ISyncDataverseClient>();
-            dataverse
-                .Setup(d => d.UpsertConnectorAsync(It.IsAny<CustomConnectorMetadata>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(true);
-
-            var result = await synchronizer.PushCustomConnectorsAsync(workspace, dataverse.Object, CancellationToken.None);
-
-            Assert.Equal("fallback-name", result.NewlyCreatedConnectorNames.Single());
-        }
-
-        [Fact]
-        public async Task PushCustomConnectorsAsync_FallsBackToConnectorId_WhenNameAndDisplayNameMissing()
-        {
-            var (synchronizer, _, _) = ComponentWriterDefensiveTests.CreateSyncInfrastructure();
-            var workspace = NewWorkspace();
-            var connectorId = Guid.NewGuid();
-            WriteConnectorMetadata(workspace, "NoName", connectorId, displayName: null, name: null, internalId: "no-name-internal");
-
-            var dataverse = new Mock<ISyncDataverseClient>();
-            dataverse
-                .Setup(d => d.UpsertConnectorAsync(It.IsAny<CustomConnectorMetadata>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(true);
-
-            var result = await synchronizer.PushCustomConnectorsAsync(workspace, dataverse.Object, CancellationToken.None);
-
-            Assert.Equal(connectorId.ToString(), result.NewlyCreatedConnectorNames.Single());
         }
 
         [Fact]
@@ -190,53 +109,9 @@ namespace Microsoft.CopilotStudio.Sync.UnitTests
 
             var result = await synchronizer.PushCustomConnectorsAsync(workspace, dataverse.Object, CancellationToken.None);
 
-            Assert.Equal(new[] { "New One" }, result.NewlyCreatedConnectorNames);
             Assert.Equal(2, result.PushedRowIds.Count);
             Assert.Equal(newId, result.PushedRowIds["new-one-internal"]);
             Assert.Equal(existingId, result.PushedRowIds["old-one-internal"]);
-        }
-
-        [Fact]
-        public async Task PushChangesetAsync_PropagatesNewlyCreatedConnectors_ToResult()
-        {
-            var (synchronizer, fileAccessorFactory, mockIsland) = ComponentWriterDefensiveTests.CreateSyncInfrastructure();
-            var workspace = NewWorkspace();
-
-            var fileAccessor = fileAccessorFactory.Create(workspace);
-            WorkspaceSynchronizer.WriteCloudCache(fileAccessor, new BotDefinition());
-            await fileAccessor.WriteAsync(new AgentFilePath(".mcs/changetoken.txt"), "token-0", CancellationToken.None);
-
-            var emptyChangeset = new PvaComponentChangeSet(null, null, "token-1");
-            mockIsland
-                .Setup(x => x.SaveChangesAsync(
-                    It.IsAny<AuthoringOperationContextBase>(),
-                    It.IsAny<PvaComponentChangeSet>(),
-                    It.IsAny<CancellationToken>()))
-                .ReturnsAsync(emptyChangeset);
-
-            var connectorId = Guid.NewGuid();
-            WriteConnectorMetadata(workspace, "Pushed", connectorId, displayName: "Pushed Display", name: "pushed", internalId: "pushed-internal");
-
-            var dataverse = new Mock<ISyncDataverseClient>();
-            dataverse
-                .Setup(d => d.UpsertConnectorAsync(It.IsAny<CustomConnectorMetadata>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(true);
-            dataverse
-                .Setup(d => d.DownloadConnectorsByInternalIdsAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(Array.Empty<CustomConnectorMetadata>());
-
-            var result = await synchronizer.PushChangesetAsync(
-                workspace,
-                ComponentWriterDefensiveTests.CreateMockOperationContext(),
-                emptyChangeset,
-                dataverse.Object,
-                agentId: Guid.NewGuid(),
-                cloudFlowMetadata: null,
-                aiPrompts: default,
-                CancellationToken.None);
-
-            Assert.Equal(0, result.UploadedKnowledgeFileCount);
-            Assert.Equal(new[] { "Pushed Display" }, result.NewlyCreatedCustomConnectors);
         }
 
         [Fact]

--- a/src/CopilotStudio.Sync.UnitTests/RemoteChildAgentPullTests.cs
+++ b/src/CopilotStudio.Sync.UnitTests/RemoteChildAgentPullTests.cs
@@ -44,6 +44,25 @@ public class RemoteChildAgentPullTests
         Assert.Contains("ParentId does not exist on cloud: cre98_AgentC1.agent.Agent", exception.Message);
     }
 
+    [Fact]
+    public void GetLocalChanges_LocalPush_DeferMissingParents_CreatesNewAgentAndDefersChild()
+    {
+        var (synchronizer, fileAccessorFactory, _) = ComponentWriterDefensiveTests.CreateSyncInfrastructure();
+        var workspace = new DirectoryPath("c:/test/workspace/");
+        var fileAccessor = fileAccessorFactory.Create(workspace);
+
+        var cloudSnapshot = CreateDefinition(Array.Empty<BotComponentBase>());
+        var agentComponent = CreateDialogComponent("cre98_AgentC1.agent.Agent", Guid.NewGuid(), default, new AgentDialog());
+        var childTopic = CreateDialogComponent("cre98_AgentC1.topic.ChildTopic", Guid.NewGuid(), agentComponent.Id, new AdaptiveDialog());
+        var localDefinition = CreateDefinition(new[] { agentComponent, childTopic });
+
+        var (_, changes) = synchronizer.GetLocalChanges(localDefinition, cloudSnapshot, fileAccessor, "token-1", isRemoteChange: false, deferMissingParents: true, out var deferredMissingParent);
+
+        Assert.True(deferredMissingParent);
+        Assert.Contains(changes, change => change.SchemaName == agentComponent.SchemaNameString && change.ChangeType == ChangeType.Create);
+        Assert.DoesNotContain(changes, change => change.SchemaName == childTopic.SchemaNameString);
+    }
+
     private static BotDefinition CreateDefinition(IEnumerable<BotComponentBase> components)
     {
         var botEntity = CodeSerializer.Deserialize<BotEntity>("kind: Bot\nschemaName: cre98_AgentC1")!;

--- a/src/CopilotStudio.Sync/Dataverse/ISyncDataverseClient.cs
+++ b/src/CopilotStudio.Sync/Dataverse/ISyncDataverseClient.cs
@@ -60,6 +60,11 @@ public interface ISyncDataverseClient
     Task EnsureConnectionReferenceExistsAsync(string connectionReferenceLogicalName, string connectorId, CancellationToken cancellationToken, Guid? customConnectorRowId = null);
 
     /// <summary>
+    /// Binds a connection reference to a connection by setting its connectionid.
+    /// </summary>
+    Task BindConnectionReferenceAsync(string connectionReferenceLogicalName, string connectionLogicalName, CancellationToken cancellationToken, string? connectionReferenceDisplayName = null);
+
+    /// <summary>
     /// Get connection references by logical names.
     /// </summary>
     Task<ConnectionReferenceInfo[]> GetConnectionReferencesByLogicalNamesAsync(IEnumerable<string> logicalNames, CancellationToken cancellationToken);
@@ -71,6 +76,13 @@ public interface ISyncDataverseClient
     /// <param name="isManaged">connector is managed or not.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     Task<CustomConnectorMetadata[]> DownloadConnectorsByInternalIdsAsync(IEnumerable<string> connectorInternalIds, bool isManaged, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Find connectors whose connectorinternalid starts with the given prefix.
+    /// </summary>
+    /// <param name="connectorInternalIdPrefix">The stable connectorinternalid prefix to match.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<CustomConnectorMetadata[]> GetConnectorsByInternalIdPrefixAsync(string connectorInternalIdPrefix, CancellationToken cancellationToken);
 
     /// <summary>
     /// Upsert a custom connector in Dataverse.

--- a/src/CopilotStudio.Sync/Dataverse/SyncDataverseClient.cs
+++ b/src/CopilotStudio.Sync/Dataverse/SyncDataverseClient.cs
@@ -736,11 +736,66 @@ public class SyncDataverseClient : ISyncDataverseClient
         CancellationToken cancellationToken,
         Guid? customConnectorRowId = null)
     {
-        var exists = await ConnectionReferenceExistsAsync(connectionReferenceLogicalName, cancellationToken).ConfigureAwait(false);
-        if (!exists)
+        var existing = await GetConnectionReferenceByLogicalNameAsync(connectionReferenceLogicalName, cancellationToken).ConfigureAwait(false);
+        if (existing is null)
         {
             await CreateConnectionReferenceAsync(connectionReferenceLogicalName, connectorId, cancellationToken, customConnectorRowId).ConfigureAwait(false);
+            return;
         }
+
+        var desiredInternalId = ExtractConnectorInternalId(connectorId);
+        var existingInternalId = ExtractConnectorInternalId(existing.ConnectorId);
+        if (!string.IsNullOrWhiteSpace(desiredInternalId) &&
+            !string.IsNullOrWhiteSpace(existingInternalId) &&
+            !string.Equals(existingInternalId, desiredInternalId, StringComparison.OrdinalIgnoreCase))
+        {
+            await UpdateConnectionReferenceConnectorAsync(existing.ConnectionReferenceId, connectorId, customConnectorRowId, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private async Task<ConnectionReferenceInfo?> GetConnectionReferenceByLogicalNameAsync(string connectionReferenceLogicalName, CancellationToken cancellationToken)
+    {
+        if (connectionReferenceLogicalName is null)
+        {
+            throw new ArgumentNullException(nameof(connectionReferenceLogicalName));
+        }
+
+        var literal = connectionReferenceLogicalName.Replace("'", "''");
+        var filterExpr = $"connectionreferencelogicalname eq '{literal}'";
+        var baseUri = new Uri(new Uri(DataverseUrl), "/api/data/v9.2/connectionreferences");
+        var requestUri = new Uri($"{baseUri}?$select=connectionreferenceid,connectionreferencelogicalname,connectorid,connectionid&$top=1&$filter={Uri.EscapeDataString(filterExpr)}");
+
+        var queryResponse = await SendAsync<ConnectionReferenceQueryResponse>(
+            HttpMethod.Get,
+            requestUri.ToString(),
+            null,
+            false,
+            cancellationToken
+        ).ConfigureAwait(false);
+
+        var existing = queryResponse?.Value;
+        return existing != null && existing.Length > 0 ? existing[0] : null;
+    }
+
+    private async Task UpdateConnectionReferenceConnectorAsync(Guid connectionReferenceId, string connectorId, Guid? customConnectorRowId, CancellationToken cancellationToken)
+    {
+        var patchUri = new Uri(new Uri(DataverseUrl), $"/api/data/v9.2/connectionreferences({connectionReferenceId})");
+
+        var body = new Dictionary<string, object>
+        {
+            ["connectorid"] = connectorId
+        };
+
+        if (customConnectorRowId.HasValue)
+        {
+            var navName = await GetCustomConnectorNavigationPropertyNameAsync(cancellationToken).ConfigureAwait(false);
+            if (!string.IsNullOrWhiteSpace(navName))
+            {
+                body[$"{navName}@odata.bind"] = $"/connectors({customConnectorRowId.Value})";
+            }
+        }
+
+        await SendAsync<object>(HttpMethodHelper.Patch, patchUri.ToString(), body, false, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/src/CopilotStudio.Sync/Dataverse/SyncDataverseClient.cs
+++ b/src/CopilotStudio.Sync/Dataverse/SyncDataverseClient.cs
@@ -65,7 +65,7 @@ public class SyncDataverseClient : ISyncDataverseClient
 
     public virtual async Task<Guid> GetAgentIdBySchemaNameAsync(string schemaName, CancellationToken cancellationToken)
     {
-        var requestUri = $"{DataverseUrl}/api/data/v9.2/bots?$select=botid&$filter=schemaname eq '{schemaName}'";
+        var requestUri = $"{DataverseUrl}/api/data/v9.2/bots?$select=botid&$filter=schemaname eq '{schemaName?.Replace("'", "''")}'";
         var result = await SendAsync<AgentInfoDetail>(HttpMethod.Get, requestUri, null, false, cancellationToken).ConfigureAwait(false);
         return result?.Value?.FirstOrDefault()?.AgentId ?? Guid.Empty;
     }
@@ -245,6 +245,42 @@ public class SyncDataverseClient : ISyncDataverseClient
 
                 next = page.TryGetProperty("@odata.nextLink", out var nextLinkProp) ? nextLinkProp.GetString() : null;
             }
+        }
+
+        return results.ToArray();
+    }
+
+    public virtual async Task<CustomConnectorMetadata[]> GetConnectorsByInternalIdPrefixAsync(string connectorInternalIdPrefix, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(connectorInternalIdPrefix))
+        {
+            return Array.Empty<CustomConnectorMetadata>();
+        }
+
+        const string select = "connectorid,name,displayname,connectorinternalid,connectortype,ismanaged,modifiedon";
+        var filter = $"startswith(connectorinternalid,'{connectorInternalIdPrefix.Replace("'", "''")}')";
+        string? next = $"{DataverseUrl}/api/data/v9.2/connectors?$select={select}&$filter={Uri.EscapeDataString(filter)}";
+
+        var results = new List<CustomConnectorMetadata>();
+        var seenConnectorIds = new HashSet<Guid>();
+
+        while (!string.IsNullOrEmpty(next))
+        {
+            var page = await SendAsync<JsonElement>(HttpMethod.Get, next!, null, false, cancellationToken).ConfigureAwait(false);
+
+            if (page.TryGetProperty("value", out var arr) && arr.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var el in arr.EnumerateArray())
+                {
+                    var meta = JsonSerializer.Deserialize<CustomConnectorMetadata>(el.GetRawText(), JsonSerializerOptions);
+                    if (meta != null && meta.ConnectorId != Guid.Empty && seenConnectorIds.Add(meta.ConnectorId))
+                    {
+                        results.Add(meta);
+                    }
+                }
+            }
+
+            next = page.TryGetProperty("@odata.nextLink", out var nextLinkProp) ? nextLinkProp.GetString() : null;
         }
 
         return results.ToArray();
@@ -705,6 +741,54 @@ public class SyncDataverseClient : ISyncDataverseClient
         {
             await CreateConnectionReferenceAsync(connectionReferenceLogicalName, connectorId, cancellationToken, customConnectorRowId).ConfigureAwait(false);
         }
+    }
+
+    /// <summary>
+    /// Binds a connection reference to a connection by setting its connectionid.
+    /// </summary>
+    /// <param name="connectionReferenceLogicalName">Logical name of the connection reference to bind.</param>
+    /// <param name="connectionLogicalName">The bound connection's logical name.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <param name="connectionReferenceDisplayName">Optional display name to set on the reference.</param>
+    public virtual async Task BindConnectionReferenceAsync(string connectionReferenceLogicalName, string connectionLogicalName, CancellationToken cancellationToken, string? connectionReferenceDisplayName = null)
+    {
+        if (connectionReferenceLogicalName is null)
+        {
+            throw new ArgumentNullException(nameof(connectionReferenceLogicalName));
+        }
+
+        if (string.IsNullOrWhiteSpace(connectionLogicalName))
+        {
+            throw new ArgumentException("Connection logical name is required.", nameof(connectionLogicalName));
+        }
+
+        var literal = connectionReferenceLogicalName.Replace("'", "''");
+        var filterExpr = $"connectionreferencelogicalname eq '{literal}'";
+        var baseUri = new Uri(new Uri(DataverseUrl), "/api/data/v9.2/connectionreferences");
+        var queryUri = new Uri($"{baseUri}?$select=connectionreferenceid&$top=1&$filter={Uri.EscapeDataString(filterExpr)}");
+
+        var queryResponse = await SendAsync<ConnectionReferenceQueryResponse>(HttpMethod.Get, queryUri.ToString(), null, false, cancellationToken).ConfigureAwait(false);
+
+        var existing = queryResponse?.Value;
+        if (existing == null || existing.Length == 0)
+        {
+            throw new InvalidOperationException($"Connection reference '{connectionReferenceLogicalName}' was not found in Dataverse.");
+        }
+
+        var connectionReferenceId = existing[0].ConnectionReferenceId;
+        var patchUri = new Uri(new Uri(DataverseUrl), $"/api/data/v9.2/connectionreferences({connectionReferenceId})");
+
+        var body = new Dictionary<string, object>
+        {
+            ["connectionid"] = connectionLogicalName
+        };
+
+        if (!string.IsNullOrWhiteSpace(connectionReferenceDisplayName))
+        {
+            body["connectionreferencedisplayname"] = connectionReferenceDisplayName!;
+        }
+
+        await SendAsync<object>(HttpMethodHelper.Patch, patchUri.ToString(), body, false, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task DownloadKnowledgeFileAsync(string knowledgeFileFolder, BotComponentId botComponentId, string fileName, CancellationToken cancellationToken = default)

--- a/src/CopilotStudio.Sync/IWorkspaceSynchronizer.cs
+++ b/src/CopilotStudio.Sync/IWorkspaceSynchronizer.cs
@@ -135,6 +135,28 @@ public interface IWorkspaceSynchronizer
         bool uploadAllKnowledgeFiles = false);
 
     /// <summary>
+    /// Pushes all local component changes to the cloud, creating newly added sub-agents if needed.
+    /// </summary>
+    /// <param name="workspaceFolder">The location of the root of the workspace.</param>
+    /// <param name="operationContext">Information about the authoring operation.</param>
+    /// <param name="workspaceDefinition">The current state of the workspace to push.</param>
+    /// <param name="dataverseClient">The dataverse client to use for communication with the dataverse service.</param>
+    /// <param name="syncInfo">Synchronization information for the agent.</param>
+    /// <param name="cloudFlowMetadata">Cloud flow metadata to project into the cloud cache.</param>
+    /// <param name="aiPrompts">AI Builder prompt metadata to project into the cloud cache.</param>
+    /// <param name="cancellationToken">Used to cancel the request.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task PushLocalChangesAsync(
+        DirectoryPath workspaceFolder,
+        AuthoringOperationContextBase operationContext,
+        DefinitionBase workspaceDefinition,
+        ISyncDataverseClient dataverseClient,
+        AgentSyncInfo syncInfo,
+        CloudFlowMetadata? cloudFlowMetadata,
+        ImmutableArray<AIPromptMetadata> aiPrompts,
+        CancellationToken cancellationToken);
+
+    /// <summary>
     /// Sync workspace to write bot definition, git ignore, change token files in .mcs.
     /// </summary>
     /// <param name="workspaceFolder">Workspace folder.</param>
@@ -251,6 +273,20 @@ public interface IWorkspaceSynchronizer
         ISyncDataverseClient dataverseClient,
         CancellationToken cancellationToken,
         IReadOnlyDictionary<string, Guid>? pushedConnectorIds = null);
+
+    /// <summary>
+    /// Returns connection reference the agent declares, annotated with the connection it is currently bound to in Dataverse.
+    /// </summary>
+    /// <param name="workspaceFolder">Workspace folder used to read the on-disk overlay.</param>
+    /// <param name="definition">The bot definition declaring connection references.</param>
+    /// <param name="dataverseClient">Dataverse client.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The declared connection references with their current binding state.</returns>
+    Task<IReadOnlyList<ConnectionNeeded>> GetAgentConnectionReferencesAsync(
+        DirectoryPath workspaceFolder,
+        DefinitionBase definition,
+        ISyncDataverseClient dataverseClient,
+        CancellationToken cancellationToken);
 
     /// <summary>
     /// Pushes local custom connector edits to Dataverse.

--- a/src/CopilotStudio.Sync/Models.cs
+++ b/src/CopilotStudio.Sync/Models.cs
@@ -219,6 +219,21 @@ public class SolutionInfo
 
 #endregion
 
+#region ConnectionNeeded
+
+public class ConnectionNeeded
+{
+    public string ConnectionReferenceLogicalName { get; init; } = string.Empty;
+
+    public string ConnectorId { get; init; } = string.Empty;
+
+    public string ConnectorName { get; init; } = string.Empty;
+
+    public string BoundConnectionId { get; init; } = string.Empty;
+}
+
+#endregion
+
 #region CloudFlowMetadata
 
 public class CloudFlowMetadata
@@ -305,11 +320,6 @@ public class CustomConnectorPushResult
     /// Map of connector internal id to the connector's Dataverse row GUID for every connector that was upserted.
     /// </summary>
     public IReadOnlyDictionary<string, Guid> PushedRowIds { get; init; } = new Dictionary<string, Guid>();
-
-    /// <summary>
-    /// Display names of custom connectors that were newly created in Dataverse
-    /// </summary>
-    public IReadOnlyList<string> NewlyCreatedConnectorNames { get; init; } = Array.Empty<string>();
 }
 
 #endregion
@@ -325,11 +335,6 @@ public class PushChangesetResult
     /// Number of knowledge files that were uploaded to the cloud.
     /// </summary>
     public int UploadedKnowledgeFileCount { get; init; }
-
-    /// <summary>
-    /// Display names of custom connectors that were newly created in Dataverse.
-    /// </summary>
-    public IReadOnlyList<string> NewlyCreatedCustomConnectors { get; init; } = Array.Empty<string>();
 }
 
 #endregion

--- a/src/CopilotStudio.Sync/WorkspaceSynchronizer.cs
+++ b/src/CopilotStudio.Sync/WorkspaceSynchronizer.cs
@@ -282,7 +282,7 @@ internal class WorkspaceSynchronizer : IWorkspaceSynchronizer
         var originalSnapshot = ReadCloudCacheSnapshot(fileAccessor);
 
         // Apply raw changeSet on cloud cache
-        var (newSnapshot, _) = UpdateCloudCache(fileAccessor, remoteChangeset, workflows, agentId: syncInfo.AgentId);
+        var (newSnapshot, _) = UpdateCloudCache(fileAccessor, remoteChangeset, workflows, aiPrompts, agentId: syncInfo.AgentId);
 
         // Persist new delta token
         await WriteChangeTokenAsync(fileAccessor, remoteChangeset, cancellationToken).ConfigureAwait(false);
@@ -668,7 +668,7 @@ internal class WorkspaceSynchronizer : IWorkspaceSynchronizer
             pushChangeset,
             cancellationToken).ConfigureAwait(false);
 
-        var connectorPushResult = await PushCustomConnectorsAsync(workspaceFolder, dataverseClient, cancellationToken).ConfigureAwait(false);
+        await PushCustomConnectorsAsync(workspaceFolder, dataverseClient, cancellationToken).ConfigureAwait(false);
 
         await WriteChangeSetAsync(workspaceFolder, changeset, cloudFlowMetadata, aiPrompts, agentId, cancellationToken).ConfigureAwait(false);
 
@@ -684,7 +684,6 @@ internal class WorkspaceSynchronizer : IWorkspaceSynchronizer
             return new PushChangesetResult
             {
                 UploadedKnowledgeFileCount = 0,
-                NewlyCreatedCustomConnectors = connectorPushResult.NewlyCreatedConnectorNames,
             };
         }
 
@@ -701,7 +700,6 @@ internal class WorkspaceSynchronizer : IWorkspaceSynchronizer
                 return new PushChangesetResult
                 {
                     UploadedKnowledgeFileCount = 0,
-                    NewlyCreatedCustomConnectors = connectorPushResult.NewlyCreatedConnectorNames,
                 };
             }
 
@@ -768,8 +766,79 @@ internal class WorkspaceSynchronizer : IWorkspaceSynchronizer
         return new PushChangesetResult
         {
             UploadedKnowledgeFileCount = numberOfUploadedFiles,
-            NewlyCreatedCustomConnectors = connectorPushResult.NewlyCreatedConnectorNames,
         };
+    }
+
+    /// <summary>
+    /// Pushes all local component changes to the cloud, creating newly added sub-agents if needed.
+    /// </summary>
+    /// <param name="workspaceFolder">The location of the root of the workspace.</param>
+    /// <param name="operationContext">Information about the authoring operation.</param>
+    /// <param name="workspaceDefinition">The current state of the workspace to push.</param>
+    /// <param name="dataverseClient">The dataverse client used for communication with the service.</param>
+    /// <param name="syncInfo">Synchronization information for the agent.</param>
+    /// <param name="cloudFlowMetadata">Cloud flow metadata to project into the cloud cache.</param>
+    /// <param name="aiPrompts">AI Builder prompt metadata to project into the cloud cache.</param>
+    /// <param name="cancellationToken">Used to cancel the request.</param>
+    public async Task PushLocalChangesAsync(
+        DirectoryPath workspaceFolder,
+        AuthoringOperationContextBase operationContext,
+        DefinitionBase workspaceDefinition,
+        ISyncDataverseClient dataverseClient,
+        AgentSyncInfo syncInfo,
+        CloudFlowMetadata? cloudFlowMetadata,
+        ImmutableArray<AIPromptMetadata> aiPrompts,
+        CancellationToken cancellationToken)
+    {
+        const int maxPasses = 32;
+        for (var pass = 0; pass < maxPasses; pass++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var fileAccessor = _fileAccessorFactory.Create(workspaceFolder);
+            var cloudSnapshot = ReadCloudCacheSnapshot(fileAccessor) ?? throw new InvalidOperationException("Unable to read cloud cache from .mcs/botdefinition.json");
+            var changeToken = await GetChangeTokenOrNullAsync(fileAccessor, cancellationToken).ConfigureAwait(false);
+            var effectiveDefinition = OverlayCliConnectionReferences(workspaceDefinition, fileAccessor, cancellationToken);
+
+            var (changeSet, changes) = GetLocalChanges(effectiveDefinition, cloudSnapshot, fileAccessor, changeToken, isRemoteChange: false, deferMissingParents: true, out var deferredMissingParent);
+
+            if (changes.IsEmpty)
+            {
+                if (deferredMissingParent)
+                {
+                    throw new InvalidOperationException("Unsupported sync operation. A component references a parent agent that could not be created on the cloud.");
+                }
+
+                break;
+            }
+
+            if (!changes.Any(c => c.SchemaName == "entity" || c.SchemaName == "icon"))
+            {
+                changeSet = changeSet.WithBot(null);
+            }
+            else if (changeSet.Bot != null)
+            {
+                var cloudEntity = (cloudSnapshot as BotDefinition)?.Entity;
+                if (cloudEntity != null && changeSet.Bot.Version != cloudEntity.Version)
+                {
+                    var entityBuilder = changeSet.Bot.ToBuilder();
+                    entityBuilder.Version = cloudEntity.Version;
+                    changeSet = changeSet.WithBot(entityBuilder.Build());
+                }
+            }
+
+            await PushChangesetAsync(workspaceFolder, operationContext, changeSet, dataverseClient, syncInfo.AgentId, cloudFlowMetadata, aiPrompts, cancellationToken).ConfigureAwait(false);
+
+            if (!deferredMissingParent)
+            {
+                break;
+            }
+
+            if (pass == maxPasses - 1)
+            {
+                throw new InvalidOperationException("Unsupported sync operation. A component references a parent agent that could not be created on the cloud.");
+            }
+        }
     }
 
     public virtual async Task ProvisionConnectionReferencesAsync(
@@ -792,20 +861,26 @@ internal class WorkspaceSynchronizer : IWorkspaceSynchronizer
     {
         var connectionRefs = definition.ConnectionReferences;
 
+        var prefixCache = new Dictionary<string, CustomConnectorMetadata[]>(StringComparer.OrdinalIgnoreCase);
+
         foreach (var connRef in connectionRefs)
         {
             try
             {
+                var originalConnectorId = connRef.ConnectorId.ToString();
+                var originalInternalId = SyncDataverseClient.ExtractConnectorInternalId(originalConnectorId);
+
                 Guid? customConnectorRowId = null;
-                var internalId = SyncDataverseClient.ExtractConnectorInternalId(connRef.ConnectorId.ToString());
-                if (pushedConnectorIds != null && !string.IsNullOrWhiteSpace(internalId) && pushedConnectorIds.TryGetValue(internalId!, out var mapped))
+                if (pushedConnectorIds != null && !string.IsNullOrWhiteSpace(originalInternalId) && pushedConnectorIds.TryGetValue(originalInternalId!, out var mapped))
                 {
                     customConnectorRowId = mapped;
                 }
 
+                var connectorId = await ResolveTargetConnectorIdAsync(originalConnectorId, dataverseClient, cancellationToken, prefixCache).ConfigureAwait(false);
+
                 await dataverseClient.EnsureConnectionReferenceExistsAsync(
                     connRef.ConnectionReferenceLogicalName.ToString(),
-                    connRef.ConnectorId.ToString(),
+                    connectorId,
                     cancellationToken,
                     customConnectorRowId).ConfigureAwait(false);
             }
@@ -819,6 +894,202 @@ internal class WorkspaceSynchronizer : IWorkspaceSynchronizer
                 // Continue with other connections
             }
         }
+    }
+
+    /// <summary>
+    /// Returns connection reference the agent declares, annotated with the connection it is currently bound to in Dataverse (if any).
+    /// </summary>
+    public virtual async Task<IReadOnlyList<ConnectionNeeded>> GetAgentConnectionReferencesAsync(DirectoryPath workspaceFolder, DefinitionBase definition, ISyncDataverseClient dataverseClient, CancellationToken cancellationToken)
+    {
+        var fileAccessor = _fileAccessorFactory.Create(workspaceFolder);
+        var effectiveDefinition = OverlayCliConnectionReferences(definition, fileAccessor, cancellationToken);
+        return await GetAgentConnectionReferencesAsync(effectiveDefinition, dataverseClient, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Returns connection reference declared by the bot definition, annotated with its current Dataverse binding state.
+    /// </summary>
+    public virtual async Task<IReadOnlyList<ConnectionNeeded>> GetAgentConnectionReferencesAsync(DefinitionBase definition, ISyncDataverseClient dataverseClient, CancellationToken cancellationToken)
+    {
+        var connectionRefs = definition.ConnectionReferences;
+        if (connectionRefs.IsDefaultOrEmpty)
+        {
+            return Array.Empty<ConnectionNeeded>();
+        }
+
+        var logicalNames = connectionRefs
+            .Select(cr => cr.ConnectionReferenceLogicalName.ToString())
+            .Where(n => !string.IsNullOrWhiteSpace(n))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (logicalNames.Count == 0)
+        {
+            return Array.Empty<ConnectionNeeded>();
+        }
+
+        var cloudRefs = await dataverseClient.GetConnectionReferencesByLogicalNamesAsync(logicalNames, cancellationToken).ConfigureAwait(false);
+        var boundIdByName = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var info in cloudRefs)
+        {
+            if (string.IsNullOrWhiteSpace(info.ConnectionReferenceLogicalName))
+            {
+                continue;
+            }
+
+            boundIdByName[info.ConnectionReferenceLogicalName] = info.ConnectionId ?? string.Empty;
+        }
+
+        var result = new List<ConnectionNeeded>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var prefixCache = new Dictionary<string, CustomConnectorMetadata[]>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var connRef in connectionRefs)
+        {
+            var logicalName = connRef.ConnectionReferenceLogicalName.ToString();
+            if (string.IsNullOrWhiteSpace(logicalName) || !seen.Add(logicalName))
+            {
+                continue;
+            }
+
+            boundIdByName.TryGetValue(logicalName, out var boundConnectionId);
+            var connectorId = await ResolveTargetConnectorIdAsync(connRef.ConnectorId.ToString(), dataverseClient, cancellationToken, prefixCache).ConfigureAwait(false);
+            var connectorName = SyncDataverseClient.ExtractConnectorInternalId(connectorId) ?? string.Empty;
+
+            result.Add(new ConnectionNeeded
+            {
+                ConnectionReferenceLogicalName = logicalName,
+                ConnectorId = connectorId,
+                ConnectorName = connectorName,
+                BoundConnectionId = boundConnectionId ?? string.Empty,
+            });
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Resolves each connection reference's connector id to the target environment.
+    /// </summary>
+    private static async Task<DefinitionBase> ResolveConnectionReferenceConnectorIdsAsync(DefinitionBase definition, ISyncDataverseClient dataverseClient, CancellationToken cancellationToken)
+    {
+        if (definition.ConnectionReferences.IsDefaultOrEmpty)
+        {
+            return definition;
+        }
+
+        var resolved = ImmutableArray.CreateBuilder<ConnectionReference>(definition.ConnectionReferences.Length);
+        var changed = false;
+        var prefixCache = new Dictionary<string, CustomConnectorMetadata[]>(StringComparer.OrdinalIgnoreCase);
+        foreach (var connRef in definition.ConnectionReferences)
+        {
+            var originalConnectorId = connRef.ConnectorId.ToString();
+            var targetConnectorId = await ResolveTargetConnectorIdAsync(originalConnectorId, dataverseClient, cancellationToken, prefixCache).ConfigureAwait(false);
+            if (string.Equals(originalConnectorId, targetConnectorId, StringComparison.Ordinal))
+            {
+                resolved.Add(connRef);
+                continue;
+            }
+
+            var builder = connRef.ToBuilder();
+            builder.ConnectorId = targetConnectorId;
+            resolved.Add(builder.Build());
+            changed = true;
+        }
+
+        return changed ? definition.WithConnectionReferences(resolved.ToImmutable()) : definition;
+    }
+
+    /// <summary>
+    /// Rewrites a full connector id so its internal-id segment points at the target environment's connector when the connector is environment-specific.
+    /// </summary>
+    private static async Task<string> ResolveTargetConnectorIdAsync(string connectorId, ISyncDataverseClient dataverseClient, CancellationToken cancellationToken, Dictionary<string, CustomConnectorMetadata[]>? prefixCache = null)
+    {
+        var connectorName = SyncDataverseClient.ExtractConnectorInternalId(connectorId) ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(connectorName))
+        {
+            return connectorId;
+        }
+
+        var resolvedConnectorName = await ResolveTargetConnectorNameAsync(connectorName, dataverseClient, cancellationToken, prefixCache).ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(resolvedConnectorName) || string.Equals(resolvedConnectorName, connectorName, StringComparison.OrdinalIgnoreCase))
+        {
+            return connectorId;
+        }
+
+        var slash = connectorId.LastIndexOf('/');
+        return slash >= 0 ? connectorId.Substring(0, slash + 1) + resolvedConnectorName! : resolvedConnectorName!;
+    }
+
+    /// <summary>
+    /// Resolves the environment-specific connector internal id for a connector whose trailing hash differs between environments.
+    /// </summary>
+    private static async Task<string?> ResolveTargetConnectorNameAsync(string connectorInternalId, ISyncDataverseClient dataverseClient, CancellationToken cancellationToken, Dictionary<string, CustomConnectorMetadata[]>? prefixCache = null)
+    {
+        var prefix = GetStableConnectorPrefix(connectorInternalId);
+        if (prefix == null)
+        {
+            return connectorInternalId;
+        }
+
+        CustomConnectorMetadata[] matches;
+        if (prefixCache != null && prefixCache.TryGetValue(prefix, out var cached))
+        {
+            matches = cached;
+        }
+        else
+        {
+            matches = await dataverseClient.GetConnectorsByInternalIdPrefixAsync(prefix, cancellationToken).ConfigureAwait(false);
+            if (prefixCache != null)
+            {
+                prefixCache[prefix] = matches;
+            }
+        }
+
+        if (matches.Length == 0)
+        {
+            return connectorInternalId;
+        }
+
+        var exact = matches.FirstOrDefault(m => string.Equals(m.ConnectorInternalId, connectorInternalId, StringComparison.OrdinalIgnoreCase));
+        if (exact != null)
+        {
+            return exact.ConnectorInternalId;
+        }
+
+        var newest = matches
+            .Where(m => !string.IsNullOrWhiteSpace(m.ConnectorInternalId))
+            .OrderByDescending(m => m.ModifiedOn)
+            .FirstOrDefault();
+
+        return newest?.ConnectorInternalId ?? connectorInternalId;
+    }
+
+    /// <summary>
+    /// Returns the stable connector internal id prefix for an environment-specific connector whose trailing segment is a 16-character hex hash; otherwise returns null.
+    /// </summary>
+    private static string? GetStableConnectorPrefix(string? connectorInternalId)
+    {
+        if (string.IsNullOrWhiteSpace(connectorInternalId))
+        {
+            return null;
+        }
+
+        const string separator = "-5f";
+        var idx = connectorInternalId!.LastIndexOf(separator, StringComparison.Ordinal);
+        if (idx <= 0)
+        {
+            return null;
+        }
+
+        var tail = connectorInternalId.Substring(idx + separator.Length);
+        if (tail.Length != 16 || !tail.All(Uri.IsHexDigit))
+        {
+            return null;
+        }
+
+        return connectorInternalId.Substring(0, idx + separator.Length);
     }
 
     /// <summary>
@@ -861,6 +1132,7 @@ internal class WorkspaceSynchronizer : IWorkspaceSynchronizer
         }
 
         definition = EnsureEntityCdsBotId(definition, syncInfo.AgentId);
+        definition = await ResolveConnectionReferenceConnectorIdsAsync(definition, dataverseClient, cancellationToken).ConfigureAwait(false);
 
         await fileAccessor.WriteAsync(GitIgnorePath, "*", cancellationToken).ConfigureAwait(false);
         WriteCloudCache(fileAccessor, definition);
@@ -1378,7 +1650,7 @@ internal class WorkspaceSynchronizer : IWorkspaceSynchronizer
 
         var changeToken = await GetChangeTokenOrNullAsync(fileAccessor, cancellationToken).ConfigureAwait(false);
         var effectiveDefinition = OverlayCliConnectionReferences(workspaceDefinition, fileAccessor, cancellationToken);
-        var (changeSet, changes) = GetLocalChanges(effectiveDefinition, cloudSnapshot, fileAccessor, changeToken);
+        var (changeSet, changes) = GetLocalChanges(effectiveDefinition, cloudSnapshot, fileAccessor, changeToken, isRemoteChange: false, deferMissingParents: true, out _);
 
         var workflowChanges = GetLocalWorkflowChangesAsync(workspaceFolder, dataverseClient, syncInfo, fileAccessor, cloudSnapshot, cancellationToken);
         changes = changes.AddRange(await workflowChanges.ConfigureAwait(false));
@@ -1435,7 +1707,11 @@ internal class WorkspaceSynchronizer : IWorkspaceSynchronizer
     }
 
     public (PvaComponentChangeSet, ImmutableArray<Change>) GetLocalChanges(DefinitionBase localDefinition, DefinitionBase cloudSnapshot, IFileAccessor fileAccessor, string? changeToken, bool isRemoteChange = false)
+        => GetLocalChanges(localDefinition, cloudSnapshot, fileAccessor, changeToken, isRemoteChange, deferMissingParents: false, out _);
+
+    public (PvaComponentChangeSet, ImmutableArray<Change>) GetLocalChanges(DefinitionBase localDefinition, DefinitionBase cloudSnapshot, IFileAccessor fileAccessor, string? changeToken, bool isRemoteChange, bool deferMissingParents, out bool deferredMissingParent)
     {
+        deferredMissingParent = false;
         var changes = ImmutableArray.CreateBuilder<Change>();
         var botComponentBuilderList = new List<BotComponentChange>();
 
@@ -1522,6 +1798,11 @@ internal class WorkspaceSynchronizer : IWorkspaceSynchronizer
                 else if (isRemoteChange)
                 {
                     parentBotComponentId = localParentComponent.Id;
+                }
+                else if (deferMissingParents)
+                {
+                    deferredMissingParent = true;
+                    continue;
                 }
                 else
                 {
@@ -4360,11 +4641,10 @@ internal class WorkspaceSynchronizer : IWorkspaceSynchronizer
     public async Task<CustomConnectorPushResult> PushCustomConnectorsAsync(DirectoryPath workspaceFolder, ISyncDataverseClient dataverseClient, CancellationToken cancellationToken)
     {
         var pushedRowIds = new Dictionary<string, Guid>(StringComparer.OrdinalIgnoreCase);
-        var newlyCreated = new List<string>();
         var connectorsRoot = Path.Combine(workspaceFolder.ToString(), ConnectorsFolder);
         if (!Directory.Exists(connectorsRoot))
         {
-            return new CustomConnectorPushResult { PushedRowIds = pushedRowIds, NewlyCreatedConnectorNames = newlyCreated };
+            return new CustomConnectorPushResult { PushedRowIds = pushedRowIds };
         }
 
         var localConnectors = new List<CustomConnectorMetadata>();
@@ -4397,7 +4677,7 @@ internal class WorkspaceSynchronizer : IWorkspaceSynchronizer
 
         if (localConnectors.Count == 0)
         {
-            return new CustomConnectorPushResult { PushedRowIds = pushedRowIds, NewlyCreatedConnectorNames = newlyCreated };
+            return new CustomConnectorPushResult { PushedRowIds = pushedRowIds };
         }
 
         foreach (var local in localConnectors)
@@ -4406,18 +4686,10 @@ internal class WorkspaceSynchronizer : IWorkspaceSynchronizer
 
             try
             {
-                var created = await dataverseClient.UpsertConnectorAsync(local, cancellationToken).ConfigureAwait(false);
+                await dataverseClient.UpsertConnectorAsync(local, cancellationToken).ConfigureAwait(false);
                 if (!string.IsNullOrWhiteSpace(local.ConnectorInternalId))
                 {
                     pushedRowIds[local.ConnectorInternalId!] = local.ConnectorId;
-                }
-
-                if (created)
-                {
-                    var connectorDisplayName = !string.IsNullOrWhiteSpace(local.DisplayName)
-                        ? local.DisplayName!
-                        : (local.Name ?? local.ConnectorId.ToString());
-                    newlyCreated.Add(connectorDisplayName);
                 }
             }
             catch (OperationCanceledException)
@@ -4431,7 +4703,7 @@ internal class WorkspaceSynchronizer : IWorkspaceSynchronizer
             }
         }
 
-        return new CustomConnectorPushResult { PushedRowIds = pushedRowIds, NewlyCreatedConnectorNames = newlyCreated };
+        return new CustomConnectorPushResult { PushedRowIds = pushedRowIds };
     }
 
     private static async Task<CustomConnectorMetadata?> TryLoadLocalConnectorAsync(string folder, CancellationToken cancellationToken)

--- a/src/CopilotStudio.Sync/WorkspaceSynchronizer.cs
+++ b/src/CopilotStudio.Sync/WorkspaceSynchronizer.cs
@@ -343,7 +343,8 @@ internal class WorkspaceSynchronizer : IWorkspaceSynchronizer
         // persist updated change set on directory
         var updatedDefinition = await UpdateWorkspaceDirectoryAsync(fileAccessor, updatedChangeSet, previousDefinition, deletedComponents.ToArray(), cancellationToken: cancellationToken).ConfigureAwait(false);
 
-        await WriteCustomConnectorsAsync(fileAccessor, workspaceFolder, updatedDefinition, dataverseClient, cancellationToken).ConfigureAwait(false);
+        var connectorResolvedDefinition = await ResolveConnectionReferenceConnectorIdsAsync(updatedDefinition, dataverseClient, cancellationToken).ConfigureAwait(false);
+        await WriteCustomConnectorsAsync(fileAccessor, workspaceFolder, connectorResolvedDefinition, dataverseClient, cancellationToken).ConfigureAwait(false);
 
         return updatedDefinition;
     }
@@ -799,6 +800,7 @@ internal class WorkspaceSynchronizer : IWorkspaceSynchronizer
             var cloudSnapshot = ReadCloudCacheSnapshot(fileAccessor) ?? throw new InvalidOperationException("Unable to read cloud cache from .mcs/botdefinition.json");
             var changeToken = await GetChangeTokenOrNullAsync(fileAccessor, cancellationToken).ConfigureAwait(false);
             var effectiveDefinition = OverlayCliConnectionReferences(workspaceDefinition, fileAccessor, cancellationToken);
+            effectiveDefinition = await ResolveConnectionReferenceConnectorIdsAsync(effectiveDefinition, dataverseClient, cancellationToken).ConfigureAwait(false);
 
             var (changeSet, changes) = GetLocalChanges(effectiveDefinition, cloudSnapshot, fileAccessor, changeToken, isRemoteChange: false, deferMissingParents: true, out var deferredMissingParent);
 

--- a/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/ConnectionHelper.cs
+++ b/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/ConnectionHelper.cs
@@ -1,0 +1,80 @@
+namespace Microsoft.PowerPlatformLS.Impl.PullAgent
+{
+    using Microsoft.Agents.ObjectModel;
+    using Microsoft.CommonLanguageServerProtocol.Framework;
+    using Microsoft.CopilotStudio.McsCore;
+    using Microsoft.CopilotStudio.Sync;
+    using Microsoft.CopilotStudio.Sync.Dataverse;
+    using Microsoft.PowerPlatformLS.Impl.PullAgent.Auth;
+    using System;
+    using System.Collections.Immutable;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    internal static class ConnectionHelper
+    {
+        public static void ApplyConnectionContext(IIslandControlPlaneService islandControlPlaneService, ITokenManager dataverseTokenManager, LspDataverseHttpClientAccessor dataverseHttpClientAccessor, ISyncDataverseClient dataverseClient, DataverseRequest request)
+        {
+            islandControlPlaneService.SetConnectionContext(request.EnvironmentInfo.AgentManagementUrl, request.AccountInfo.ClusterCategory);
+            dataverseTokenManager.SetTokens(request.DataverseAccessToken, request.CopilotStudioAccessToken);
+            dataverseHttpClientAccessor.SetDataverseUrl(new Uri(request.EnvironmentInfo.DataverseUrl));
+            dataverseClient.SetDataverseUrl(request.EnvironmentInfo.DataverseUrl);
+        }
+
+        public static AgentSyncInfo BuildDefaultSyncInfo(DataverseRequest request) => new()
+        {
+            AgentId = Guid.Empty,
+            DataverseEndpoint = new Uri(request.EnvironmentInfo.DataverseUrl),
+            EnvironmentId = request.EnvironmentInfo.EnvironmentId,
+            AccountInfo = request.AccountInfo,
+            SolutionVersions = request.SolutionVersions,
+            AgentManagementEndpoint = new Uri(request.EnvironmentInfo.AgentManagementUrl)
+        };
+
+        public static async Task<ImmutableArray<ConnectionNeeded>> ProvisionAndGetConnectionsAsync(IWorkspaceSynchronizer synchronizer, DirectoryPath workspaceFolder, DefinitionBase definition, ISyncDataverseClient dataverseClient, CancellationToken cancellationToken)
+        {
+            var connectorPushResult = await synchronizer.PushCustomConnectorsAsync(workspaceFolder, dataverseClient, cancellationToken);
+            await synchronizer.ProvisionConnectionReferencesAsync(workspaceFolder, definition, dataverseClient, cancellationToken, connectorPushResult.PushedRowIds);
+            var agentConnections = await synchronizer.GetAgentConnectionReferencesAsync(workspaceFolder, definition, dataverseClient, cancellationToken);
+            return agentConnections.ToImmutableArray();
+        }
+
+        public static async Task BindConnectionsAsync(ISyncDataverseClient dataverseClient, ImmutableArray<ConnectionBindingInput> bindings, ILspLogger logger, CancellationToken cancellationToken)
+        {
+            if (bindings.IsDefaultOrEmpty)
+            {
+                return;
+            }
+
+            foreach (var binding in bindings)
+            {
+                if (string.IsNullOrWhiteSpace(binding.ConnectionReferenceLogicalName) || string.IsNullOrWhiteSpace(binding.ConnectionLogicalName))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    await dataverseClient.BindConnectionReferenceAsync(binding.ConnectionReferenceLogicalName, binding.ConnectionLogicalName, cancellationToken, binding.ConnectionDisplayName);
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    logger.LogSensitiveInformation($"Failed to bind connection reference '{binding.ConnectionReferenceLogicalName}': {ex.Message}", "Failed to bind a connection reference.");
+                    throw new ConnectionBindingException("Failed to bind a connection reference.", ex);
+                }
+            }
+        }
+    }
+
+    internal sealed class ConnectionBindingException : InvalidOperationException
+    {
+        public ConnectionBindingException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/DependencyInjection/PullAgentLspModule.cs
+++ b/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/DependencyInjection/PullAgentLspModule.cs
@@ -78,6 +78,8 @@
             services.AddSingleton<IMethodHandler, GetRemoteFileHandler>();
             services.AddSingleton<IMethodHandler, GetWorkspaceDetailsHandler>();
             services.AddSingleton<IMethodHandler, ReattachAgentHandler>();
+            services.AddSingleton<IMethodHandler, PrepareReattachHandler>();
+            services.AddSingleton<IMethodHandler, PreparePushHandler>();
 
             void AddHttpClient<THandler>(string name) where THandler : DelegatingHandler
             {

--- a/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/PreparePushHandler.cs
+++ b/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/PreparePushHandler.cs
@@ -1,0 +1,85 @@
+namespace Microsoft.PowerPlatformLS.Impl.PullAgent
+{
+    using Microsoft.Agents.Platform.Content.Exceptions;
+    using Microsoft.CommonLanguageServerProtocol.Framework;
+    using Microsoft.CopilotStudio.Sync;
+    using Microsoft.CopilotStudio.Sync.Dataverse;
+    using Microsoft.CopilotStudio.McsCore;
+    using Microsoft.PowerPlatformLS.Contracts.FileLayout;
+    using Microsoft.PowerPlatformLS.Contracts.Internal.Models;
+    using Microsoft.PowerPlatformLS.Impl.PullAgent.Auth;
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Prepares connections for a push of an already-connected agent: provisions custom connectors and connection
+    /// references, then returns the connection references the client must fulfill before <see cref="SyncAgentRequest"/>.
+    /// </summary>
+    [LanguageServerEndpoint(PreparePushRequest.MessageName, LanguageServerConstants.DefaultLanguageName)]
+    internal class PreparePushHandler : IRequestHandler<PreparePushRequest, PreparePushResponse, RequestContext>
+    {
+        private readonly IIslandControlPlaneService _islandControlPlaneService;
+        private readonly IWorkspaceSynchronizer _workspaceSynchronizer;
+        private readonly ITokenManager _dataverseTokenManager;
+        private readonly ISyncDataverseClient _dataverseClient;
+        private readonly LspDataverseHttpClientAccessor _dataverseHttpClientAccessor;
+        private readonly ILspLogger _logger;
+
+        public bool MutatesSolutionState => true;
+
+        public PreparePushHandler(
+            IIslandControlPlaneService islandControlPlaneService,
+            IWorkspaceSynchronizer workspaceSynchronizer,
+            ITokenManager dataverseTokenManager,
+            ISyncDataverseClient dataverseClient,
+            LspDataverseHttpClientAccessor dataverseHttpClientAccessor,
+            ILspLogger logger)
+        {
+            _islandControlPlaneService = islandControlPlaneService;
+            _workspaceSynchronizer = workspaceSynchronizer ?? throw new ArgumentNullException(nameof(workspaceSynchronizer));
+            _dataverseTokenManager = dataverseTokenManager ?? throw new ArgumentNullException(nameof(dataverseTokenManager));
+            _dataverseClient = dataverseClient ?? throw new ArgumentNullException(nameof(dataverseClient));
+            _dataverseHttpClientAccessor = dataverseHttpClientAccessor ?? throw new ArgumentNullException(nameof(dataverseHttpClientAccessor));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public async Task<PreparePushResponse> HandleRequestAsync(PreparePushRequest request, RequestContext context, CancellationToken cancellationToken)
+        {
+            try
+            {
+                ConnectionHelper.ApplyConnectionContext(_islandControlPlaneService, _dataverseTokenManager, _dataverseHttpClientAccessor, _dataverseClient, request);
+                var workspace = (IMcsWorkspace)context.Workspace;
+                var classification = AgentClassifier.Classify(workspace.Definition, workspace.FolderPath.ToString());
+
+                if (!classification.Allows(SyncOperation.Push))
+                {
+                    return new PreparePushResponse()
+                    {
+                        Code = 400,
+                        Message = AuthoringSupportGate.DescribeBlocked(classification, SyncOperation.Push),
+                    };
+                }
+
+                var agentConnections = await ConnectionHelper.ProvisionAndGetConnectionsAsync(_workspaceSynchronizer, workspace.FolderPath, workspace.Definition, _dataverseClient, cancellationToken);
+
+                return new PreparePushResponse()
+                {
+                    Code = 200,
+                    Message = string.Empty,
+                    AgentConnections = agentConnections,
+                };
+            }
+            catch (DataverseBadRequestException ex)
+            {
+                _logger.LogException(ex);
+                return new PreparePushResponse() { Code = ex.StatusCode, Message = ex.Message };
+            }
+            catch (Exception ex)
+            {
+                _logger.LogException(ex);
+                return new PreparePushResponse() { Code = 500, Message = ex.Message };
+            }
+        }
+    }
+}

--- a/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/PreparePushRequest.cs
+++ b/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/PreparePushRequest.cs
@@ -1,0 +1,11 @@
+namespace Microsoft.PowerPlatformLS.Impl.PullAgent
+{
+    using Microsoft.PowerPlatformLS.Contracts.Lsp.Models;
+
+    internal class PreparePushRequest : DataverseRequest, IHasWorkspace
+    {
+        public const string MessageName = "powerplatformls/preparePush";
+
+        public required Uri WorkspaceUri { get; set; }
+    }
+}

--- a/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/PreparePushResponse.cs
+++ b/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/PreparePushResponse.cs
@@ -1,0 +1,11 @@
+namespace Microsoft.PowerPlatformLS.Impl.PullAgent
+{
+    using Microsoft.CopilotStudio.Sync;
+    using Microsoft.PowerPlatformLS.Contracts.Lsp.Models;
+    using System.Collections.Immutable;
+
+    internal class PreparePushResponse : ResponseBase
+    {
+        public ImmutableArray<ConnectionNeeded> AgentConnections { get; init; } = ImmutableArray<ConnectionNeeded>.Empty;
+    }
+}

--- a/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/PrepareReattachHandler.cs
+++ b/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/PrepareReattachHandler.cs
@@ -1,0 +1,162 @@
+namespace Microsoft.PowerPlatformLS.Impl.PullAgent
+{
+    using Microsoft.Agents.ObjectModel;
+    using Microsoft.Agents.Platform.Content.Exceptions;
+    using Microsoft.CommonLanguageServerProtocol.Framework;
+    using Microsoft.CopilotStudio.Sync;
+    using Microsoft.CopilotStudio.Sync.Dataverse;
+    using Microsoft.CopilotStudio.McsCore;
+    using Microsoft.PowerPlatformLS.Contracts.FileLayout;
+    using Microsoft.PowerPlatformLS.Contracts.Internal.Models;
+    using Microsoft.PowerPlatformLS.Impl.PullAgent.Auth;
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Prepares connections for a reattach: validates the agent directory, provisions the cloud agent (creating it when missing), provisions custom connectors and connection references, then returns the connection
+    /// references the client must fulfill before finalizing the reattach (<see cref="ReattachAgentRequest"/>).
+    /// </summary>
+    [LanguageServerEndpoint(PrepareReattachRequest.MessageName, LanguageServerConstants.DefaultLanguageName)]
+    internal class PrepareReattachHandler : IRequestHandler<PrepareReattachRequest, PrepareReattachResponse, RequestContext>
+    {
+        private readonly IIslandControlPlaneService _islandControlPlaneService;
+        private readonly IWorkspaceSynchronizer _workspaceSynchronizer;
+        private readonly ITokenManager _dataverseTokenManager;
+        private readonly ISyncDataverseClient _dataverseClient;
+        private readonly LspDataverseHttpClientAccessor _dataverseHttpClientAccessor;
+        private readonly ILspLogger _logger;
+
+        public bool MutatesSolutionState => true;
+
+        public PrepareReattachHandler(
+            IIslandControlPlaneService islandControlPlaneService,
+            IWorkspaceSynchronizer workspaceSynchronizer,
+            ITokenManager dataverseTokenManager,
+            ISyncDataverseClient dataverseClient,
+            LspDataverseHttpClientAccessor dataverseHttpClientAccessor,
+            ILspLogger logger)
+        {
+            _islandControlPlaneService = islandControlPlaneService;
+            _workspaceSynchronizer = workspaceSynchronizer ?? throw new ArgumentNullException(nameof(workspaceSynchronizer));
+            _dataverseTokenManager = dataverseTokenManager ?? throw new ArgumentNullException(nameof(dataverseTokenManager));
+            _dataverseClient = dataverseClient ?? throw new ArgumentNullException(nameof(dataverseClient));
+            _dataverseHttpClientAccessor = dataverseHttpClientAccessor ?? throw new ArgumentNullException(nameof(dataverseHttpClientAccessor));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public async Task<PrepareReattachResponse> HandleRequestAsync(PrepareReattachRequest request, RequestContext context, CancellationToken cancellationToken)
+        {
+            var defaultSyncInfo = ConnectionHelper.BuildDefaultSyncInfo(request);
+
+            try
+            {
+                ConnectionHelper.ApplyConnectionContext(_islandControlPlaneService, _dataverseTokenManager, _dataverseHttpClientAccessor, _dataverseClient, request);
+
+                var workspace = (IMcsWorkspace)context.Workspace;
+                var workspaceFolder = request.WorkspaceUri.ToDirectoryPath();
+                bool isNewAgent = false;
+                var language = context.Language;
+
+                if (!language.IsValidAgentDirectory(workspaceFolder, out _))
+                {
+                    return CreateErrorResponse(400, "Agent directory is not valid for reattach. Try opening root of the selected agent folder.", defaultSyncInfo);
+                }
+
+                if (_workspaceSynchronizer.IsSyncInfoAvailable(workspaceFolder))
+                {
+                    return CreateErrorResponse(400, "This agent is already connected to a cloud instance.", defaultSyncInfo);
+                }
+
+                string thisSchema = string.Empty;
+                string agentDisplayName = "ReattachAgent";
+
+                if (workspace.Definition is BotComponentCollectionDefinition collection)
+                {
+                    thisSchema = collection.GetRootSchemaName();
+                }
+                else if (workspace.Definition is BotDefinition bot)
+                {
+                    thisSchema = bot.GetRootSchemaName();
+                    if (!string.IsNullOrEmpty(bot.Entity?.DisplayName))
+                    {
+                        agentDisplayName = bot.Entity.DisplayName;
+                    }
+                }
+
+                if (!string.IsNullOrWhiteSpace(thisSchema) && !SchemaNameValidator.IsValid(thisSchema))
+                {
+                    return CreateErrorResponse(400, $"Invalid schema name '{thisSchema}'.", defaultSyncInfo);
+                }
+
+                var classification = AgentClassifier.Classify(workspace.Definition, workspaceFolder.ToString());
+                if (!classification.Allows(SyncOperation.Reattach))
+                {
+                    return CreateErrorResponse(400, AuthoringSupportGate.DescribeBlocked(classification, SyncOperation.Reattach), defaultSyncInfo);
+                }
+
+                var agentId = await _dataverseClient.GetAgentIdBySchemaNameAsync(thisSchema, cancellationToken);
+                bool updateWorkspaceDirectory = false;
+                if (agentId == Guid.Empty)
+                {
+                    var authoringShape = workspace.AuthoringShape;
+                    if (authoringShape == AuthoringShape.Unknown)
+                    {
+                        authoringShape = AgentClassifier.DetectAuthoringShapeFromFolder(workspaceFolder.ToString());
+                    }
+
+                    var newAgent = await _dataverseClient.CreateNewAgentAsync(agentDisplayName, thisSchema, authoringShape, cancellationToken);
+                    agentId = newAgent.AgentId;
+                    isNewAgent = true;
+
+                    if (!string.IsNullOrWhiteSpace(thisSchema) && thisSchema != newAgent.SchemaName)
+                    {
+                        _logger.LogSensitiveInformation($"PrepareReattachInfo: Local schema name '{thisSchema}' is different with the new agent's schema name '{newAgent.SchemaName}'.", "PrepareReattachInfo: Local schema name differs from the new agent's schema name.");
+                    }
+
+                    updateWorkspaceDirectory = thisSchema != newAgent.SchemaName;
+                }
+
+                var syncInfo = new AgentSyncInfo()
+                {
+                    AgentId = agentId,
+                    DataverseEndpoint = new Uri(request.EnvironmentInfo.DataverseUrl),
+                    EnvironmentId = request.EnvironmentInfo.EnvironmentId,
+                    AccountInfo = request.AccountInfo,
+                    SolutionVersions = request.SolutionVersions,
+                    AgentManagementEndpoint = new Uri(request.EnvironmentInfo.AgentManagementUrl)
+                };
+
+                var agentConnections = await ConnectionHelper.ProvisionAndGetConnectionsAsync(
+                    _workspaceSynchronizer, workspaceFolder, workspace.Definition, _dataverseClient, cancellationToken);
+
+                return new PrepareReattachResponse()
+                {
+                    Code = 200,
+                    Message = string.Empty,
+                    AgentSyncInfo = syncInfo,
+                    IsNewAgent = isNewAgent,
+                    UpdateWorkspaceDirectory = updateWorkspaceDirectory,
+                    AgentConnections = agentConnections,
+                };
+            }
+            catch (DataverseBadRequestException ex)
+            {
+                _logger.LogException(ex);
+                return CreateErrorResponse(ex.StatusCode, ex.Message, defaultSyncInfo);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogException(ex);
+                return CreateErrorResponse(500, ex.Message, defaultSyncInfo);
+            }
+        }
+
+        private static PrepareReattachResponse CreateErrorResponse(int code, string message, AgentSyncInfo defaultSyncInfo) => new()
+        {
+            Code = code,
+            Message = message,
+            AgentSyncInfo = defaultSyncInfo,
+        };
+    }
+}

--- a/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/PrepareReattachRequest.cs
+++ b/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/PrepareReattachRequest.cs
@@ -1,0 +1,11 @@
+namespace Microsoft.PowerPlatformLS.Impl.PullAgent
+{
+    using Microsoft.PowerPlatformLS.Contracts.Lsp.Models;
+
+    internal class PrepareReattachRequest : DataverseRequest, IHasWorkspace
+    {
+        public const string MessageName = "powerplatformls/prepareReattach";
+
+        public required Uri WorkspaceUri { get; set; }
+    }
+}

--- a/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/PrepareReattachResponse.cs
+++ b/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/PrepareReattachResponse.cs
@@ -1,0 +1,17 @@
+namespace Microsoft.PowerPlatformLS.Impl.PullAgent
+{
+    using Microsoft.CopilotStudio.Sync;
+    using Microsoft.PowerPlatformLS.Contracts.Lsp.Models;
+    using System.Collections.Immutable;
+
+    internal class PrepareReattachResponse : ResponseBase
+    {
+        public AgentSyncInfo? AgentSyncInfo { get; init; }
+
+        public bool IsNewAgent { get; init; } = false;
+
+        public bool UpdateWorkspaceDirectory { get; init; } = false;
+
+        public ImmutableArray<ConnectionNeeded> AgentConnections { get; init; } = ImmutableArray<ConnectionNeeded>.Empty;
+    }
+}

--- a/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/ReattachAgentHandler.cs
+++ b/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/ReattachAgentHandler.cs
@@ -96,7 +96,17 @@ namespace Microsoft.PowerPlatformLS.Impl.PullAgent
                     };
                 }
 
-                if (request.AgentSyncInfo is null && !_workspaceSynchronizer.IsSyncInfoAvailable(workspaceFolder))
+                if (_workspaceSynchronizer.IsSyncInfoAvailable(workspaceFolder))
+                {
+                    return new ReattachAgentResponse()
+                    {
+                        Code = 400,
+                        Message = "This agent is already connected to a cloud instance.",
+                        AgentSyncInfo = defaultSyncInfo
+                    };
+                }
+
+                if (request.AgentSyncInfo is null)
                 {
                     return new ReattachAgentResponse()
                     {
@@ -106,7 +116,7 @@ namespace Microsoft.PowerPlatformLS.Impl.PullAgent
                     };
                 }
 
-                var syncInfo = request.AgentSyncInfo ?? await _workspaceSynchronizer.GetSyncInfoAsync(workspaceFolder);
+                var syncInfo = request.AgentSyncInfo;
                 var agentId = syncInfo.AgentId;
                 var operationContext = await _operationContextProvider.GetAsync(syncInfo);
 

--- a/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/ReattachAgentHandler.cs
+++ b/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/ReattachAgentHandler.cs
@@ -1,6 +1,5 @@
 namespace Microsoft.PowerPlatformLS.Impl.PullAgent
 {
-    using Microsoft.Agents.ObjectModel;
     using Microsoft.Agents.Platform.Content.Exceptions;
     using Microsoft.CommonLanguageServerProtocol.Framework;
     using Microsoft.CopilotStudio.Sync;
@@ -10,10 +9,13 @@ namespace Microsoft.PowerPlatformLS.Impl.PullAgent
     using Microsoft.PowerPlatformLS.Contracts.Internal.Models;
     using Microsoft.PowerPlatformLS.Impl.PullAgent.Auth;
     using System;
-    using System.Collections.Immutable;
     using System.Threading;
     using System.Threading.Tasks;
 
+    /// <summary>
+    /// Binds the connections the client created after <see cref="PrepareReattachRequest"/>, then upserts workflows and AI prompts and syncs the workspace.
+    /// Binding runs before the workflow upsert so workflows that depend on those connections succeed.
+    /// </summary>
     [LanguageServerEndpoint(ReattachAgentRequest.MessageName, LanguageServerConstants.DefaultLanguageName)]
     internal class ReattachAgentHandler : IRequestHandler<ReattachAgentRequest, ReattachAgentResponse, RequestContext>
     {
@@ -55,7 +57,6 @@ namespace Microsoft.PowerPlatformLS.Impl.PullAgent
         public async Task<ReattachAgentResponse> HandleRequestAsync(ReattachAgentRequest request, RequestContext context, CancellationToken cancellationToken)
         {
             var workspaceFolder = request.WorkspaceUri.ToDirectoryPath();
-            bool isNewAgent = false;
 
             var defaultSyncInfo = new AgentSyncInfo()
             {
@@ -69,17 +70,12 @@ namespace Microsoft.PowerPlatformLS.Impl.PullAgent
 
             try
             {
-                _islandControlPlaneService.SetConnectionContext(
-                    request.EnvironmentInfo.AgentManagementUrl,
-                    request.AccountInfo.ClusterCategory);
-                _dataverseTokenManager.SetTokens(request.DataverseAccessToken, request.CopilotStudioAccessToken);
-                _dataverseHttpClientAccessor.SetDataverseUrl(new Uri(request.EnvironmentInfo.DataverseUrl));
-                _dataverseClient.SetDataverseUrl(request.EnvironmentInfo.DataverseUrl);
+                ConnectionHelper.ApplyConnectionContext(_islandControlPlaneService, _dataverseTokenManager, _dataverseHttpClientAccessor, _dataverseClient, request);
 
                 var workspace = (IMcsWorkspace)context.Workspace;
                 var language = context.Language;
 
-                if (!language.IsValidAgentDirectory(workspaceFolder, out var validDirectory))
+                if (!language.IsValidAgentDirectory(workspaceFolder, out _))
                 {
                     return new ReattachAgentResponse()
                     {
@@ -89,48 +85,6 @@ namespace Microsoft.PowerPlatformLS.Impl.PullAgent
                     };
                 }
 
-                if (_workspaceSynchronizer.IsSyncInfoAvailable(workspaceFolder))
-                {
-                    return new ReattachAgentResponse()
-                    {
-                        Code = 400,
-                        Message = $"This agent is already connected to a cloud instance {request.EnvironmentInfo.AgentManagementUrl}.",
-                        AgentSyncInfo = defaultSyncInfo
-                    };
-                }
-
-                string thisSchema = string.Empty;
-                string agentDisplayName = "ReattachAgent";
-
-                if (workspace.Definition is BotComponentCollectionDefinition collection)
-                {
-                    thisSchema = collection.GetRootSchemaName();
-                }
-                else if (workspace.Definition is BotDefinition bot)
-                {
-                    thisSchema = bot.GetRootSchemaName();
-                    if (!string.IsNullOrEmpty(bot.Entity?.DisplayName))
-                    {
-                        agentDisplayName = bot.Entity.DisplayName;
-                    }
-                }
-
-                if (!string.IsNullOrWhiteSpace(thisSchema) && !SchemaNameValidator.IsValid(thisSchema))
-                {
-                    return new ReattachAgentResponse()
-                    {
-                        Code = 400,
-                        Message = $"Invalid schema name '{thisSchema}'.",
-                        AgentSyncInfo = defaultSyncInfo
-                    };
-                }
-
-                // Fail-closed support gate (TDD D35): reattach creates/updates a cloud agent, so
-                // it requires a Supported authoring shape. Classify from the definition AND the
-                // workspace layout: a plain classic agent resolves to Supported via its layout, a
-                // component-collection root is a recognized format, but an explicitly unrecognized
-                // shape stays Provisional. Return an explicit 400 (this handler maps thrown
-                // exceptions to 500).
                 var classification = AgentClassifier.Classify(workspace.Definition, workspaceFolder.ToString());
                 if (!classification.Allows(SyncOperation.Reattach))
                 {
@@ -142,57 +96,35 @@ namespace Microsoft.PowerPlatformLS.Impl.PullAgent
                     };
                 }
 
-                var agentId = await _dataverseClient.GetAgentIdBySchemaNameAsync(thisSchema, cancellationToken);
-                bool updateWorkspaceDirectory = false;
-                if (agentId == Guid.Empty)
+                if (request.AgentSyncInfo is null && !_workspaceSynchronizer.IsSyncInfoAvailable(workspaceFolder))
                 {
-                    var authoringShape = workspace.AuthoringShape;
-                    if (authoringShape == AuthoringShape.Unknown)
+                    return new ReattachAgentResponse()
                     {
-                        authoringShape = AgentClassifier.DetectAuthoringShapeFromFolder(workspaceFolder.ToString());
-                    }
-
-                    var newAgent = await _dataverseClient.CreateNewAgentAsync(agentDisplayName, thisSchema, authoringShape, cancellationToken);
-                    agentId = newAgent.AgentId;
-                    isNewAgent = true;
-
-                    if (!string.IsNullOrWhiteSpace(thisSchema) && thisSchema != newAgent.SchemaName)
-                    {
-                        _logger.LogError($"ReattachAgentInfo: Local schema name '{thisSchema}' is different with the new agent's schema name '{newAgent.SchemaName}'.");
-                    }
-
-                    // Update if schema name is new and generated when creating new agent.
-                    updateWorkspaceDirectory = thisSchema != newAgent.SchemaName;
+                        Code = 400,
+                        Message = "Reattach was not prepared for this agent. Run reattach again.",
+                        AgentSyncInfo = defaultSyncInfo
+                    };
                 }
 
-                var syncInfo = new AgentSyncInfo()
-                {
-                    AgentId = agentId,
-                    DataverseEndpoint = new Uri(request.EnvironmentInfo.DataverseUrl),
-                    EnvironmentId = request.EnvironmentInfo.EnvironmentId,
-                    AccountInfo = request.AccountInfo,
-                    SolutionVersions = request.SolutionVersions,
-                    AgentManagementEndpoint = new Uri(request.EnvironmentInfo.AgentManagementUrl)
-                };
-
-                await _workspaceSynchronizer.SaveSyncInfoAsync(workspaceFolder, syncInfo);
+                var syncInfo = request.AgentSyncInfo ?? await _workspaceSynchronizer.GetSyncInfoAsync(workspaceFolder);
+                var agentId = syncInfo.AgentId;
                 var operationContext = await _operationContextProvider.GetAsync(syncInfo);
 
-                var connectorPushResult = await _workspaceSynchronizer.PushCustomConnectorsAsync(workspaceFolder, _dataverseClient, cancellationToken);
-                await _workspaceSynchronizer.ProvisionConnectionReferencesAsync(workspaceFolder, workspace.Definition, _dataverseClient, cancellationToken, connectorPushResult.PushedRowIds);
+                await ConnectionHelper.BindConnectionsAsync(_dataverseClient, request.ConnectionBindings, _logger, cancellationToken);
+
                 var (workflowResponse, cloudFlowMetadata) = await _workspaceSynchronizer.UpsertWorkflowForAgentAsync(workspaceFolder, _dataverseClient, agentId, cancellationToken);
                 var (aiPromptResponse, _) = await _workspaceSynchronizer.UpsertAIPromptsForAgentAsync(workspaceFolder, _dataverseClient, agentId, cancellationToken);
-                await _workspaceSynchronizer.SyncWorkspaceAsync(workspaceFolder, operationContext, changeToken: null, updateWorkspaceDirectory, _dataverseClient, syncInfo, cloudFlowMetadata, cancellationToken: cancellationToken);
+                await _workspaceSynchronizer.SyncWorkspaceAsync(workspaceFolder, operationContext, changeToken: null, request.UpdateWorkspaceDirectory, _dataverseClient, syncInfo, cloudFlowMetadata, cancellationToken: cancellationToken);
+                await _workspaceSynchronizer.SaveSyncInfoAsync(workspaceFolder, syncInfo);
 
                 return new ReattachAgentResponse()
                 {
                     Code = 200,
                     Message = string.Empty,
                     AgentSyncInfo = syncInfo,
-                    IsNewAgent = isNewAgent,
+                    IsNewAgent = request.IsNewAgent,
                     WorkflowResponse = workflowResponse,
                     AIPromptResponse = aiPromptResponse,
-                    NewlyCreatedCustomConnectors = connectorPushResult.NewlyCreatedConnectorNames.ToImmutableArray(),
                 };
             }
             catch (DataverseBadRequestException ex)
@@ -205,8 +137,19 @@ namespace Microsoft.PowerPlatformLS.Impl.PullAgent
                     AgentSyncInfo = defaultSyncInfo
                 };
             }
+            catch (ConnectionBindingException ex)
+            {
+                _logger.LogException(ex);
+                return new ReattachAgentResponse()
+                {
+                    Code = 400,
+                    Message = ex.Message,
+                    AgentSyncInfo = defaultSyncInfo
+                };
+            }
             catch (Exception ex)
             {
+                _logger.LogException(ex);
                 return new ReattachAgentResponse()
                 {
                     Code = 500,

--- a/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/ReattachAgentRequest.cs
+++ b/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/ReattachAgentRequest.cs
@@ -1,6 +1,8 @@
 ﻿namespace Microsoft.PowerPlatformLS.Impl.PullAgent
 {
+    using Microsoft.CopilotStudio.Sync;
     using Microsoft.PowerPlatformLS.Contracts.Lsp.Models;
+    using System.Collections.Immutable;
 
     /// <summary>
     /// ReattachAgentRequest is used to reattach the agent to a workspace.
@@ -10,5 +12,25 @@
         public const string MessageName = "powerplatformls/reattachAgent";
 
         public required Uri WorkspaceUri { get; set; }
+
+        public AgentSyncInfo? AgentSyncInfo { get; set; }
+
+        public ImmutableArray<ConnectionBindingInput> ConnectionBindings { get; set; } = ImmutableArray<ConnectionBindingInput>.Empty;
+
+        public bool IsNewAgent { get; set; } = false;
+
+        public bool UpdateWorkspaceDirectory { get; set; } = false;
+    }
+
+    /// <summary>
+    /// A connection reference logical name paired with the logical name of the connection to bind it to.
+    /// </summary>
+    internal class ConnectionBindingInput
+    {
+        public string ConnectionReferenceLogicalName { get; set; } = string.Empty;
+
+        public string ConnectionLogicalName { get; set; } = string.Empty;
+
+        public string? ConnectionDisplayName { get; set; }
     }
 }

--- a/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/ReattachAgentResponse.cs
+++ b/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/ReattachAgentResponse.cs
@@ -14,11 +14,5 @@
         public ImmutableArray<WorkflowResponse> WorkflowResponse { get; init; } = ImmutableArray<WorkflowResponse>.Empty;
 
         public ImmutableArray<SyncDataverseClient.AIPromptResponse> AIPromptResponse { get; init; } = ImmutableArray<SyncDataverseClient.AIPromptResponse>.Empty;
-
-        /// <summary>
-        /// Display names of custom connectors that were newly created in Dataverse during reattach.
-        /// Empty when no new connectors were created.
-        /// </summary>
-        public ImmutableArray<string> NewlyCreatedCustomConnectors { get; init; } = ImmutableArray<string>.Empty;
     }
 }

--- a/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/SyncAgentRequest.cs
+++ b/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/SyncAgentRequest.cs
@@ -1,9 +1,12 @@
 ﻿namespace Microsoft.PowerPlatformLS.Impl.PullAgent
 {
     using Microsoft.PowerPlatformLS.Contracts.Lsp.Models;
+    using System.Collections.Immutable;
 
     internal class SyncAgentRequest : DataverseRequest, IHasWorkspace
     {
         public required Uri WorkspaceUri { get; set; }
+
+        public ImmutableArray<ConnectionBindingInput> ConnectionBindings { get; set; } = ImmutableArray<ConnectionBindingInput>.Empty;
     }
 }

--- a/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/SyncAgentResponse.cs
+++ b/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/SyncAgentResponse.cs
@@ -12,11 +12,5 @@
         public ImmutableArray<WorkflowResponse> WorkflowResponse { get; init; } = ImmutableArray<WorkflowResponse>.Empty;
 
         public ImmutableArray<SyncDataverseClient.AIPromptResponse> AIPromptResponse { get; init; } = ImmutableArray<SyncDataverseClient.AIPromptResponse>.Empty;
-
-        /// <summary>
-        /// Display names of custom connectors that were newly created in Dataverse
-        /// during this push (i.e. did not exist before). Empty when none were created.
-        /// </summary>
-        public ImmutableArray<string> NewlyCreatedCustomConnectors { get; init; } = ImmutableArray<string>.Empty;
     }
 }

--- a/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/SyncHandler.cs
+++ b/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/SyncHandler.cs
@@ -60,7 +60,7 @@ namespace Microsoft.PowerPlatformLS.Impl.PullAgent
 
                 var operationContext = await _operationContextProvider.GetAsync(syncInfo);
 
-                var (updatedDefinition, workflowResponse, aiPromptResponse, newlyCreatedCustomConnectors) = await ExecuteAsync(workspace, operationContext, _dataverseClient, syncInfo, cancellationToken);
+                var (updatedDefinition, workflowResponse, aiPromptResponse) = await ExecuteAsync(workspace, operationContext, _dataverseClient, syncInfo, request.ConnectionBindings, cancellationToken);
                 var (_, localChanges) = await _synchronizer.GetLocalChangesAsync(workspace.FolderPath, updatedDefinition, _dataverseClient, syncInfo, cancellationToken);
 
                 return new SyncAgentResponse
@@ -70,7 +70,6 @@ namespace Microsoft.PowerPlatformLS.Impl.PullAgent
                     LocalChanges = localChanges,
                     WorkflowResponse = workflowResponse,
                     AIPromptResponse = aiPromptResponse,
-                    NewlyCreatedCustomConnectors = newlyCreatedCustomConnectors,
                 };
             }
             catch (InvalidOperationException ex)
@@ -102,11 +101,12 @@ namespace Microsoft.PowerPlatformLS.Impl.PullAgent
             }
         }
 
-        protected abstract Task<(DefinitionBase, ImmutableArray<WorkflowResponse>, ImmutableArray<SyncDataverseClient.AIPromptResponse>, ImmutableArray<string>)> ExecuteAsync(
+        protected abstract Task<(DefinitionBase, ImmutableArray<WorkflowResponse>, ImmutableArray<SyncDataverseClient.AIPromptResponse>)> ExecuteAsync(
             IMcsWorkspace workspace,
             AuthoringOperationContextBase operationContext,
             ISyncDataverseClient dataverseClient,
             AgentSyncInfo syncInfo,
+            ImmutableArray<ConnectionBindingInput> connectionBindings,
             CancellationToken cancellationToken);
     }
 }

--- a/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/SyncPullHandler.cs
+++ b/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/SyncPullHandler.cs
@@ -19,9 +19,9 @@ namespace Microsoft.PowerPlatformLS.Impl.PullAgent
         {
         }
 
-        protected override async Task<(DefinitionBase, ImmutableArray<WorkflowResponse>, ImmutableArray<SyncDataverseClient.AIPromptResponse>, ImmutableArray<string>)> ExecuteAsync(IMcsWorkspace workspace, AuthoringOperationContextBase operationContext, ISyncDataverseClient dataverseClient, AgentSyncInfo syncInfo, CancellationToken cancellationToken)
+        protected override async Task<(DefinitionBase, ImmutableArray<WorkflowResponse>, ImmutableArray<SyncDataverseClient.AIPromptResponse>)> ExecuteAsync(IMcsWorkspace workspace, AuthoringOperationContextBase operationContext, ISyncDataverseClient dataverseClient, AgentSyncInfo syncInfo, ImmutableArray<ConnectionBindingInput> connectionBindings, CancellationToken cancellationToken)
         {
-            return (await _synchronizer.PullExistingChangesAsync(workspace.FolderPath, operationContext, workspace.Definition, dataverseClient, syncInfo, cancellationToken).ConfigureAwait(false), ImmutableArray<WorkflowResponse>.Empty, ImmutableArray<Microsoft.CopilotStudio.Sync.Dataverse.SyncDataverseClient.AIPromptResponse>.Empty, ImmutableArray<string>.Empty);
+            return (await _synchronizer.PullExistingChangesAsync(workspace.FolderPath, operationContext, workspace.Definition, dataverseClient, syncInfo, cancellationToken).ConfigureAwait(false), ImmutableArray<WorkflowResponse>.Empty, ImmutableArray<Microsoft.CopilotStudio.Sync.Dataverse.SyncDataverseClient.AIPromptResponse>.Empty);
         }
     }
 }

--- a/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/SyncPushHandler.cs
+++ b/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/SyncPushHandler.cs
@@ -8,9 +8,7 @@ namespace Microsoft.PowerPlatformLS.Impl.PullAgent
     using Microsoft.CopilotStudio.Sync.Dataverse;
     using Microsoft.PowerPlatformLS.Contracts.FileLayout;
     using Microsoft.PowerPlatformLS.Impl.PullAgent.Auth;
-    using System;
     using System.Collections.Immutable;
-    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -23,7 +21,7 @@ namespace Microsoft.PowerPlatformLS.Impl.PullAgent
         {
         }
 
-        protected override async Task<(DefinitionBase, ImmutableArray<WorkflowResponse>, ImmutableArray<SyncDataverseClient.AIPromptResponse>, ImmutableArray<string>)> ExecuteAsync(IMcsWorkspace workspace, AuthoringOperationContextBase operationContext, ISyncDataverseClient dataverseClient, AgentSyncInfo syncInfo, CancellationToken cancellationToken)
+        protected override async Task<(DefinitionBase, ImmutableArray<WorkflowResponse>, ImmutableArray<SyncDataverseClient.AIPromptResponse>)> ExecuteAsync(IMcsWorkspace workspace, AuthoringOperationContextBase operationContext, ISyncDataverseClient dataverseClient, AgentSyncInfo syncInfo, ImmutableArray<ConnectionBindingInput> connectionBindings, CancellationToken cancellationToken)
         {
             // Fail-closed support gate (TDD D35): push is destructive to the cloud, so it
             // requires a Supported authoring shape. Classify from the definition AND the
@@ -34,21 +32,15 @@ namespace Microsoft.PowerPlatformLS.Impl.PullAgent
             var classification = AgentClassifier.Classify(workspace.Definition, workspace.FolderPath.ToString());
             AuthoringSupportGate.EnsureAllowed(classification, SyncOperation.Push);
 
+            await _synchronizer.ProvisionConnectionReferencesAsync(workspace.FolderPath, workspace.Definition, dataverseClient, cancellationToken);
+            await ConnectionHelper.BindConnectionsAsync(dataverseClient, connectionBindings, _logger, cancellationToken);
+
             var (workflowResponse, cloudFlowMetadata) = await _synchronizer.UpsertWorkflowForAgentAsync(workspace.FolderPath, dataverseClient, syncInfo.AgentId, cancellationToken);
 
             var (aiPromptResponse, aiPromptMetadata) = await _synchronizer.UpsertAIPromptsForAgentAsync(workspace.FolderPath, dataverseClient, syncInfo.AgentId, cancellationToken);
 
-            await _synchronizer.ProvisionConnectionReferencesAsync(workspace.FolderPath, workspace.Definition, dataverseClient, cancellationToken);
-
-            // Execute the push
-            var (localChanges, changeList) = await _synchronizer.GetLocalChangesAsync(workspace.FolderPath, workspace.Definition, dataverseClient, syncInfo, cancellationToken);
-            if (!changeList.Any(c => c.SchemaName == "entity" || c.SchemaName == "icon"))
-            {
-                localChanges = localChanges.WithBot(null);
-            }
-
-            var pushResult = await _synchronizer.PushChangesetAsync(workspace.FolderPath, operationContext, localChanges, dataverseClient, syncInfo.AgentId, cloudFlowMetadata, aiPromptMetadata, cancellationToken);
-            return (workspace.Definition, workflowResponse, aiPromptResponse, pushResult.NewlyCreatedCustomConnectors.ToImmutableArray());
+            await _synchronizer.PushLocalChangesAsync(workspace.FolderPath, operationContext, workspace.Definition, dataverseClient, syncInfo, cloudFlowMetadata, aiPromptMetadata, cancellationToken);
+            return (workspace.Definition, workflowResponse, aiPromptResponse);
         }
     }
 }

--- a/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.PullAgent/DataverseClientTests.cs
+++ b/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.PullAgent/DataverseClientTests.cs
@@ -626,7 +626,8 @@
                     new
                     {
                         connectionreferenceid = connectionRefId,
-                        connectionreferencelogicalname = connectionRefName
+                        connectionreferencelogicalname = connectionRefName,
+                        connectorid = connectorId
                     }
                 }
             });
@@ -651,7 +652,6 @@
             // Act
             await client.EnsureConnectionReferenceExistsAsync(connectionRefName, connectorId, CancellationToken.None);
 
-            // Assert - only GET was called, not POST
             handlerMock.Protected().Verify(
                "SendAsync",
                Times.Once(),
@@ -662,6 +662,142 @@
                "SendAsync",
                Times.Never(),
                ItExpr.Is<HttpRequestMessage>(req => req.Method == HttpMethod.Post),
+               ItExpr.IsAny<CancellationToken>());
+
+            handlerMock.Protected().Verify(
+               "SendAsync",
+               Times.Never(),
+               ItExpr.Is<HttpRequestMessage>(req => req.Method == HttpMethod.Patch),
+               ItExpr.IsAny<CancellationToken>());
+        }
+
+        [Fact]
+        public async Task EnsureConnectionReferenceExistsAsync_RepairsConnectorId_WhenStale()
+        {
+            // Arrange
+            var connectionRefName = "cre6c_test.shared_connector.12345";
+            var desiredConnectorId = "/providers/Microsoft.PowerApps/apis/shared_connector-target";
+            var staleConnectorId = "/providers/Microsoft.PowerApps/apis/shared_connector-source";
+            var connectionRefId = Guid.NewGuid();
+            var responseBody = JsonSerializer.Serialize(new
+            {
+                value = new[]
+                {
+                    new
+                    {
+                        connectionreferenceid = connectionRefId,
+                        connectionreferencelogicalname = connectionRefName,
+                        connectorid = staleConnectorId
+                    }
+                }
+            });
+
+            HttpRequestMessage? patchRequest = null;
+            string? patchBody = null;
+            var handlerMock = new Mock<HttpMessageHandler>();
+            handlerMock
+               .Protected()
+               .Setup<Task<HttpResponseMessage>>(
+                   "SendAsync",
+                   ItExpr.Is<HttpRequestMessage>(req => req.Method == HttpMethod.Get),
+                   ItExpr.IsAny<CancellationToken>()
+               )
+               .ReturnsAsync(new HttpResponseMessage
+               {
+                   StatusCode = HttpStatusCode.OK,
+                   Content = new StringContent(responseBody, Encoding.UTF8, "application/json")
+               });
+
+            handlerMock
+               .Protected()
+               .Setup<Task<HttpResponseMessage>>(
+                   "SendAsync",
+                   ItExpr.Is<HttpRequestMessage>(req => req.Method == HttpMethod.Patch),
+                   ItExpr.IsAny<CancellationToken>()
+               )
+               .Callback<HttpRequestMessage, CancellationToken>((req, _) =>
+               {
+                   patchRequest = req;
+                   patchBody = req.Content!.ReadAsStringAsync().GetAwaiter().GetResult();
+               })
+               .ReturnsAsync(new HttpResponseMessage
+               {
+                   StatusCode = HttpStatusCode.NoContent
+               });
+
+            var httpClient = new HttpClient(handlerMock.Object);
+            var client = CreateClientFromHttpClient(httpClient);
+
+            // Act
+            await client.EnsureConnectionReferenceExistsAsync(connectionRefName, desiredConnectorId, CancellationToken.None);
+
+            handlerMock.Protected().Verify(
+               "SendAsync",
+               Times.Never(),
+               ItExpr.Is<HttpRequestMessage>(req => req.Method == HttpMethod.Post),
+               ItExpr.IsAny<CancellationToken>());
+
+            handlerMock.Protected().Verify(
+               "SendAsync",
+               Times.Once(),
+               ItExpr.Is<HttpRequestMessage>(req => req.Method == HttpMethod.Patch),
+               ItExpr.IsAny<CancellationToken>());
+
+            Assert.NotNull(patchRequest);
+            Assert.Contains(connectionRefId.ToString(), patchRequest!.RequestUri!.ToString(), StringComparison.OrdinalIgnoreCase);
+            Assert.NotNull(patchBody);
+            Assert.Contains(desiredConnectorId, patchBody!, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public async Task EnsureConnectionReferenceExistsAsync_DoesNotRepair_WhenInternalIdMatches()
+        {
+            var connectionRefName = "cre6c_test.shared_connector.12345";
+            var desiredConnectorId = "shared_commondataserviceforapps";
+            var existingConnectorId = "/providers/Microsoft.PowerApps/apis/shared_commondataserviceforapps";
+            var connectionRefId = Guid.NewGuid();
+            var responseBody = JsonSerializer.Serialize(new
+            {
+                value = new[]
+                {
+                    new
+                    {
+                        connectionreferenceid = connectionRefId,
+                        connectionreferencelogicalname = connectionRefName,
+                        connectorid = existingConnectorId
+                    }
+                }
+            });
+
+            var handlerMock = new Mock<HttpMessageHandler>();
+            handlerMock
+               .Protected()
+               .Setup<Task<HttpResponseMessage>>(
+                   "SendAsync",
+                   ItExpr.Is<HttpRequestMessage>(req => req.Method == HttpMethod.Get),
+                   ItExpr.IsAny<CancellationToken>()
+               )
+               .ReturnsAsync(new HttpResponseMessage
+               {
+                   StatusCode = HttpStatusCode.OK,
+                   Content = new StringContent(responseBody, Encoding.UTF8, "application/json")
+               });
+
+            var httpClient = new HttpClient(handlerMock.Object);
+            var client = CreateClientFromHttpClient(httpClient);
+
+            await client.EnsureConnectionReferenceExistsAsync(connectionRefName, desiredConnectorId, CancellationToken.None);
+
+            handlerMock.Protected().Verify(
+               "SendAsync",
+               Times.Never(),
+               ItExpr.Is<HttpRequestMessage>(req => req.Method == HttpMethod.Post),
+               ItExpr.IsAny<CancellationToken>());
+
+            handlerMock.Protected().Verify(
+               "SendAsync",
+               Times.Never(),
+               ItExpr.Is<HttpRequestMessage>(req => req.Method == HttpMethod.Patch),
                ItExpr.IsAny<CancellationToken>());
         }
 

--- a/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.PullAgent/Methods/ConnectionHelperTests.cs
+++ b/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.PullAgent/Methods/ConnectionHelperTests.cs
@@ -1,0 +1,166 @@
+namespace Microsoft.PowerPlatformLS.UnitTests.Impl.PullAgent.Methods
+{
+    using Microsoft.CommonLanguageServerProtocol.Framework;
+    using Microsoft.CopilotStudio.Sync;
+    using Microsoft.CopilotStudio.Sync.Dataverse;
+    using Microsoft.PowerPlatformLS.Impl.PullAgent;
+    using Moq;
+    using System;
+    using System.Collections.Immutable;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Xunit;
+
+    public class ConnectionHelperTests
+    {
+        private const string EnvironmentId = "TestEnvironment";
+        private const string DataverseUrl = "https://test.crm.dynamics.com";
+        private const string AgentManagementUrl = "https://test.agentmanagement.com";
+
+        [Fact]
+        public async Task BindConnectionsAsyncBindsAllValidBindingsTest()
+        {
+            var dataverseClient = new MockDataverseClient();
+            var bindings = ImmutableArray.Create(
+                new ConnectionBindingInput
+                {
+                    ConnectionReferenceLogicalName = "cr_first",
+                    ConnectionLogicalName = "connection-one",
+                    ConnectionDisplayName = "Connection One"
+                },
+                new ConnectionBindingInput
+                {
+                    ConnectionReferenceLogicalName = "cr_second",
+                    ConnectionLogicalName = "connection-two",
+                    ConnectionDisplayName = "Connection Two"
+                });
+
+            await ConnectionHelper.BindConnectionsAsync(dataverseClient, bindings, new Mock<ILspLogger>().Object, CancellationToken.None);
+
+            Assert.Equal(2, dataverseClient.BindConnectionReferenceCalls.Count);
+            Assert.Equal("cr_first", dataverseClient.BindConnectionReferenceCalls[0].ConnectionReferenceLogicalName);
+            Assert.Equal("connection-one", dataverseClient.BindConnectionReferenceCalls[0].ConnectionLogicalName);
+            Assert.Equal("Connection One", dataverseClient.BindConnectionReferenceCalls[0].ConnectionDisplayName);
+            Assert.Equal("cr_second", dataverseClient.BindConnectionReferenceCalls[1].ConnectionReferenceLogicalName);
+        }
+
+        [Fact]
+        public async Task BindConnectionsAsyncSkipsBindingsWithBlankNamesTest()
+        {
+            var dataverseClient = new MockDataverseClient();
+            var bindings = ImmutableArray.Create(
+                new ConnectionBindingInput
+                {
+                    ConnectionReferenceLogicalName = "cr_valid",
+                    ConnectionLogicalName = "connection-valid"
+                },
+                new ConnectionBindingInput
+                {
+                    ConnectionReferenceLogicalName = "cr_missing_connection",
+                    ConnectionLogicalName = "   "
+                },
+                new ConnectionBindingInput
+                {
+                    ConnectionReferenceLogicalName = string.Empty,
+                    ConnectionLogicalName = "connection-missing-ref"
+                });
+
+            await ConnectionHelper.BindConnectionsAsync(dataverseClient, bindings, new Mock<ILspLogger>().Object, CancellationToken.None);
+
+            Assert.Single(dataverseClient.BindConnectionReferenceCalls);
+            Assert.Equal("cr_valid", dataverseClient.BindConnectionReferenceCalls[0].ConnectionReferenceLogicalName);
+        }
+
+        [Fact]
+        public async Task BindConnectionsAsyncWithEmptyArrayIsNoOpTest()
+        {
+            var dataverseClient = new MockDataverseClient();
+
+            await ConnectionHelper.BindConnectionsAsync(dataverseClient, ImmutableArray<ConnectionBindingInput>.Empty, new Mock<ILspLogger>().Object, CancellationToken.None);
+            await ConnectionHelper.BindConnectionsAsync(dataverseClient, default, new Mock<ILspLogger>().Object, CancellationToken.None);
+
+            Assert.Empty(dataverseClient.BindConnectionReferenceCalls);
+        }
+
+        [Fact]
+        public async Task BindConnectionsAsyncBindFailureThrowsRedactedExceptionAndLogsSensitiveTest()
+        {
+            var logger = new Mock<ILspLogger>();
+            var bindings = ImmutableArray.Create(
+                new ConnectionBindingInput
+                {
+                    ConnectionReferenceLogicalName = "cr_secretref",
+                    ConnectionLogicalName = "secret-connection"
+                });
+
+            var exception = await Assert.ThrowsAsync<ConnectionBindingException>(() =>
+                ConnectionHelper.BindConnectionsAsync(new MockDataverseClientThrowingBind(), bindings, logger.Object, CancellationToken.None));
+
+            Assert.Contains("Failed to bind a connection reference", exception.Message);
+            Assert.DoesNotContain("cr_secretref", exception.Message);
+            Assert.NotNull(exception.InnerException);
+            logger.Verify(
+                l => l.LogSensitiveInformation(
+                    It.Is<string>(s => s.Contains("cr_secretref")),
+                    It.Is<string>(s => !s.Contains("cr_secretref"))),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task BindConnectionsAsyncCancellationIsNotWrappedTest()
+        {
+            var dataverseClient = new Mock<ISyncDataverseClient>();
+            dataverseClient
+                .Setup(c => c.BindConnectionReferenceAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>(), It.IsAny<string?>()))
+                .ThrowsAsync(new OperationCanceledException());
+            var bindings = ImmutableArray.Create(
+                new ConnectionBindingInput
+                {
+                    ConnectionReferenceLogicalName = "cr_ref",
+                    ConnectionLogicalName = "connection"
+                });
+
+            await Assert.ThrowsAsync<OperationCanceledException>(() =>
+                ConnectionHelper.BindConnectionsAsync(dataverseClient.Object, bindings, new Mock<ILspLogger>().Object, CancellationToken.None));
+        }
+
+        [Fact]
+        public void BuildDefaultSyncInfoMapsRequestFieldsTest()
+        {
+            var accountInfo = new AccountInfo
+            {
+                AccountId = "account",
+                TenantId = Guid.NewGuid(),
+                AccountEmail = "email"
+            };
+            var solutionVersions = new SolutionInfo
+            {
+                CopilotStudioSolutionVersion = new Version(1, 0, 0, 0)
+            };
+            var request = new PreparePushRequest
+            {
+                WorkspaceUri = new Uri("file:///c:/agent"),
+                AccountInfo = accountInfo,
+                EnvironmentInfo = new EnvironmentInfo
+                {
+                    DataverseUrl = DataverseUrl,
+                    AgentManagementUrl = AgentManagementUrl,
+                    EnvironmentId = EnvironmentId,
+                    DisplayName = "Test Environment"
+                },
+                SolutionVersions = solutionVersions,
+                CopilotStudioAccessToken = "cs-token",
+                DataverseAccessToken = "dv-token"
+            };
+
+            var syncInfo = ConnectionHelper.BuildDefaultSyncInfo(request);
+
+            Assert.Equal(Guid.Empty, syncInfo.AgentId);
+            Assert.Equal(EnvironmentId, syncInfo.EnvironmentId);
+            Assert.Equal(new Uri(DataverseUrl), syncInfo.DataverseEndpoint);
+            Assert.Equal(new Uri(AgentManagementUrl), syncInfo.AgentManagementEndpoint);
+            Assert.Same(accountInfo, syncInfo.AccountInfo);
+            Assert.Same(solutionVersions, syncInfo.SolutionVersions);
+        }
+    }
+}

--- a/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.PullAgent/Methods/PreparePushHandlerTests.cs
+++ b/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.PullAgent/Methods/PreparePushHandlerTests.cs
@@ -1,0 +1,199 @@
+namespace Microsoft.PowerPlatformLS.UnitTests.Impl.PullAgent.Methods
+{
+    using Microsoft.Agents.ObjectModel;
+    using Microsoft.Agents.Platform.Content.Exceptions;
+    using Microsoft.CommonLanguageServerProtocol.Framework;
+    using Microsoft.CopilotStudio.McsCore;
+    using Microsoft.CopilotStudio.Sync;
+    using Microsoft.CopilotStudio.Sync.Dataverse;
+    using Microsoft.PowerPlatformLS.Contracts.Internal.Models;
+    using Microsoft.PowerPlatformLS.Impl.PullAgent;
+    using Microsoft.PowerPlatformLS.Impl.PullAgent.Auth;
+    using Microsoft.PowerPlatformLS.UnitTests.Impl.Language.CopilotStudio;
+    using Moq;
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Xunit;
+    using DirectoryPath = Microsoft.CopilotStudio.McsCore.DirectoryPath;
+
+    public class PreparePushHandlerTests
+    {
+        private const string TestDataPath = "TestData";
+        private const string WorkspacePath = "Workspace/LocalWorkspace";
+        private const string TopicsPath = "topics/Goodbye.mcs.yml";
+        private const string EnvironmentId = "TestEnvironment";
+        private const string AccountId = "testAccount";
+        private const string AccountEmail = "testEmail";
+        private const string DataverseUrl = "https://test.crm.dynamics.com";
+        private const string AgentManagementUrl = "https://test.agentmanagement.com";
+        private const string CopilotStudioToken = "CopilotStudioToken";
+        private const string DataverseToken = "DataverseToken";
+
+        [Fact]
+        public async Task PreparePushValidWorkspaceReturns200Test()
+        {
+            var (requestContext, request) = CreateSetup();
+            var handler = CreateHandler(new MockDataverseClient(), new TestWorkspaceSynchronizer());
+
+            var response = await handler.HandleRequestAsync(request, requestContext, CancellationToken.None);
+
+            Assert.Equal(200, response.Code);
+            Assert.True(response.AgentConnections.IsDefaultOrEmpty);
+        }
+
+        [Fact]
+        public async Task PreparePushReturnsProvisionedConnectionsTest()
+        {
+            var (requestContext, request) = CreateSetup();
+            var connection = new ConnectionNeeded
+            {
+                ConnectionReferenceLogicalName = "cr_needed",
+                ConnectorId = "connector-id",
+                ConnectorName = "My Connector"
+            };
+            var handler = CreateHandler(new MockDataverseClient(), new PreparePushConnectionReturningSynchronizer(connection));
+
+            var response = await handler.HandleRequestAsync(request, requestContext, CancellationToken.None);
+
+            Assert.Equal(200, response.Code);
+            var returned = Assert.Single(response.AgentConnections);
+            Assert.Equal("cr_needed", returned.ConnectionReferenceLogicalName);
+        }
+
+        [Fact]
+        public async Task PreparePushUnrecognizedTemplateBlockedWith400NoProvisioningTest()
+        {
+            var (requestContext, request) = CreateSetup("Workspace/UnrecognizedTemplateWorkspace");
+            var synchronizer = new PreparePushProvisionTrackingSynchronizer();
+            var handler = CreateHandler(new MockDataverseClient(), synchronizer);
+
+            var response = await handler.HandleRequestAsync(request, requestContext, CancellationToken.None);
+
+            Assert.Equal(400, response.Code);
+            Assert.Contains(SyncOperation.Push.ToString(), response.Message);
+            Assert.False(synchronizer.ProvisionAttempted);
+        }
+
+        [Fact]
+        public async Task PreparePushBadRequestReturnsStatusCodeTest()
+        {
+            var (requestContext, request) = CreateSetup();
+            var logger = new Mock<ILspLogger>();
+            var synchronizer = new PreparePushThrowingSynchronizer(new DataverseBadRequestException(
+                errorCodeName: "BadRequest",
+                errorCodeValue: "400",
+                serviceRequestId: Guid.NewGuid().ToString(),
+                message: "Invalid connector",
+                innerException: null));
+            var handler = CreateHandler(new MockDataverseClient(), synchronizer, logger.Object);
+
+            var response = await handler.HandleRequestAsync(request, requestContext, CancellationToken.None);
+
+            Assert.Equal(400, response.Code);
+            Assert.Contains("BadRequest", response.Message);
+            logger.Verify(l => l.LogException(It.IsAny<DataverseBadRequestException>(), It.IsAny<string>(), It.IsAny<object[]>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task PreparePushGenericExceptionReturns500Test()
+        {
+            var (requestContext, request) = CreateSetup();
+            var synchronizer = new PreparePushThrowingSynchronizer(new InvalidOperationException("provision failed"));
+            var handler = CreateHandler(new MockDataverseClient(), synchronizer);
+
+            var response = await handler.HandleRequestAsync(request, requestContext, CancellationToken.None);
+
+            Assert.Equal(500, response.Code);
+            Assert.Contains("provision failed", response.Message);
+        }
+
+        private static (RequestContext, PreparePushRequest) CreateSetup(string? customWorkspace = null)
+        {
+            var workspacePath = Path.GetFullPath(Path.Combine(TestDataPath, customWorkspace ?? WorkspacePath));
+            var world = new World(workspacePath);
+            var doc = world.GetDocument(Path.Combine(workspacePath, TopicsPath));
+            var requestContext = world.GetRequestContext(doc, 0);
+
+            var request = new PreparePushRequest
+            {
+                WorkspaceUri = new Uri(workspacePath),
+                AccountInfo = new AccountInfo
+                {
+                    AccountId = AccountId,
+                    TenantId = Guid.NewGuid(),
+                    AccountEmail = AccountEmail
+                },
+                EnvironmentInfo = new EnvironmentInfo
+                {
+                    DataverseUrl = DataverseUrl,
+                    AgentManagementUrl = AgentManagementUrl,
+                    EnvironmentId = EnvironmentId,
+                    DisplayName = "Test Environment"
+                },
+                SolutionVersions = new SolutionInfo
+                {
+                    CopilotStudioSolutionVersion = new Version(1, 0, 0, 0)
+                },
+                CopilotStudioAccessToken = CopilotStudioToken,
+                DataverseAccessToken = DataverseToken
+            };
+
+            return (requestContext, request);
+        }
+
+        private static PreparePushHandler CreateHandler(ISyncDataverseClient dataverseClient, IWorkspaceSynchronizer synchronizer, ILspLogger? logger = null)
+        {
+            var mockAuthProvider = new Mock<ISyncAuthProvider>();
+            mockAuthProvider.Setup(a => a.AcquireTokenAsync(It.IsAny<Uri>(), It.IsAny<CancellationToken>())).ReturnsAsync("mock-token");
+            var accessor = new LspDataverseHttpClientAccessor(mockAuthProvider.Object);
+
+            return new PreparePushHandler(
+                new Mock<IIslandControlPlaneService>().Object,
+                synchronizer,
+                new TestTokenManager(),
+                dataverseClient,
+                accessor,
+                logger ?? new Mock<ILspLogger>().Object);
+        }
+    }
+
+    internal sealed class PreparePushConnectionReturningSynchronizer : TestWorkspaceSynchronizer
+    {
+        private readonly ConnectionNeeded _connection;
+
+        public PreparePushConnectionReturningSynchronizer(ConnectionNeeded connection)
+        {
+            _connection = connection;
+        }
+
+        public override Task<IReadOnlyList<ConnectionNeeded>> GetAgentConnectionReferencesAsync(DirectoryPath workspaceFolder, DefinitionBase definition, ISyncDataverseClient dataverseClient, CancellationToken cancellationToken)
+            => Task.FromResult<IReadOnlyList<ConnectionNeeded>>(new[] { _connection });
+    }
+
+    internal sealed class PreparePushProvisionTrackingSynchronizer : TestWorkspaceSynchronizer
+    {
+        public bool ProvisionAttempted { get; private set; }
+
+        public override Task<CustomConnectorPushResult> PushCustomConnectorsAsync(DirectoryPath workspaceFolder, ISyncDataverseClient dataverseClient, CancellationToken cancellationToken)
+        {
+            ProvisionAttempted = true;
+            return base.PushCustomConnectorsAsync(workspaceFolder, dataverseClient, cancellationToken);
+        }
+    }
+
+    internal sealed class PreparePushThrowingSynchronizer : TestWorkspaceSynchronizer
+    {
+        private readonly Exception _exception;
+
+        public PreparePushThrowingSynchronizer(Exception exception)
+        {
+            _exception = exception;
+        }
+
+        public override Task<CustomConnectorPushResult> PushCustomConnectorsAsync(DirectoryPath workspaceFolder, ISyncDataverseClient dataverseClient, CancellationToken cancellationToken)
+            => throw _exception;
+    }
+}

--- a/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.PullAgent/Methods/PrepareReattachHandlerTests.cs
+++ b/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.PullAgent/Methods/PrepareReattachHandlerTests.cs
@@ -1,0 +1,302 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+
+namespace Microsoft.PowerPlatformLS.UnitTests.Impl.PullAgent.Methods
+{
+    using Microsoft.Agents.Platform.Content.Exceptions;
+    using Microsoft.CommonLanguageServerProtocol.Framework;
+    using Microsoft.CopilotStudio.McsCore;
+    using Microsoft.CopilotStudio.Sync;
+    using Microsoft.CopilotStudio.Sync.Dataverse;
+    using Microsoft.PowerPlatformLS.Contracts.Internal.Models;
+    using Microsoft.PowerPlatformLS.Impl.PullAgent;
+    using Microsoft.PowerPlatformLS.UnitTests.Impl.Language.CopilotStudio;
+    using Moq;
+    using System;
+    using System.IO;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Xunit;
+
+    public class PrepareReattachHandlerTests
+    {
+        private const string TestDataPath = "TestData";
+        private const string WorkspacePath = "Workspace/LocalWorkspace";
+        private const string TopicsPath = "topics/Goodbye.mcs.yml";
+        private const string EnvironmentId = "TestEnvironment";
+        private const string AccountId = "testAccount";
+        private const string AccountEmail = "testEmail";
+        private const string DataverseUrl = "https://test.crm.dynamics.com";
+        private const string AgentManagementUrl = "https://test.agentmanagement.com";
+        private const string CopilotStudioToken = "CopilotStudioToken";
+        private const string DataverseToken = "DataverseToken";
+
+        [Fact]
+        public async Task PrepareReattachValidDirectoryTest()
+        {
+            var context = CreatePrepareTestSetup();
+            var synchronizer = new TestWorkspaceSynchronizer();
+            var handler = TestHandlerFactory.CreatePrepareHandler(new MockDataverseClient(), synchronizer);
+
+            var response = await handler.HandleRequestAsync(context.Request, context.RequestContext, CancellationToken.None);
+
+            Assert.Equal(200, response.Code);
+            Assert.NotNull(response.AgentSyncInfo);
+            Assert.Equal(EnvironmentId, response.AgentSyncInfo!.EnvironmentId);
+            Assert.Equal(AccountId, response.AgentSyncInfo?.AccountInfo?.AccountId);
+            Assert.True(response.IsNewAgent);
+            Assert.Equal(0, synchronizer.SavedSyncInfoCount);
+        }
+
+        [Fact]
+        public async Task PrepareReattachCreateAgentFailureTest()
+        {
+            var context = CreatePrepareTestSetup();
+            var failingClient = new Mock<ISyncDataverseClient>();
+            failingClient.Setup(c => c.GetAgentIdBySchemaNameAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(Guid.Empty);
+            failingClient.Setup(c => c.CreateNewAgentAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<AuthoringShape>(), It.IsAny<CancellationToken>())).ThrowsAsync(new InvalidOperationException("Dataverse failure!"));
+            var handler = TestHandlerFactory.CreatePrepareHandler(failingClient.Object, new TestWorkspaceSynchronizer());
+
+            var response = await handler.HandleRequestAsync(context.Request, context.RequestContext, CancellationToken.None);
+
+            Assert.NotEqual(200, response.Code);
+            Assert.Equal(Guid.Empty, response.AgentSyncInfo?.AgentId);
+            Assert.NotNull(response.Message);
+        }
+
+        [Fact]
+        public async Task PrepareReattachInvalidDirectoryTest()
+        {
+            var context = CreatePrepareTestSetup("Workspace/InvalidWorkspace");
+            var handler = TestHandlerFactory.CreatePrepareHandler(new MockDataverseClient(), new TestWorkspaceSynchronizer());
+
+            var response = await handler.HandleRequestAsync(context.Request, context.RequestContext, CancellationToken.None);
+
+            Assert.NotEqual(200, response.Code);
+            Assert.Equal(Guid.Empty, response.AgentSyncInfo?.AgentId);
+            Assert.NotNull(response.Message);
+        }
+
+        [Fact]
+        public async Task PrepareReattachAlreadyConnectedTest()
+        {
+            var context = CreatePrepareTestSetup();
+            var handler = TestHandlerFactory.CreatePrepareHandler(new MockDataverseClient(), new TestWorkspaceSynchronizerSyncInfoExists());
+
+            var response = await handler.HandleRequestAsync(context.Request, context.RequestContext, CancellationToken.None);
+
+            Assert.Equal(400, response.Code);
+            Assert.Equal(Guid.Empty, response.AgentSyncInfo?.AgentId);
+            Assert.NotNull(response.Message);
+            Assert.False(response.IsNewAgent);
+        }
+
+        [Fact]
+        public async Task PrepareReattachAlreadyConnectedMessageDoesNotLeakUrlTest()
+        {
+            var context = CreatePrepareTestSetup();
+            var handler = TestHandlerFactory.CreatePrepareHandler(new MockDataverseClient(), new TestWorkspaceSynchronizerSyncInfoExists());
+
+            var response = await handler.HandleRequestAsync(context.Request, context.RequestContext, CancellationToken.None);
+
+            Assert.Equal(400, response.Code);
+            Assert.DoesNotContain(DataverseUrl, response.Message);
+            Assert.DoesNotContain(AgentManagementUrl, response.Message);
+        }
+
+        [Fact]
+        public async Task PrepareReattachRemoteAgentExistsTest()
+        {
+            var context = CreatePrepareTestSetup();
+            var mockClient = new Mock<ISyncDataverseClient>();
+            mockClient.Setup(c => c.GetAgentIdBySchemaNameAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(Guid.NewGuid());
+            var handler = TestHandlerFactory.CreatePrepareHandler(mockClient.Object, new TestWorkspaceSynchronizer());
+
+            var response = await handler.HandleRequestAsync(context.Request, context.RequestContext, CancellationToken.None);
+
+            Assert.Equal(200, response.Code);
+            Assert.False(response.IsNewAgent);
+        }
+
+        [Fact]
+        public async Task PrepareReattachReturnsAgentConnectionsTest()
+        {
+            var context = CreatePrepareTestSetup();
+            var handler = TestHandlerFactory.CreatePrepareHandler(new MockDataverseClient(), new TestWorkspaceSynchronizer());
+
+            var response = await handler.HandleRequestAsync(context.Request, context.RequestContext, CancellationToken.None);
+
+            Assert.Equal(200, response.Code);
+            Assert.True(response.AgentConnections.IsDefaultOrEmpty);
+        }
+
+        [Fact]
+        public async Task PrepareReattachDataverseBadRequestTest()
+        {
+            var context = CreatePrepareTestSetup();
+            var mockLogger = new Mock<ILspLogger>();
+            var badRequestClient = new Mock<ISyncDataverseClient>();
+            badRequestClient.Setup(c => c.GetAgentIdBySchemaNameAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new DataverseBadRequestException(
+                    errorCodeName: "BadRequest",
+                    errorCodeValue: "400",
+                    serviceRequestId: Guid.NewGuid().ToString(),
+                    message: "Invalid schema name",
+                    innerException: null));
+            var handler = TestHandlerFactory.CreatePrepareHandler(badRequestClient.Object, new TestWorkspaceSynchronizer(), mockLogger.Object);
+
+            var response = await handler.HandleRequestAsync(context.Request, context.RequestContext, CancellationToken.None);
+
+            Assert.Equal(400, response.Code);
+            Assert.Contains("BadRequest", response.Message);
+            mockLogger.Verify(l => l.LogException(It.IsAny<DataverseBadRequestException>(), It.IsAny<string>(), It.IsAny<object[]>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task PrepareReattachWithExceptionTest()
+        {
+            var context = CreatePrepareTestSetup();
+            var throwingClient = new Mock<ISyncDataverseClient>();
+            throwingClient.Setup(c => c.GetAgentIdBySchemaNameAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).Throws(new InvalidOperationException("invalid operation exception"));
+            var handler = TestHandlerFactory.CreatePrepareHandler(throwingClient.Object, new TestWorkspaceSynchronizer());
+
+            var response = await handler.HandleRequestAsync(context.Request, context.RequestContext, CancellationToken.None);
+
+            Assert.Equal(500, response.Code);
+            Assert.Contains("exception", response.Message);
+        }
+
+        [Fact]
+        public async Task PrepareReattachWithConnectionTrackingDoesNotFailTest()
+        {
+            var context = CreatePrepareTestSetup();
+            var trackingClient = new MockDataverseClientWithConnectionTracking();
+            var handler = TestHandlerFactory.CreatePrepareHandler(trackingClient, new TestWorkspaceSynchronizer());
+
+            var response = await handler.HandleRequestAsync(context.Request, context.RequestContext, CancellationToken.None);
+
+            Assert.Equal(200, response.Code);
+            Assert.Empty(trackingClient.ProvisionedConnections);
+        }
+
+        [Fact]
+        public async Task PrepareReattach_UnrecognizedTemplate_BlockedWith400_NoMutationTest()
+        {
+            var context = CreatePrepareTestSetup("Workspace/UnrecognizedTemplateWorkspace");
+            var dataverse = new Mock<ISyncDataverseClient>();
+            dataverse.Setup(c => c.GetAgentIdBySchemaNameAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(Guid.Empty);
+            var handler = TestHandlerFactory.CreatePrepareHandler(dataverse.Object, new TestWorkspaceSynchronizer());
+
+            var response = await handler.HandleRequestAsync(context.Request, context.RequestContext, CancellationToken.None);
+
+            Assert.Equal(400, response.Code);
+            Assert.False(response.IsNewAgent);
+            Assert.Equal(Guid.Empty, response.AgentSyncInfo?.AgentId);
+            Assert.Contains(SyncOperation.Reattach.ToString(), response.Message);
+            dataverse.Verify(c => c.GetAgentIdBySchemaNameAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+            dataverse.Verify(c => c.CreateNewAgentAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<AuthoringShape>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task PrepareReattach_ComponentCollectionRoot_NotBlockedByGateTest()
+        {
+            var dir = Path.GetFullPath(Path.Combine(TestDataPath, "WorkspaceWithCC"));
+            var world = new World(dir);
+            var ccDir = Path.Combine(dir, "MyCC333");
+            var workspace = world.GetWorkspace(ccDir);
+            var doc = workspace.GetDocumentOrThrow(new AgentFilePath("collection.mcs.yml"));
+            var requestContext = world.GetRequestContext(doc, 0);
+
+            var request = new PrepareReattachRequest
+            {
+                WorkspaceUri = new Uri(ccDir),
+                AccountInfo = new AccountInfo
+                {
+                    AccountId = AccountId,
+                    TenantId = Guid.NewGuid(),
+                    AccountEmail = AccountEmail
+                },
+                EnvironmentInfo = new EnvironmentInfo
+                {
+                    DataverseUrl = DataverseUrl,
+                    AgentManagementUrl = AgentManagementUrl,
+                    EnvironmentId = EnvironmentId,
+                    DisplayName = "Test Environment"
+                },
+                SolutionVersions = new SolutionInfo
+                {
+                    CopilotStudioSolutionVersion = new Version(1, 0, 0, 0)
+                },
+                CopilotStudioAccessToken = CopilotStudioToken,
+                DataverseAccessToken = DataverseToken
+            };
+
+            var handler = TestHandlerFactory.CreatePrepareHandler(new MockDataverseClient(), new TestWorkspaceSynchronizer());
+
+            var response = await handler.HandleRequestAsync(request, requestContext, CancellationToken.None);
+
+            Assert.Equal(200, response.Code);
+            Assert.True(response.IsNewAgent);
+        }
+
+        private PrepareReattachTestContext CreatePrepareTestSetup(string? customWorkspace = null)
+        {
+            var workspacePath = Path.GetFullPath(Path.Combine(TestDataPath, customWorkspace ?? WorkspacePath));
+            World world;
+            RequestContext requestContext;
+
+            if (Directory.Exists(workspacePath) && File.Exists(Path.Combine(workspacePath, TopicsPath)))
+            {
+                world = new World(workspacePath);
+                var path = Path.Combine(workspacePath, TopicsPath);
+                var doc = world.GetDocument(path);
+                requestContext = world.GetRequestContext(doc, 0);
+            }
+            else
+            {
+                world = new World();
+                var doc = world.AddFile("topic2.mcs.yml");
+                requestContext = world.GetRequestContext(doc, 0);
+            }
+
+            var request = new PrepareReattachRequest
+            {
+                WorkspaceUri = new Uri(workspacePath),
+                AccountInfo = new AccountInfo
+                {
+                    AccountId = AccountId,
+                    TenantId = Guid.NewGuid(),
+                    AccountEmail = AccountEmail
+                },
+                EnvironmentInfo = new EnvironmentInfo
+                {
+                    DataverseUrl = DataverseUrl,
+                    AgentManagementUrl = AgentManagementUrl,
+                    EnvironmentId = EnvironmentId,
+                    DisplayName = "Test Environment"
+                },
+                SolutionVersions = new SolutionInfo
+                {
+                    CopilotStudioSolutionVersion = new Version(1, 0, 0, 0)
+                },
+                CopilotStudioAccessToken = CopilotStudioToken,
+                DataverseAccessToken = DataverseToken
+            };
+
+            return new PrepareReattachTestContext
+            {
+                World = world,
+                RequestContext = requestContext,
+                Request = request
+            };
+        }
+    }
+
+    internal class PrepareReattachTestContext
+    {
+        public required World World { get; init; }
+
+        public required RequestContext RequestContext { get; init; }
+
+        public required PrepareReattachRequest Request { get; init; }
+    }
+}

--- a/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.PullAgent/Methods/ReattachAgentHandlerTests.cs
+++ b/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.PullAgent/Methods/ReattachAgentHandlerTests.cs
@@ -6,8 +6,6 @@
     using Microsoft.CommonLanguageServerProtocol.Framework;
     using Microsoft.CopilotStudio.Sync;
     using Microsoft.CopilotStudio.Sync.Dataverse;
-    using Microsoft.PowerPlatformLS.Contracts.FileLayout;
-    using Microsoft.PowerPlatformLS.Contracts.Internal.Common;
     using Microsoft.PowerPlatformLS.Contracts.Internal.Models;
     using Microsoft.PowerPlatformLS.Impl.PullAgent;
     using Microsoft.PowerPlatformLS.Impl.PullAgent.Auth;
@@ -18,8 +16,6 @@
     using System.Collections.Immutable;
     using System.IO;
     using System.Linq;
-    using System.Net.Http;
-    using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
     using Xunit;
@@ -41,110 +37,162 @@
         private const string DataverseToken = "DataverseToken";
 
         [Fact]
-        public async Task ReattachAgentValidDirectoryTest()
-        {
-            var context = CreateTestSetup();
-            var handler = TestHandlerFactory.CreateHandler(new MockDataverseClient(), new TestWorkspaceSynchronizer(), CreateOperationProvider());
-
-            var response = await handler.HandleRequestAsync(context.Request, context.RequestContext, CancellationToken.None);
-
-            Assert.Equal(200, response.Code);
-            Assert.NotNull(response.AgentSyncInfo);
-            Assert.Equal(EnvironmentId, response.AgentSyncInfo!.EnvironmentId);
-            Assert.Equal(AccountId, response.AgentSyncInfo?.AccountInfo?.AccountId);
-            Assert.True(response.IsNewAgent);
-        }
-
-        [Fact]
-        public async Task ReattachAgentDataverseFailureTest()
-        {
-            var context = CreateTestSetup();
-            var failingClient = new Mock<ISyncDataverseClient>();
-            failingClient.Setup(c => c.GetAgentIdBySchemaNameAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(Guid.Empty);
-            failingClient.Setup(c => c.CreateNewAgentAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<AuthoringShape>(), It.IsAny<CancellationToken>())).ThrowsAsync(new InvalidOperationException("Dataverse failure!"));
-            var handler = TestHandlerFactory.CreateHandler(failingClient.Object, new TestWorkspaceSynchronizer(), CreateOperationProvider());
-
-            var response = await handler.HandleRequestAsync(context.Request, context.RequestContext, CancellationToken.None);
-
-            Assert.NotEqual(200, response.Code);
-            Assert.Equal(Guid.Empty, response.AgentSyncInfo?.AgentId);
-            Assert.NotNull(response.Message);
-        }
-
-        [Fact]
-        public async Task ReattachAgentInvalidDirectoryTest()
-        {
-            var context = CreateTestSetup("Workspace/InvalidWorkspace");
-            var handler = TestHandlerFactory.CreateHandler(new MockDataverseClient(), new TestWorkspaceSynchronizer(), CreateOperationProvider());
-
-            var response = await handler.HandleRequestAsync(context.Request, context.RequestContext, CancellationToken.None);
-
-            Assert.NotEqual(200, response.Code);
-            Assert.Equal(Guid.Empty, response.AgentSyncInfo?.AgentId);
-            Assert.NotNull(response.Message);
-        }
-
-        [Fact]
-        public async Task ReattachAgentWithExistingConnJsonTest()
+        public async Task ReattachAgentFinalizesWhenPreparedTest()
         {
             var context = CreateTestSetup();
             var handler = TestHandlerFactory.CreateHandler(new MockDataverseClient(), new TestWorkspaceSynchronizerSyncInfoExists(), CreateOperationProvider());
 
             var response = await handler.HandleRequestAsync(context.Request, context.RequestContext, CancellationToken.None);
 
-            Assert.Equal(400, response.Code);
-            Assert.Equal(Guid.Empty, response.AgentSyncInfo?.AgentId);
-            Assert.NotNull(response.Message);
-            Assert.False(response.IsNewAgent);
+            Assert.Equal(200, response.Code);
+            Assert.NotNull(response.AgentSyncInfo);
         }
 
         [Fact]
-        public async Task ReattachAgentRemoteAgentExistsTest()
+        public async Task ReattachAgentFinalizesWithPreparedSyncInfoFromRequestTest()
         {
             var context = CreateTestSetup();
-            var existingAgentClient = new MockDataverseClient();
-            var mockClient = new Mock<ISyncDataverseClient>();
-            mockClient.Setup(c => c.GetAgentIdBySchemaNameAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(Guid.NewGuid());
-            var handler = TestHandlerFactory.CreateHandler(mockClient.Object, new TestWorkspaceSynchronizer(), CreateOperationProvider());
+            context.Request.AgentSyncInfo = CreatePreparedSyncInfo();
+            var synchronizer = new TestWorkspaceSynchronizer();
+            var handler = TestHandlerFactory.CreateHandler(new MockDataverseClient(), synchronizer, CreateOperationProvider());
 
             var response = await handler.HandleRequestAsync(context.Request, context.RequestContext, CancellationToken.None);
 
             Assert.Equal(200, response.Code);
-            Assert.False(response.IsNewAgent);
-            Assert.NotNull(response.Message);
+            Assert.NotNull(response.AgentSyncInfo);
+            Assert.Equal(context.Request.AgentSyncInfo.AgentId, response.AgentSyncInfo.AgentId);
+            Assert.Equal(1, synchronizer.SavedSyncInfoCount);
         }
 
         [Fact]
-        public async Task ReattachAgentReturnsNewlyCreatedCustomConnectorsTest()
+        public async Task ReattachAgentNotPreparedReturns400Test()
         {
             var context = CreateTestSetup();
-            var connectorPushResult = new CustomConnectorPushResult
-            {
-                PushedRowIds = new Dictionary<string, Guid> { ["my-conn-internal"] = Guid.NewGuid() },
-                NewlyCreatedConnectorNames = new[] { "My New Connector" },
-            };
-            var workspace = new TestWorkspaceSynchronizerWithConnectors(connectorPushResult);
-
-            var handler = TestHandlerFactory.CreateHandler(new MockDataverseClient(), workspace, CreateOperationProvider());
-
-            var response = await handler.HandleRequestAsync(context.Request, context.RequestContext, CancellationToken.None);
-
-            Assert.Equal(200, response.Code);
-            Assert.Equal(new[] { "My New Connector" }, response.NewlyCreatedCustomConnectors);
-        }
-
-        [Fact]
-        public async Task ReattachAgentEmptyNewlyCreatedConnectors_WhenNoneCreatedTest()
-        {
-            var context = CreateTestSetup();
-            
             var handler = TestHandlerFactory.CreateHandler(new MockDataverseClient(), new TestWorkspaceSynchronizer(), CreateOperationProvider());
 
             var response = await handler.HandleRequestAsync(context.Request, context.RequestContext, CancellationToken.None);
 
-            Assert.Equal(200, response.Code);
-            Assert.Empty(response.NewlyCreatedCustomConnectors);
+            Assert.Equal(400, response.Code);
+            Assert.Equal(Guid.Empty, response.AgentSyncInfo?.AgentId);
+            Assert.NotNull(response.Message);
         }
+
+        [Fact]
+        public async Task ReattachAgentPropagatesIsNewAgentFromRequestTest()
+        {
+            var context = CreateTestSetup();
+            context.Request.IsNewAgent = true;
+            var handler = TestHandlerFactory.CreateHandler(new MockDataverseClient(), new TestWorkspaceSynchronizerSyncInfoExists(), CreateOperationProvider());
+
+            var response = await handler.HandleRequestAsync(context.Request, context.RequestContext, CancellationToken.None);
+
+            Assert.Equal(200, response.Code);
+            Assert.True(response.IsNewAgent);
+        }
+
+        [Fact]
+        public async Task ReattachAgentBindsConnectionBindingsTest()
+        {
+            var context = CreateTestSetup();
+            context.Request.ConnectionBindings = ImmutableArray.Create(
+                new ConnectionBindingInput
+                {
+                    ConnectionReferenceLogicalName = "cr_testref",
+                    ConnectionLogicalName = "shared-test-connection",
+                    ConnectionDisplayName = "My Test Connection"
+                },
+                new ConnectionBindingInput
+                {
+                    ConnectionReferenceLogicalName = "cr_blank",
+                    ConnectionLogicalName = string.Empty
+                });
+
+            var dataverseClient = new MockDataverseClient();
+            var handler = TestHandlerFactory.CreateHandler(dataverseClient, new TestWorkspaceSynchronizerSyncInfoExists(), CreateOperationProvider());
+
+            var response = await handler.HandleRequestAsync(context.Request, context.RequestContext, CancellationToken.None);
+
+            Assert.Equal(200, response.Code);
+            Assert.Single(dataverseClient.BindConnectionReferenceCalls);
+            Assert.Equal("cr_testref", dataverseClient.BindConnectionReferenceCalls[0].ConnectionReferenceLogicalName);
+            Assert.Equal("shared-test-connection", dataverseClient.BindConnectionReferenceCalls[0].ConnectionLogicalName);
+            Assert.Equal("My Test Connection", dataverseClient.BindConnectionReferenceCalls[0].ConnectionDisplayName);
+        }
+
+        [Fact]
+        public async Task ReattachAgentBindsBeforeUpsertingWorkflowsTest()
+        {
+            var context = CreateTestSetup();
+            context.Request.ConnectionBindings = ImmutableArray.Create(
+                new ConnectionBindingInput
+                {
+                    ConnectionReferenceLogicalName = "cr_testref",
+                    ConnectionLogicalName = "shared-test-connection"
+                });
+
+            var dataverseClient = new MockDataverseClient();
+            var synchronizer = new TestWorkspaceSynchronizerRecordingOrderSyncInfoExists(dataverseClient);
+            var handler = TestHandlerFactory.CreateHandler(dataverseClient, synchronizer, CreateOperationProvider());
+
+            var response = await handler.HandleRequestAsync(context.Request, context.RequestContext, CancellationToken.None);
+
+            Assert.Equal(200, response.Code);
+            Assert.True(dataverseClient.BindConnectionReferenceCalls.Count > 0);
+            Assert.True(synchronizer.UpsertWorkflowInvokedAfterBind);
+        }
+
+        [Fact]
+        public async Task ReattachAgentBindFailureFailsAndDoesNotSaveSyncInfoTest()
+        {
+            var context = CreateTestSetup();
+            context.Request.AgentSyncInfo = CreatePreparedSyncInfo();
+            context.Request.ConnectionBindings = ImmutableArray.Create(
+                new ConnectionBindingInput
+                {
+                    ConnectionReferenceLogicalName = "cr_testref",
+                    ConnectionLogicalName = "shared-test-connection"
+                });
+
+            var synchronizer = new TestWorkspaceSynchronizer();
+            var handler = TestHandlerFactory.CreateHandler(new MockDataverseClientThrowingBind(), synchronizer, CreateOperationProvider());
+
+            var response = await handler.HandleRequestAsync(context.Request, context.RequestContext, CancellationToken.None);
+
+            Assert.Equal(400, response.Code);
+            Assert.Contains("Failed to bind a connection reference", response.Message);
+            Assert.DoesNotContain("cr_testref", response.Message);
+            Assert.Equal(0, synchronizer.SavedSyncInfoCount);
+        }
+
+        [Fact]
+        public async Task ReattachAgentDataverseBadRequestTest()
+        {
+            var context = CreateTestSetup();
+            var mockLogger = new Mock<ILspLogger>();
+            var synchronizer = new TestWorkspaceSynchronizerThrowingWorkflowSyncInfoExists(
+                new DataverseBadRequestException("BadRequest", "400", Guid.NewGuid().ToString(), "Invalid workflow", null));
+            var handler = TestHandlerFactory.CreateHandler(new MockDataverseClient(), synchronizer, CreateOperationProvider(), mockLogger.Object);
+
+            var response = await handler.HandleRequestAsync(context.Request, context.RequestContext, CancellationToken.None);
+
+            Assert.Equal(400, response.Code);
+            Assert.Contains("BadRequest", response.Message);
+            mockLogger.Verify(l => l.LogException(It.IsAny<DataverseBadRequestException>(), It.IsAny<string>(), It.IsAny<object[]>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task ReattachAgentWithExceptionTest()
+        {
+            var context = CreateTestSetup();
+            var synchronizer = new TestWorkspaceSynchronizerThrowingWorkflowSyncInfoExists(new InvalidOperationException("invalid operation exception"));
+            var handler = TestHandlerFactory.CreateHandler(new MockDataverseClient(), synchronizer, CreateOperationProvider());
+
+            var response = await handler.HandleRequestAsync(context.Request, context.RequestContext, CancellationToken.None);
+
+            Assert.Equal(500, response.Code);
+            Assert.Contains("exception", response.Message);
+        }
+
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
@@ -186,126 +234,6 @@
             Assert.NotNull(syncInfo.Definition);
             Assert.NotNull(syncInfo.Changeset);
             Assert.True(synchronizer.ReattachCalled);
-        }
-
-        [Fact]
-        public async Task ReattachAgentDataverseBadRequestTest()
-        {
-            var context = CreateTestSetup();
-            var mockLogger = new Mock<ILspLogger>();
-            var badRequestClient = new Mock<ISyncDataverseClient>();
-            badRequestClient.Setup(c => c.GetAgentIdBySchemaNameAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .ThrowsAsync(new DataverseBadRequestException(
-                    errorCodeName: "BadRequest",
-                    errorCodeValue: "400",
-                    serviceRequestId: Guid.NewGuid().ToString(),
-                    message: "Invalid schema name",
-                    innerException: null));
-            var handler = TestHandlerFactory.CreateHandler(badRequestClient.Object, new TestWorkspaceSynchronizer(), CreateOperationProvider(), mockLogger.Object);
-
-            var response = await handler.HandleRequestAsync(context.Request, context.RequestContext, CancellationToken.None);
-
-            Assert.Equal(400, response.Code);
-            Assert.Contains("BadRequest", response.Message);
-            mockLogger.Verify(l => l.LogException(It.IsAny<DataverseBadRequestException>(), It.IsAny<string>(), It.IsAny<object[]>()), Times.Once);
-        }
-
-        [Fact]
-        public async Task ReattachAgentWithExceptionTest()
-        {
-            var context = CreateTestSetup();
-            var throwingClient = new Mock<ISyncDataverseClient>();
-            throwingClient.Setup(c => c.GetAgentIdBySchemaNameAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).Throws(new InvalidOperationException("invalid operation exception"));
-            var handler = TestHandlerFactory.CreateHandler(throwingClient.Object, new TestWorkspaceSynchronizer(), CreateOperationProvider());
-
-            var response = await handler.HandleRequestAsync(context.Request, context.RequestContext, CancellationToken.None);
-
-            Assert.Equal(500, response.Code);
-            Assert.Contains("exception", response.Message);
-        }
-
-        [Fact]
-        public async Task ReattachAgentWithConnectionTrackingDoesNotFailTest()
-        {
-            // This test verifies that connection provisioning logic doesn't break the reattach flow
-            // when there are no portable connections (workspace has no configuration)
-            var context = CreateTestSetup();
-            var trackingClient = new MockDataverseClientWithConnectionTracking();
-            var handler = TestHandlerFactory.CreateHandler(trackingClient, new TestWorkspaceSynchronizer(), CreateOperationProvider());
-
-            var response = await handler.HandleRequestAsync(context.Request, context.RequestContext, CancellationToken.None);
-
-            Assert.Equal(200, response.Code);
-            // No connections should be provisioned since workspace has no portable connections
-            Assert.Empty(trackingClient.ProvisionedConnections);
-        }
-
-        [Fact]
-        public async Task ReattachAgent_UnrecognizedTemplate_BlockedWith400_NoMutationTest()
-        {
-            // D35 (primary): an EXPLICITLY unrecognized authoring shape (unknown template) whose
-            // folder merely falls back to a classic layout must NOT be promoted to Supported.
-            // Reattach fails closed (400) before any cloud mutation.
-            var context = CreateTestSetup("Workspace/UnrecognizedTemplateWorkspace");
-            var dataverse = new Mock<ISyncDataverseClient>();
-            dataverse.Setup(c => c.GetAgentIdBySchemaNameAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(Guid.Empty);
-            var handler = TestHandlerFactory.CreateHandler(dataverse.Object, new TestWorkspaceSynchronizer(), CreateOperationProvider());
-
-            var response = await handler.HandleRequestAsync(context.Request, context.RequestContext, CancellationToken.None);
-
-            Assert.Equal(400, response.Code);
-            Assert.False(response.IsNewAgent);
-            Assert.Equal(Guid.Empty, response.AgentSyncInfo?.AgentId);
-            Assert.Contains(SyncOperation.Reattach.ToString(), response.Message);
-            // No mutation: the gate blocks before any Dataverse interaction.
-            dataverse.Verify(c => c.GetAgentIdBySchemaNameAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
-            dataverse.Verify(c => c.CreateNewAgentAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<AuthoringShape>(), It.IsAny<CancellationToken>()), Times.Never);
-        }
-
-        [Fact]
-        public async Task ReattachAgent_ComponentCollectionRoot_NotBlockedByGateTest()
-        {
-            // D35 (secondary regression guard): a component-collection root (no BotEntity, no
-            // settings.mcs.yml) is a recognized format and must NOT be blocked by the gate -
-            // reattach proceeds and creates the new agent as before.
-            var dir = Path.GetFullPath(Path.Combine(TestDataPath, "WorkspaceWithCC"));
-            var world = new World(dir);
-            var ccDir = Path.Combine(dir, "MyCC333");
-            var workspace = world.GetWorkspace(ccDir);
-            var doc = workspace.GetDocumentOrThrow(new AgentFilePath("collection.mcs.yml"));
-            var requestContext = world.GetRequestContext(doc, 0);
-
-            var request = new ReattachAgentRequest
-            {
-                WorkspaceUri = new Uri(ccDir),
-                AccountInfo = new AccountInfo
-                {
-                    AccountId = AccountId,
-                    TenantId = Guid.NewGuid(),
-                    AccountEmail = AccountEmail
-                },
-                EnvironmentInfo = new EnvironmentInfo
-                {
-                    DataverseUrl = DataverseUrl,
-                    AgentManagementUrl = AgentManagementUrl,
-                    EnvironmentId = EnvironmentId,
-                    DisplayName = "Test Environment"
-                },
-                SolutionVersions = new SolutionInfo
-                {
-                    CopilotStudioSolutionVersion = new Version(1, 0, 0, 0)
-                },
-                CopilotStudioAccessToken = CopilotStudioToken,
-                DataverseAccessToken = DataverseToken
-            };
-
-            var handler = TestHandlerFactory.CreateHandler(new MockDataverseClient(), new TestWorkspaceSynchronizer(), CreateOperationProvider());
-
-            var response = await handler.HandleRequestAsync(request, requestContext, CancellationToken.None);
-
-            // Gate recognized the component-collection format as Supported, so reattach proceeded.
-            Assert.Equal(200, response.Code);
-            Assert.True(response.IsNewAgent);
         }
 
         private ReattachAgentTestContext CreateTestSetup(string? customWorkspace = null)
@@ -385,6 +313,24 @@
             );
         }
 
+        private static AgentSyncInfo CreatePreparedSyncInfo() => new()
+        {
+            AgentId = Guid.NewGuid(),
+            EnvironmentId = EnvironmentId,
+            DataverseEndpoint = new Uri(DataverseUrl),
+            AgentManagementEndpoint = new Uri(AgentManagementUrl),
+            AccountInfo = new AccountInfo
+            {
+                AccountId = AccountId,
+                TenantId = Guid.NewGuid(),
+                AccountEmail = AccountEmail
+            },
+            SolutionVersions = new SolutionInfo
+            {
+                CopilotStudioSolutionVersion = new Version(1, 0, 0, 0)
+            },
+        };
+
 
     }
 
@@ -462,6 +408,14 @@
         public virtual Task EnsureConnectionReferenceExistsAsync(string connectionReferenceLogicalName, string connectorId, CancellationToken cancellationToken, Guid? customConnectorRowId = null)
             => Task.CompletedTask;
 
+        public List<(string ConnectionReferenceLogicalName, string ConnectionLogicalName, string? ConnectionDisplayName)> BindConnectionReferenceCalls { get; } = new();
+
+        public virtual Task BindConnectionReferenceAsync(string connectionReferenceLogicalName, string connectionLogicalName, CancellationToken cancellationToken, string? connectionReferenceDisplayName = null)
+        {
+            BindConnectionReferenceCalls.Add((connectionReferenceLogicalName, connectionLogicalName, connectionReferenceDisplayName));
+            return Task.CompletedTask;
+        }
+
         public void SetConnectionReferences(ConnectionReferenceInfo[] connectionReferences)
         {
             _connectionReferencesByLogicalName = connectionReferences.ToDictionary(x => x.ConnectionReferenceLogicalName, StringComparer.OrdinalIgnoreCase);
@@ -498,6 +452,11 @@
             CancellationToken cancellationToken)
             => Task.FromResult(Array.Empty<CustomConnectorMetadata>());
 
+        public virtual Task<CustomConnectorMetadata[]> GetConnectorsByInternalIdPrefixAsync(
+            string connectorInternalIdPrefix,
+            CancellationToken cancellationToken)
+            => Task.FromResult(Array.Empty<CustomConnectorMetadata>());
+
         public virtual Task<bool> UpsertConnectorAsync(CustomConnectorMetadata connector, CancellationToken cancellationToken)
             => Task.FromResult(false);
 
@@ -524,19 +483,34 @@
                 opProvider,
                 logger ?? new Mock<ILspLogger>().Object);
         }
+
+        public static PrepareReattachHandler CreatePrepareHandler(ISyncDataverseClient dataverseClient, IWorkspaceSynchronizer workspace, ILspLogger? logger = null)
+        {
+            var mockAuthProvider = new Mock<ISyncAuthProvider>();
+            mockAuthProvider.Setup(a => a.AcquireTokenAsync(It.IsAny<Uri>(), It.IsAny<CancellationToken>())).ReturnsAsync("mock-token");
+            var accessor = new LspDataverseHttpClientAccessor(mockAuthProvider.Object);
+            return new PrepareReattachHandler(
+                new Mock<IIslandControlPlaneService>().Object,
+                workspace,
+                new TestTokenManager(),
+                dataverseClient,
+                accessor,
+                logger ?? new Mock<ILspLogger>().Object);
+        }
     }
 
     internal class TestTokenManager : ITokenManager
     {
         public void SetTokens(string dataverseToken, string copilotStudioToken)
         {
-            // No ops
         }
     }
 
     internal class TestWorkspaceSynchronizer : IWorkspaceSynchronizer
     {
         public bool ReattachCalled { get; private set; } = false;
+
+        public int SavedSyncInfoCount { get; private set; }
 
         public virtual bool IsSyncInfoAvailable(Microsoft.CopilotStudio.McsCore.DirectoryPath workspaceFolder) => false;
 
@@ -561,8 +535,9 @@
             });
         }
 
-        public Task SaveSyncInfoAsync(Microsoft.CopilotStudio.McsCore.DirectoryPath workspaceFolder, AgentSyncInfo connectionDetails)
+        public virtual Task SaveSyncInfoAsync(Microsoft.CopilotStudio.McsCore.DirectoryPath workspaceFolder, AgentSyncInfo connectionDetails)
         {
+            SavedSyncInfoCount++;
             return Task.CompletedTask;
         }
 
@@ -587,6 +562,9 @@
 
         public Task<PushChangesetResult> PushChangesetAsync(Microsoft.CopilotStudio.McsCore.DirectoryPath workspaceFolder, AuthoringOperationContextBase operationContext, PvaComponentChangeSet localWorkspaceDefinition, ISyncDataverseClient dataverseClient, Guid? agentId, CloudFlowMetadata? cloudFlowMetadata, ImmutableArray<AIPromptMetadata> aiPrompts, CancellationToken cancellationToken, bool uploadAllKnowledgeFiles = false)
             => Task.FromResult(new PushChangesetResult());
+
+        public Task PushLocalChangesAsync(Microsoft.CopilotStudio.McsCore.DirectoryPath workspaceFolder, AuthoringOperationContextBase operationContext, DefinitionBase workspaceDefinition, ISyncDataverseClient dataverseClient, AgentSyncInfo syncInfo, CloudFlowMetadata? cloudFlowMetadata, ImmutableArray<AIPromptMetadata> aiPrompts, CancellationToken cancellationToken)
+            => Task.CompletedTask;
 
         public Task<WorkspaceSyncInfo> SyncWorkspaceAsync(Microsoft.CopilotStudio.McsCore.DirectoryPath workspaceFolder, AuthoringOperationContextBase operationContext, string? changeToken, bool updateWorkspaceDirectory, ISyncDataverseClient dataverseClient, AgentSyncInfo syncInfo, CloudFlowMetadata? cloudFlowMetadata, CancellationToken cancellationToken)
         {
@@ -626,6 +604,9 @@
         public Task ProvisionConnectionReferencesAsync(Microsoft.CopilotStudio.McsCore.DirectoryPath workspaceFolder, DefinitionBase definition, ISyncDataverseClient dataverseClient, CancellationToken cancellationToken, IReadOnlyDictionary<string, Guid>? pushedConnectorIds = null)
             => Task.CompletedTask;
 
+        public virtual Task<IReadOnlyList<ConnectionNeeded>> GetAgentConnectionReferencesAsync(Microsoft.CopilotStudio.McsCore.DirectoryPath workspaceFolder, DefinitionBase definition, ISyncDataverseClient dataverseClient, CancellationToken cancellationToken)
+            => Task.FromResult<IReadOnlyList<ConnectionNeeded>>(Array.Empty<ConnectionNeeded>());
+
         public virtual Task<CustomConnectorPushResult> PushCustomConnectorsAsync(Microsoft.CopilotStudio.McsCore.DirectoryPath workspaceFolder, ISyncDataverseClient dataverseClient, CancellationToken cancellationToken)
             => Task.FromResult(new CustomConnectorPushResult());
 
@@ -650,17 +631,39 @@
         public override bool IsSyncInfoAvailable(Microsoft.CopilotStudio.McsCore.DirectoryPath workspaceFolder) => true;
     }
 
-    internal class TestWorkspaceSynchronizerWithConnectors : TestWorkspaceSynchronizer
+    internal class TestWorkspaceSynchronizerRecordingOrderSyncInfoExists : TestWorkspaceSynchronizer
     {
-        private readonly CustomConnectorPushResult _result;
+        private readonly MockDataverseClient _dataverseClient;
 
-        public TestWorkspaceSynchronizerWithConnectors(CustomConnectorPushResult result)
+        public bool UpsertWorkflowInvokedAfterBind { get; private set; }
+
+        public TestWorkspaceSynchronizerRecordingOrderSyncInfoExists(MockDataverseClient dataverseClient)
         {
-            _result = result;
+            _dataverseClient = dataverseClient;
         }
 
-        public override Task<CustomConnectorPushResult> PushCustomConnectorsAsync(Microsoft.CopilotStudio.McsCore.DirectoryPath workspaceFolder, ISyncDataverseClient dataverseClient, CancellationToken cancellationToken)
-            => Task.FromResult(_result);
+        public override bool IsSyncInfoAvailable(Microsoft.CopilotStudio.McsCore.DirectoryPath workspaceFolder) => true;
+
+        public override Task<(ImmutableArray<WorkflowResponse>, CloudFlowMetadata)> UpsertWorkflowForAgentAsync(Microsoft.CopilotStudio.McsCore.DirectoryPath workspaceFolder, ISyncDataverseClient dataverseClient, Guid? agentId, CancellationToken cancellationToken)
+        {
+            UpsertWorkflowInvokedAfterBind = _dataverseClient.BindConnectionReferenceCalls.Count > 0;
+            return base.UpsertWorkflowForAgentAsync(workspaceFolder, dataverseClient, agentId, cancellationToken);
+        }
+    }
+
+    internal class TestWorkspaceSynchronizerThrowingWorkflowSyncInfoExists : TestWorkspaceSynchronizer
+    {
+        private readonly Exception _exception;
+
+        public TestWorkspaceSynchronizerThrowingWorkflowSyncInfoExists(Exception exception)
+        {
+            _exception = exception;
+        }
+
+        public override bool IsSyncInfoAvailable(Microsoft.CopilotStudio.McsCore.DirectoryPath workspaceFolder) => true;
+
+        public override Task<(ImmutableArray<WorkflowResponse>, CloudFlowMetadata)> UpsertWorkflowForAgentAsync(Microsoft.CopilotStudio.McsCore.DirectoryPath workspaceFolder, ISyncDataverseClient dataverseClient, Guid? agentId, CancellationToken cancellationToken)
+            => throw _exception;
     }
 
     internal class TestOperationContextProvider : IOperationContextProvider
@@ -711,6 +714,14 @@
         {
             ProvisionedConnections.Add((connectionReferenceLogicalName, connectorId));
             return Task.CompletedTask;
+        }
+    }
+
+    internal class MockDataverseClientThrowingBind : MockDataverseClient
+    {
+        public override Task BindConnectionReferenceAsync(string connectionReferenceLogicalName, string connectionLogicalName, CancellationToken cancellationToken, string? connectionReferenceDisplayName = null)
+        {
+            throw new InvalidOperationException("bind failed");
         }
     }
 }

--- a/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.PullAgent/Methods/ReattachAgentHandlerTests.cs
+++ b/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.PullAgent/Methods/ReattachAgentHandlerTests.cs
@@ -40,12 +40,27 @@
         public async Task ReattachAgentFinalizesWhenPreparedTest()
         {
             var context = CreateTestSetup();
-            var handler = TestHandlerFactory.CreateHandler(new MockDataverseClient(), new TestWorkspaceSynchronizerSyncInfoExists(), CreateOperationProvider());
+            context.Request.AgentSyncInfo = CreatePreparedSyncInfo();
+            var handler = TestHandlerFactory.CreateHandler(new MockDataverseClient(), new TestWorkspaceSynchronizer(), CreateOperationProvider());
 
             var response = await handler.HandleRequestAsync(context.Request, context.RequestContext, CancellationToken.None);
 
             Assert.Equal(200, response.Code);
             Assert.NotNull(response.AgentSyncInfo);
+        }
+
+        [Fact]
+        public async Task ReattachAgentAlreadyConnectedReturns400Test()
+        {
+            var context = CreateTestSetup();
+            context.Request.AgentSyncInfo = CreatePreparedSyncInfo();
+            var handler = TestHandlerFactory.CreateHandler(new MockDataverseClient(), new TestWorkspaceSynchronizerSyncInfoExists(), CreateOperationProvider());
+
+            var response = await handler.HandleRequestAsync(context.Request, context.RequestContext, CancellationToken.None);
+
+            Assert.Equal(400, response.Code);
+            Assert.Contains("already connected", response.Message);
+            Assert.Equal(Guid.Empty, response.AgentSyncInfo?.AgentId);
         }
 
         [Fact]
@@ -82,7 +97,8 @@
         {
             var context = CreateTestSetup();
             context.Request.IsNewAgent = true;
-            var handler = TestHandlerFactory.CreateHandler(new MockDataverseClient(), new TestWorkspaceSynchronizerSyncInfoExists(), CreateOperationProvider());
+            context.Request.AgentSyncInfo = CreatePreparedSyncInfo();
+            var handler = TestHandlerFactory.CreateHandler(new MockDataverseClient(), new TestWorkspaceSynchronizer(), CreateOperationProvider());
 
             var response = await handler.HandleRequestAsync(context.Request, context.RequestContext, CancellationToken.None);
 
@@ -94,6 +110,7 @@
         public async Task ReattachAgentBindsConnectionBindingsTest()
         {
             var context = CreateTestSetup();
+            context.Request.AgentSyncInfo = CreatePreparedSyncInfo();
             context.Request.ConnectionBindings = ImmutableArray.Create(
                 new ConnectionBindingInput
                 {
@@ -108,7 +125,7 @@
                 });
 
             var dataverseClient = new MockDataverseClient();
-            var handler = TestHandlerFactory.CreateHandler(dataverseClient, new TestWorkspaceSynchronizerSyncInfoExists(), CreateOperationProvider());
+            var handler = TestHandlerFactory.CreateHandler(dataverseClient, new TestWorkspaceSynchronizer(), CreateOperationProvider());
 
             var response = await handler.HandleRequestAsync(context.Request, context.RequestContext, CancellationToken.None);
 
@@ -123,6 +140,7 @@
         public async Task ReattachAgentBindsBeforeUpsertingWorkflowsTest()
         {
             var context = CreateTestSetup();
+            context.Request.AgentSyncInfo = CreatePreparedSyncInfo();
             context.Request.ConnectionBindings = ImmutableArray.Create(
                 new ConnectionBindingInput
                 {
@@ -131,7 +149,7 @@
                 });
 
             var dataverseClient = new MockDataverseClient();
-            var synchronizer = new TestWorkspaceSynchronizerRecordingOrderSyncInfoExists(dataverseClient);
+            var synchronizer = new TestWorkspaceSynchronizerRecordingOrder(dataverseClient);
             var handler = TestHandlerFactory.CreateHandler(dataverseClient, synchronizer, CreateOperationProvider());
 
             var response = await handler.HandleRequestAsync(context.Request, context.RequestContext, CancellationToken.None);
@@ -168,8 +186,9 @@
         public async Task ReattachAgentDataverseBadRequestTest()
         {
             var context = CreateTestSetup();
+            context.Request.AgentSyncInfo = CreatePreparedSyncInfo();
             var mockLogger = new Mock<ILspLogger>();
-            var synchronizer = new TestWorkspaceSynchronizerThrowingWorkflowSyncInfoExists(
+            var synchronizer = new TestWorkspaceSynchronizerThrowingWorkflow(
                 new DataverseBadRequestException("BadRequest", "400", Guid.NewGuid().ToString(), "Invalid workflow", null));
             var handler = TestHandlerFactory.CreateHandler(new MockDataverseClient(), synchronizer, CreateOperationProvider(), mockLogger.Object);
 
@@ -184,7 +203,8 @@
         public async Task ReattachAgentWithExceptionTest()
         {
             var context = CreateTestSetup();
-            var synchronizer = new TestWorkspaceSynchronizerThrowingWorkflowSyncInfoExists(new InvalidOperationException("invalid operation exception"));
+            context.Request.AgentSyncInfo = CreatePreparedSyncInfo();
+            var synchronizer = new TestWorkspaceSynchronizerThrowingWorkflow(new InvalidOperationException("invalid operation exception"));
             var handler = TestHandlerFactory.CreateHandler(new MockDataverseClient(), synchronizer, CreateOperationProvider());
 
             var response = await handler.HandleRequestAsync(context.Request, context.RequestContext, CancellationToken.None);
@@ -631,18 +651,16 @@
         public override bool IsSyncInfoAvailable(Microsoft.CopilotStudio.McsCore.DirectoryPath workspaceFolder) => true;
     }
 
-    internal class TestWorkspaceSynchronizerRecordingOrderSyncInfoExists : TestWorkspaceSynchronizer
+    internal class TestWorkspaceSynchronizerRecordingOrder : TestWorkspaceSynchronizer
     {
         private readonly MockDataverseClient _dataverseClient;
 
         public bool UpsertWorkflowInvokedAfterBind { get; private set; }
 
-        public TestWorkspaceSynchronizerRecordingOrderSyncInfoExists(MockDataverseClient dataverseClient)
+        public TestWorkspaceSynchronizerRecordingOrder(MockDataverseClient dataverseClient)
         {
             _dataverseClient = dataverseClient;
         }
-
-        public override bool IsSyncInfoAvailable(Microsoft.CopilotStudio.McsCore.DirectoryPath workspaceFolder) => true;
 
         public override Task<(ImmutableArray<WorkflowResponse>, CloudFlowMetadata)> UpsertWorkflowForAgentAsync(Microsoft.CopilotStudio.McsCore.DirectoryPath workspaceFolder, ISyncDataverseClient dataverseClient, Guid? agentId, CancellationToken cancellationToken)
         {
@@ -651,16 +669,14 @@
         }
     }
 
-    internal class TestWorkspaceSynchronizerThrowingWorkflowSyncInfoExists : TestWorkspaceSynchronizer
+    internal class TestWorkspaceSynchronizerThrowingWorkflow : TestWorkspaceSynchronizer
     {
         private readonly Exception _exception;
 
-        public TestWorkspaceSynchronizerThrowingWorkflowSyncInfoExists(Exception exception)
+        public TestWorkspaceSynchronizerThrowingWorkflow(Exception exception)
         {
             _exception = exception;
         }
-
-        public override bool IsSyncInfoAvailable(Microsoft.CopilotStudio.McsCore.DirectoryPath workspaceFolder) => true;
 
         public override Task<(ImmutableArray<WorkflowResponse>, CloudFlowMetadata)> UpsertWorkflowForAgentAsync(Microsoft.CopilotStudio.McsCore.DirectoryPath workspaceFolder, ISyncDataverseClient dataverseClient, Guid? agentId, CancellationToken cancellationToken)
             => throw _exception;

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/clients/bapClient.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/clients/bapClient.ts
@@ -289,7 +289,7 @@ function getHostName(clusterCategory: CoreServicesClusterCategory): string {
     }
 }
 
-function getTokenScopeHostName(clusterCategory: CoreServicesClusterCategory): string {
+export function getTokenScopeHostName(clusterCategory: CoreServicesClusterCategory): string {
     switch (clusterCategory) {
         case CoreServicesClusterCategory.Exp:
         case CoreServicesClusterCategory.Dev:

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/commands/reattachAgent.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/commands/reattachAgent.ts
@@ -1,13 +1,14 @@
 import * as vscode from 'vscode';
-import { AccountInfo, EnvironmentInfo, ReattachAgentRequest, ReattachAgentResponse} from '../types';
+import { AccountInfo, ConnectionBinding, EnvironmentInfo, PrepareReattachRequest, PrepareReattachResponse, ReattachAgentRequest, ReattachAgentResponse } from '../types';
 import { DefaultCoreServicesClusterCategory, LspMethods, TelemetryEventsKeys } from '../constants';
 import { listEnvironmentsAsync } from '../clients/bapClient';
 import { hasStoredAccount, switchAccount, getPreferredTreeAccount, listStoredAccounts } from '../clients/account';
 import { pushNewWorkspace } from '../sync/workspaceScm';
 import { lspClient, buildLspRequestPayload } from '../services/lspClient';
 import logger from '../services/logger';
-import { logWorkflowIssues, logAIPromptIssues, logNewCustomConnectorsRaw, withSyncCommandBusy } from '../sync/workspaceSynchronizer';
+import { logWorkflowIssues, logAIPromptIssues, withSyncCommandBusy } from '../sync/workspaceSynchronizer';
 import { getActiveAgentAccount, getAllProjectAccounts } from '../sync/localWorkspaces';
+import { createAgentConnections } from '../connections/connectionRepair';
 
 type ReattachEnvironmentPickItem = vscode.QuickPickItem & {
   environment: EnvironmentInfo;
@@ -125,15 +126,58 @@ export const registerReattachAgentCommand = (context: vscode.ExtensionContext) =
           cancellable: false
         },
         async () => {
-          // For sync buttons to be disabled and loading indicators to be visible during the REATTACH_AGENT call.
           await withSyncCommandBusy(workspaceUri, async () => {
             try {
               const selectedAccount = pickedEnvironment.sourceAccount ?? getPreferredTreeAccount();
-              const reattachRequest: ReattachAgentRequest = {
-                ...await buildLspRequestPayload(undefined, environmentInfo, selectedAccount),
+              const basePayload = await buildLspRequestPayload(undefined, environmentInfo, selectedAccount);
+
+              const prepareRequest: PrepareReattachRequest = {
+                ...basePayload,
                 workspaceUri
               };
-              const reattachResult = await lspClient.sendRequest<ReattachAgentResponse>(LspMethods.REATTACH_AGENT, reattachRequest);
+              const prepareResult = await lspClient.sendRequest<PrepareReattachResponse>(LspMethods.PREPARE_REATTACH, prepareRequest);
+              if (prepareResult.code !== 200) {
+                logger.logError(TelemetryEventsKeys.ReattachAgentError, `Reattach prepare failed: ${prepareResult.message ?? 'Unknown error'}`);
+                return;
+              }
+
+              let connectionBindings: ConnectionBinding[] = [];
+              let unfinishedConnections: string[] = [];
+              try {
+                if (prepareResult.agentConnections && prepareResult.agentConnections.length > 0) {
+                  const repair = await createAgentConnections(
+                    prepareResult.agentConnections,
+                    environmentInfo,
+                    basePayload.accountInfo.clusterCategory ?? DefaultCoreServicesClusterCategory,
+                    selectedAccount ?? undefined
+                  );
+                  connectionBindings = repair.bindings;
+                  unfinishedConnections = repair.unfinished;
+                }
+              } catch (error) {
+                logger.logError(TelemetryEventsKeys.ConnectionCreationError, `Error creating agent connections: ${(error as Error).message}`);
+                unfinishedConnections = prepareResult.agentConnections?.map(c => c.connectionReferenceLogicalName) ?? [];
+              }
+
+              const finalizeRequest: ReattachAgentRequest = {
+                ...basePayload,
+                workspaceUri,
+                agentSyncInfo: prepareResult.agentSyncInfo,
+                connectionBindings,
+                isNewAgent: prepareResult.isNewAgent,
+                updateWorkspaceDirectory: prepareResult.updateWorkspaceDirectory
+              };
+              const reattachResult = await lspClient.sendRequest<ReattachAgentResponse>(LspMethods.REATTACH_AGENT, finalizeRequest);
+              if (reattachResult.code !== 200) {
+                logger.logError(TelemetryEventsKeys.ReattachAgentError, `Reattach finalize failed: ${reattachResult.message ?? 'Unknown error'}`);
+                return;
+              }
+
+              if (unfinishedConnections.length > 0) {
+                void vscode.window.showWarningMessage(
+                  `The agent was reattached, but these connections still need to be set up before it can run: ${unfinishedConnections.join(', ')}.`
+                );
+              }
 
               if (reattachResult.isNewAgent) {
                 const newWorkspace = {
@@ -152,7 +196,6 @@ export const registerReattachAgentCommand = (context: vscode.ExtensionContext) =
 
               logWorkflowIssues(reattachResult.workflowResponse);
               logAIPromptIssues(reattachResult.aiPromptResponse);
-              logNewCustomConnectorsRaw(reattachResult.newlyCreatedCustomConnectors, workspaceUri);
             } catch (error) {
               logger.logError(TelemetryEventsKeys.ReattachAgentError, `Error reattaching agent: ${(error as Error).message}`);
             }

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/commands/syncWorkspace.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/commands/syncWorkspace.ts
@@ -1,7 +1,7 @@
 import { commands, DiagnosticSeverity, ExtensionContext, languages, ProgressLocation, RelativePattern, TextDocument, Uri, window, workspace as VSworkspace } from "vscode";
 import { CopilotStudioWorkspace, getAllWorkspaces, hasConnectionFileInWorkspace } from "../sync/localWorkspaces";
 import { selectWorkspace } from "../sync/workspacePicker";
-import { getOrAddSynchronizer, withSyncCommandBusy, WorkspaceSynchronizer } from "../sync/workspaceSynchronizer";
+import { getOrAddSynchronizer, preparePushConnections, withSyncCommandBusy, WorkspaceSynchronizer } from "../sync/workspaceSynchronizer";
 import { registerVirtualKnowledgeProvider } from "../knowledgeFiles/virtualKnowledgeFile";
 import { getWorkspaceChanges, refreshAgentChangesAfterFetch } from "../sync/workspaceScm";
 import { TelemetryEventsKeys } from "../constants";
@@ -196,7 +196,26 @@ const registerSyncCommand = (
           }
           if (errors.count === 0) {
             const synchronizer = getOrAddSynchronizer(selectedWorkspace);
-            await action(synchronizer);
+            if (id === 'microsoft-copilot-studio.applyChanges') {
+              const prepared = await preparePushConnections(selectedWorkspace);
+              if (prepared.status === 'failed') {
+                await window.showErrorMessage(`Cannot perform ${displayName.toLowerCase()} operation: preparing connections failed.`);
+                return;
+              }
+              if (prepared.status === 'incomplete') {
+                const proceed = await window.showWarningMessage(
+                  `These connections still need to be set up before the agent can run: ${prepared.unfinished.join(', ')}. Apply changes anyway?`,
+                  { modal: true },
+                  'Apply Anyway'
+                );
+                if (proceed !== 'Apply Anyway') {
+                  return;
+                }
+              }
+              await synchronizer.push(false, prepared.bindings);
+            } else {
+              await action(synchronizer);
+            }
           }
         });
       });

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/connections/connectionCreation.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/connections/connectionCreation.ts
@@ -1,0 +1,202 @@
+import * as http from 'http';
+import * as crypto from 'crypto';
+import * as process from 'process';
+import { AddressInfo } from 'net';
+import * as vscode from 'vscode';
+import { CoreServicesClusterCategory } from '../constants';
+
+const PROTOCOL_VERSION = '1';
+const TIMEOUT_MS = 5 * 60 * 1000;
+
+const openInBrowser = async (targetUrl: string): Promise<boolean> => {
+  if (process.platform !== 'linux') {
+    try {
+      const { default: open } = await import('open');
+      await open(targetUrl);
+      return true;
+    } catch {
+    }
+  }
+
+  try {
+    return await vscode.env.openExternal(vscode.Uri.parse(targetUrl));
+  } catch {
+    return false;
+  }
+};
+
+export type ConnectionCreationResult =
+  | { status: 'created'; connectionId?: string; connectionName?: string; displayName?: string }
+  | { status: 'cancelled' }
+  | { status: 'error'; errorMessage?: string };
+
+export interface ConnectionCreationOptions {
+  connectorName: string;
+  environmentId: string;
+  clusterCategory: CoreServicesClusterCategory;
+  cancellationToken?: vscode.CancellationToken;
+}
+
+const getPlayerBaseUrl = (clusterCategory: CoreServicesClusterCategory): string => {
+  switch (clusterCategory) {
+    case CoreServicesClusterCategory.Gov:
+    case CoreServicesClusterCategory.GovFR:
+      return 'https://apps.gov.powerapps.us';
+    case CoreServicesClusterCategory.High:
+      return 'https://apps.high.powerapps.us';
+    case CoreServicesClusterCategory.DoD:
+      return 'https://play.apps.appsplatform.us';
+    case CoreServicesClusterCategory.Mooncake:
+      return 'https://apps.powerapps.cn';
+    case CoreServicesClusterCategory.Ex:
+      return 'https://apps.powerapps.eaglex.ic.gov';
+    case CoreServicesClusterCategory.Rx:
+      return 'https://apps.powerapps.microsoft.scloud';
+    case CoreServicesClusterCategory.Exp:
+    case CoreServicesClusterCategory.Dev:
+    case CoreServicesClusterCategory.Test:
+    case CoreServicesClusterCategory.Preprod:
+    case CoreServicesClusterCategory.Prv:
+      return 'https://apps.preview.powerapps.com';
+    case CoreServicesClusterCategory.Prod:
+    case CoreServicesClusterCategory.FirstRelease:
+    default:
+      return 'https://apps.powerapps.com';
+  }
+};
+
+const normalizeConnector = (connector: string): string => {
+  const trimmed = connector.trim().replace(/\/+$/, '');
+  return trimmed.includes('/') ? trimmed.substring(trimmed.lastIndexOf('/') + 1) : trimmed;
+};
+
+const buildPlayerUrl = (
+  clusterCategory: CoreServicesClusterCategory,
+  environmentId: string,
+  connector: string,
+  callbackUrl: string,
+  nonce: string
+): string => {
+  const url = new URL(`/appframework/e/${environmentId}/connections/new`, getPlayerBaseUrl(clusterCategory));
+  url.searchParams.set('connector', connector);
+  url.searchParams.set('callbackUrl', callbackUrl);
+  url.searchParams.set('nonce', nonce);
+  url.searchParams.set('v', PROTOCOL_VERSION);
+  return url.toString();
+};
+
+const escapeHtml = (s: string): string => s.replace(/[&<>"']/g, c => `&#${c.charCodeAt(0)};`);
+
+const renderResultPage = (status: string | null, message?: string): string => {
+  const safeMessage = message ? escapeHtml(message) : '';
+  const heading =
+    status === 'created'
+      ? 'Connection created. You can close this tab and return to VS Code.'
+      : status === 'error'
+        ? 'Connection creation failed.'
+        : 'Connection creation was cancelled.';
+  return `<!DOCTYPE html><html><head><meta charset="utf-8"><title>Copilot Studio</title></head>`
+    + `<body style="font-family: sans-serif; padding: 2rem; font-size: 0.9rem;"><p style="font-size: 1rem; font-weight: 600; margin: 0 0 0.5rem;">${escapeHtml(heading)}</p>`
+    + (safeMessage ? `<p style="margin: 0;">${safeMessage}</p>` : '')
+    + `</body></html>`;
+};
+
+export const awaitConnectionCreation = (options: ConnectionCreationOptions): Promise<ConnectionCreationResult> => {
+  const { connectorName, environmentId, clusterCategory, cancellationToken } = options;
+  const nonce = crypto.randomUUID();
+  const connector = normalizeConnector(connectorName);
+
+  return new Promise<ConnectionCreationResult>((resolve) => {
+    let settled = false;
+    let timeoutId: NodeJS.Timeout | undefined;
+    let cancellationListener: vscode.Disposable | undefined;
+
+    const server = http.createServer((req, res) => {
+      const requestUrl = new URL(req.url ?? '/', 'http://127.0.0.1');
+
+      if (requestUrl.pathname !== '/callback' || req.method !== 'GET') {
+        res.writeHead(404);
+        res.end('Not found');
+        return;
+      }
+
+      if (requestUrl.searchParams.get('nonce') !== nonce) {
+        res.writeHead(403, { 'Content-Type': 'text/html; charset=utf-8' });
+        res.end('<h2>Verification failed. Please run the command again.</h2>');
+        return;
+      }
+
+      const status = requestUrl.searchParams.get('status');
+      const message = requestUrl.searchParams.get('message') ?? undefined;
+
+      res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+      res.end(renderResultPage(status, message));
+
+      if (status === 'created') {
+        finish({
+          status: 'created',
+          connectionId: requestUrl.searchParams.get('connectionId') ?? undefined,
+          connectionName: requestUrl.searchParams.get('connectionName') ?? undefined,
+          displayName: requestUrl.searchParams.get('displayName') ?? undefined,
+        });
+      } else if (status === 'error') {
+        finish({ status: 'error', errorMessage: message });
+      } else {
+        finish({ status: 'cancelled' });
+      }
+    });
+
+    const cleanup = () => {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+        timeoutId = undefined;
+      }
+      cancellationListener?.dispose();
+      cancellationListener = undefined;
+      if (server.listening) {
+        server.close();
+      }
+    };
+
+    const finish = (result: ConnectionCreationResult) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      resolve(result);
+    };
+
+    server.on('error', (err) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      resolve({ status: 'error', errorMessage: err.message });
+    });
+
+    server.listen(0, '127.0.0.1', async () => {
+      const { port } = server.address() as AddressInfo;
+      const callbackUrl = `http://127.0.0.1:${port}/callback`;
+      const playerUrl = buildPlayerUrl(clusterCategory, environmentId, connector, callbackUrl, nonce);
+
+      try {
+        const opened = await openInBrowser(playerUrl);
+        if (!opened) {
+          await vscode.window.showWarningMessage(
+            `Could not open the browser automatically. Open this URL to create the connection:\n${playerUrl}`
+          );
+        }
+      } catch (error) {
+        finish({ status: 'error', errorMessage: (error as Error).message });
+      }
+    });
+
+    timeoutId = setTimeout(() => finish({ status: 'cancelled' }), TIMEOUT_MS);
+
+    if (cancellationToken) {
+      cancellationListener = cancellationToken.onCancellationRequested(() => finish({ status: 'cancelled' }));
+    }
+  });
+};

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/connections/connectionCreation.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/connections/connectionCreation.ts
@@ -1,29 +1,11 @@
 import * as http from 'http';
 import * as crypto from 'crypto';
-import * as process from 'process';
 import { AddressInfo } from 'net';
 import * as vscode from 'vscode';
 import { CoreServicesClusterCategory } from '../constants';
 
 const PROTOCOL_VERSION = '1';
 const TIMEOUT_MS = 5 * 60 * 1000;
-
-const openInBrowser = async (targetUrl: string): Promise<boolean> => {
-  if (process.platform !== 'linux') {
-    try {
-      const { default: open } = await import('open');
-      await open(targetUrl);
-      return true;
-    } catch {
-    }
-  }
-
-  try {
-    return await vscode.env.openExternal(vscode.Uri.parse(targetUrl));
-  } catch {
-    return false;
-  }
-};
 
 export type ConnectionCreationResult =
   | { status: 'created'; connectionId?: string; connectionName?: string; displayName?: string }
@@ -177,12 +159,12 @@ export const awaitConnectionCreation = (options: ConnectionCreationOptions): Pro
     });
 
     server.listen(0, '127.0.0.1', async () => {
-      const { port } = server.address() as AddressInfo;
-      const callbackUrl = `http://127.0.0.1:${port}/callback`;
-      const playerUrl = buildPlayerUrl(clusterCategory, environmentId, connector, callbackUrl, nonce);
-
       try {
-        const opened = await openInBrowser(playerUrl);
+        const { port } = server.address() as AddressInfo;
+        const localCallbackUri = vscode.Uri.parse(`http://127.0.0.1:${port}/callback`);
+        const externalCallbackUri = await vscode.env.asExternalUri(localCallbackUri);
+        const playerUrl = buildPlayerUrl(clusterCategory, environmentId, connector, externalCallbackUri.toString(), nonce);
+        const opened = await vscode.env.openExternal(vscode.Uri.parse(playerUrl));
         if (!opened) {
           await vscode.window.showWarningMessage(
             `Could not open the browser automatically. Open this URL to create the connection:\n${playerUrl}`

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/connections/connectionExistence.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/connections/connectionExistence.ts
@@ -165,12 +165,14 @@ export interface WaitForConnectorAvailableOptions extends ConnectorAvailabilityO
 
 const delay = (ms: number, cancellationToken?: CancellationToken): Promise<void> =>
   new Promise((resolve) => {
+    let listener: { dispose(): void } | undefined;
     const timer = setTimeout(() => {
       listener?.dispose();
       resolve();
     }, ms);
-    const listener = cancellationToken?.onCancellationRequested(() => {
+    listener = cancellationToken?.onCancellationRequested(() => {
       clearTimeout(timer);
+      listener?.dispose();
       resolve();
     });
   });

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/connections/connectionExistence.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/connections/connectionExistence.ts
@@ -1,0 +1,206 @@
+import { CancellationToken, Uri } from 'vscode';
+import { FetchAccessToken } from '../clients/account';
+import { getTokenScopeHostName } from '../clients/bapClient';
+import { CoreServicesClusterCategory, TelemetryEventsKeys } from '../constants';
+import logger from '../services/logger';
+
+const CONNECTIONS_API_VERSION = '2016-11-01';
+
+const getConnectionsApiHost = (clusterCategory: CoreServicesClusterCategory): string => {
+  switch (clusterCategory) {
+    case CoreServicesClusterCategory.Gov:
+    case CoreServicesClusterCategory.GovFR:
+      return 'gov.api.powerapps.us';
+    case CoreServicesClusterCategory.High:
+      return 'high.api.powerapps.us';
+    case CoreServicesClusterCategory.DoD:
+      return 'api.apps.appsplatform.us';
+    case CoreServicesClusterCategory.Mooncake:
+      return 'api.powerapps.cn';
+    case CoreServicesClusterCategory.Ex:
+      return 'api.powerapps.eaglex.ic.gov';
+    case CoreServicesClusterCategory.Rx:
+      return 'api.powerapps.microsoft.scloud';
+    case CoreServicesClusterCategory.Exp:
+    case CoreServicesClusterCategory.Dev:
+    case CoreServicesClusterCategory.Test:
+    case CoreServicesClusterCategory.Preprod:
+    case CoreServicesClusterCategory.Prv:
+    case CoreServicesClusterCategory.Prod:
+    case CoreServicesClusterCategory.FirstRelease:
+    default:
+      return 'api.powerapps.com';
+  }
+};
+
+const lastSegment = (value: string): string => {
+  const trimmed = value.trim().replace(/\/+$/, '');
+  return trimmed.includes('/') ? trimmed.substring(trimmed.lastIndexOf('/') + 1) : trimmed;
+};
+
+const escapeODataString = (value: string): string => value.replace(/'/g, "''");
+
+interface ConnectionListItem {
+  name?: string;
+}
+
+interface ConnectionListResponse {
+  value?: ConnectionListItem[];
+}
+
+export interface ConnectionExistenceOptions {
+  connectorName: string;
+  connectionId: string;
+  environmentId: string;
+  clusterCategory: CoreServicesClusterCategory;
+  accountId: string | null;
+  accountHint?: string;
+}
+
+export const connectionExists = async (
+  options: ConnectionExistenceOptions
+): Promise<boolean | undefined> => {
+  const { connectorName, connectionId, environmentId, clusterCategory, accountId, accountHint } = options;
+
+  const normalizedConnector = lastSegment(connectorName);
+  const targetName = lastSegment(connectionId);
+  if (!normalizedConnector || !targetName) {
+    return undefined;
+  }
+
+  const filter = `environment eq '${escapeODataString(environmentId)}'`;
+  const requestUri = Uri.from({
+    scheme: 'https',
+    authority: getConnectionsApiHost(clusterCategory),
+    path: `/providers/Microsoft.PowerApps/apis/${normalizedConnector}/connections`,
+    query: `api-version=${CONNECTIONS_API_VERSION}&$filter=${encodeURIComponent(filter)}`
+  });
+
+  const resource = Uri.from({
+    scheme: 'https',
+    authority: getTokenScopeHostName(clusterCategory)
+  });
+
+  try {
+    const { response } = await FetchAccessToken(resource, requestUri, accountId, null, accountId === null, accountHint);
+    if (!response.ok) {
+      logger.logInfo(
+        TelemetryEventsKeys.ConnectionCreationInfo,
+        `Connection existence check returned status ${response.status} for connector <pii>${normalizedConnector}</pii>.`
+      );
+      return undefined;
+    }
+
+    const body = (await response.json()) as ConnectionListResponse;
+    const connections = body.value ?? [];
+    return connections.some((c) => (c.name ?? '').localeCompare(targetName, undefined, { sensitivity: 'accent' }) === 0);
+  } catch (error) {
+    logger.logInfo(
+      TelemetryEventsKeys.ConnectionCreationInfo,
+      `Connection existence check failed for connector <pii>${normalizedConnector}</pii>: ${(error as Error).message}`
+    );
+    return undefined;
+  }
+};
+
+const CUSTOM_CONNECTOR_INTERNAL_ID_REGEX = /-5f[0-9a-f]{16}$/i;
+
+export const isCustomConnectorInternalId = (connectorName: string): boolean => {
+  return CUSTOM_CONNECTOR_INTERNAL_ID_REGEX.test(lastSegment(connectorName));
+};
+
+export interface ConnectorAvailabilityOptions {
+  connectorName: string;
+  environmentId: string;
+  clusterCategory: CoreServicesClusterCategory;
+  accountId: string | null;
+  accountHint?: string;
+}
+
+const connectorAvailable = async (
+  options: ConnectorAvailabilityOptions
+): Promise<boolean | undefined> => {
+  const { connectorName, environmentId, clusterCategory, accountId, accountHint } = options;
+
+  const normalizedConnector = lastSegment(connectorName);
+  if (!normalizedConnector) {
+    return undefined;
+  }
+
+  const filter = `environment eq '${escapeODataString(environmentId)}'`;
+  const requestUri = Uri.from({
+    scheme: 'https',
+    authority: getConnectionsApiHost(clusterCategory),
+    path: `/providers/Microsoft.PowerApps/apis/${normalizedConnector}/connections`,
+    query: `api-version=${CONNECTIONS_API_VERSION}&$filter=${encodeURIComponent(filter)}`
+  });
+
+  const resource = Uri.from({
+    scheme: 'https',
+    authority: getTokenScopeHostName(clusterCategory)
+  });
+
+  try {
+    const { response } = await FetchAccessToken(resource, requestUri, accountId, null, accountId === null, accountHint);
+    if (response.ok) {
+      return true;
+    }
+    if (response.status === 404) {
+      return false;
+    }
+    return undefined;
+  } catch (error) {
+    logger.logInfo(
+      TelemetryEventsKeys.ConnectionCreationInfo,
+      `Connector availability check failed for connector <pii>${normalizedConnector}</pii>: ${(error as Error).message}`
+    );
+    return undefined;
+  }
+};
+
+export interface WaitForConnectorAvailableOptions extends ConnectorAvailabilityOptions {
+  timeoutMs?: number;
+  cancellationToken?: CancellationToken;
+}
+
+const delay = (ms: number, cancellationToken?: CancellationToken): Promise<void> =>
+  new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      listener?.dispose();
+      resolve();
+    }, ms);
+    const listener = cancellationToken?.onCancellationRequested(() => {
+      clearTimeout(timer);
+      resolve();
+    });
+  });
+
+export const waitForConnectorAvailable = async (
+  options: WaitForConnectorAvailableOptions
+): Promise<boolean> => {
+  const timeoutMs = options.timeoutMs ?? 30_000;
+  const normalizedConnector = lastSegment(options.connectorName);
+  const deadline = Date.now() + timeoutMs;
+  let nextDelayMs = 1_000;
+  const maxDelayMs = 3_000;
+
+  while (!options.cancellationToken?.isCancellationRequested) {
+    const available = await connectorAvailable(options);
+    if (available === true) {
+      return true;
+    }
+
+    if (Date.now() >= deadline) {
+      logger.logInfo(
+        TelemetryEventsKeys.ConnectionCreationInfo,
+        `Connector <pii>${normalizedConnector}</pii> was not available in the API Hub within ${timeoutMs} ms; proceeding anyway.`
+      );
+      return false;
+    }
+
+    await delay(Math.min(nextDelayMs, Math.max(0, deadline - Date.now())), options.cancellationToken);
+    nextDelayMs = Math.min(Math.floor(nextDelayMs * 1.5), maxDelayMs);
+  }
+
+  return false;
+};

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/connections/connectionRepair.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/connections/connectionRepair.ts
@@ -1,0 +1,192 @@
+import * as vscode from 'vscode';
+import { ConnectionBinding, ConnectionNeeded, EnvironmentInfo } from '../types';
+import { CoreServicesClusterCategory, TelemetryEventsKeys } from '../constants';
+import logger from '../services/logger';
+import { awaitConnectionCreation } from './connectionCreation';
+import { connectionExists, isCustomConnectorInternalId, waitForConnectorAvailable } from './connectionExistence';
+
+export type ConnectionRepairAccount = { accountId?: string; accountEmail?: string };
+
+export interface ConnectionRepairResult {
+  bindings: ConnectionBinding[];
+  unfinished: string[];
+}
+
+const resolveConnectionLogicalName = (connectionName?: string, connectionId?: string): string => {
+  if (connectionName) {
+    return connectionName;
+  }
+  if (connectionId) {
+    const segments = connectionId.split('/').filter(s => s.length > 0);
+    if (segments.length > 0) {
+      return segments[segments.length - 1];
+    }
+  }
+  return '';
+};
+
+const resolveConnectionsNeeding = async (
+  agentConnections: ConnectionNeeded[],
+  environmentInfo: EnvironmentInfo,
+  clusterCategory: CoreServicesClusterCategory,
+  account: ConnectionRepairAccount | undefined
+): Promise<{ needed: ConnectionNeeded[]; unverified: ConnectionNeeded[] }> => {
+  const needed: ConnectionNeeded[] = [];
+  const unverified: ConnectionNeeded[] = [];
+  for (const connection of agentConnections) {
+    if (!connection.boundConnectionId) {
+      needed.push(connection);
+      continue;
+    }
+
+    const exists = await connectionExists({
+      connectorName: connection.connectorName || connection.connectorId,
+      connectionId: connection.boundConnectionId,
+      environmentId: environmentInfo.environmentId,
+      clusterCategory,
+      accountId: account?.accountId ?? null,
+      accountHint: account?.accountEmail
+    });
+
+    if (exists === false) {
+      needed.push(connection);
+    } else if (exists === undefined) {
+      unverified.push(connection);
+    }
+  }
+  return { needed, unverified };
+};
+
+const createConnections = async (
+  connectionsNeeded: ConnectionNeeded[],
+  environmentInfo: EnvironmentInfo,
+  clusterCategory: CoreServicesClusterCategory
+): Promise<ConnectionRepairResult> => {
+  const count = connectionsNeeded.length;
+  if (count === 0) {
+    return { bindings: [], unfinished: [] };
+  }
+
+  return vscode.window.withProgress(
+    {
+      location: vscode.ProgressLocation.Notification,
+      title: 'Creating connections',
+      cancellable: true
+    },
+    async (progress, token) => {
+      const bindings: ConnectionBinding[] = [];
+      const unfinished: string[] = [];
+
+      for (let i = 0; i < connectionsNeeded.length; i++) {
+        const connection = connectionsNeeded[i];
+        const label = connection.connectorName || connection.connectorId || connection.connectionReferenceLogicalName;
+
+        if (token.isCancellationRequested) {
+          for (let j = i; j < connectionsNeeded.length; j++) {
+            unfinished.push(connectionsNeeded[j].connectionReferenceLogicalName);
+          }
+          break;
+        }
+
+        progress.report({ message: `${i + 1} of ${count}: ${label} — complete it in your browser...` });
+
+        const result = await awaitConnectionCreation({
+          connectorName: connection.connectorName || connection.connectorId,
+          environmentId: environmentInfo.environmentId,
+          clusterCategory,
+          cancellationToken: token
+        });
+
+        if (result.status === 'cancelled') {
+          logger.logInfo(TelemetryEventsKeys.ConnectionCreationInfo, `Connection creation cancelled for <pii>${connection.connectionReferenceLogicalName}</pii>.`);
+          unfinished.push(connection.connectionReferenceLogicalName);
+          continue;
+        }
+
+        if (result.status === 'error') {
+          logger.logError(TelemetryEventsKeys.ConnectionCreationError, `Connection creation failed for <pii>${connection.connectionReferenceLogicalName}</pii>: ${result.errorMessage ?? 'Unknown error'}`);
+          unfinished.push(connection.connectionReferenceLogicalName);
+          continue;
+        }
+
+        const connectionLogicalName = resolveConnectionLogicalName(result.connectionName, result.connectionId);
+        if (!connectionLogicalName) {
+          logger.logError(TelemetryEventsKeys.ConnectionCreationError, `Connection created but no connection identifier was returned for <pii>${connection.connectionReferenceLogicalName}</pii>.`);
+          unfinished.push(connection.connectionReferenceLogicalName);
+          continue;
+        }
+
+        bindings.push({
+          connectionReferenceLogicalName: connection.connectionReferenceLogicalName,
+          connectionLogicalName,
+          connectionDisplayName: result.displayName || connection.connectorName || undefined
+        });
+      }
+
+      return { bindings, unfinished };
+    }
+  );
+};
+
+const waitForCustomConnectorsAvailable = async (
+  connectionsNeeded: ConnectionNeeded[],
+  environmentInfo: EnvironmentInfo,
+  clusterCategory: CoreServicesClusterCategory,
+  account: ConnectionRepairAccount | undefined
+): Promise<void> => {
+  const customConnectors = new Set<string>();
+  for (const connection of connectionsNeeded) {
+    const connectorName = connection.connectorName || connection.connectorId;
+    if (connectorName && isCustomConnectorInternalId(connectorName)) {
+      customConnectors.add(connectorName);
+    }
+  }
+
+  if (customConnectors.size === 0) {
+    return;
+  }
+
+  await vscode.window.withProgress(
+    {
+      location: vscode.ProgressLocation.Notification,
+      title: 'Waiting for custom connectors to be ready...',
+      cancellable: true
+    },
+    async (_progress, token) => {
+      await Promise.all(
+        Array.from(customConnectors, (connectorName) =>
+          waitForConnectorAvailable({
+            connectorName,
+            environmentId: environmentInfo.environmentId,
+            clusterCategory,
+            accountId: account?.accountId ?? null,
+            accountHint: account?.accountEmail,
+            cancellationToken: token
+          })
+        )
+      );
+    }
+  );
+};
+
+export const createAgentConnections = async (
+  agentConnections: ConnectionNeeded[],
+  environmentInfo: EnvironmentInfo,
+  clusterCategory: CoreServicesClusterCategory,
+  account: ConnectionRepairAccount | undefined
+): Promise<ConnectionRepairResult> => {
+  const { needed, unverified } = await resolveConnectionsNeeding(agentConnections, environmentInfo, clusterCategory, account);
+
+  const unverifiedNames = unverified.map(c => c.connectionReferenceLogicalName);
+  for (const connection of unverified) {
+    logger.logWarning(TelemetryEventsKeys.ConnectionCreationError, `Could not verify whether the connection for <pii>${connection.connectionReferenceLogicalName}</pii> still exists; skipping re-creation.`);
+  }
+
+  if (needed.length === 0) {
+    return { bindings: [], unfinished: unverifiedNames };
+  }
+
+  await waitForCustomConnectorsAvailable(needed, environmentInfo, clusterCategory, account);
+  const result = await createConnections(needed, environmentInfo, clusterCategory);
+  return { bindings: result.bindings, unfinished: [...result.unfinished, ...unverifiedNames] };
+};

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/constants.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/constants.ts
@@ -12,7 +12,9 @@ export const LspMethods = {
   LIST_AGENTS: "powerplatformls/listAgents",
   LIST_ENVIRONMENTS: "powerplatformls/listEnvironments",
   LIST_WORKSPACES: "workspace/listWorkspaces",
+  PREPARE_REATTACH: "powerplatformls/prepareReattach",
   REATTACH_AGENT: "powerplatformls/reattachAgent",
+  PREPARE_PUSH: "powerplatformls/preparePush",
   SYNC_PULL: "powerplatformls/syncPull",
   SYNC_PUSH: "powerplatformls/syncPush",
 } as const;
@@ -74,6 +76,8 @@ export const TelemetryEventsKeys = {
   ReadKnowledgeFileError: "ReadKnowledgeFileError",
   ReattachAgentError: "ReattachAgentError",
   ReattachAgentInfo: "ReattachAgentInfo",
+  ConnectionCreationInfo: "ConnectionCreationInfo",
+  ConnectionCreationError: "ConnectionCreationError",
   PostOpenInstruction: "PostOpenInstruction",
   PostOpenError: "PostOpenError",
   WorkspaceRefreshLoopCap: "WorkspaceRefreshLoopCap",

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/sync/workspaceSynchronizer.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/sync/workspaceSynchronizer.ts
@@ -1,12 +1,13 @@
 import * as vscode from 'vscode';
 import { resetAccount } from '../clients/account';
-import { SyncRequest, SyncResponse, WorkflowResponse, AIPromptResponse } from '../types';
+import { SyncRequest, SyncResponse, WorkflowResponse, AIPromptResponse, ConnectionBinding, EnvironmentInfo, PreparePushRequest, PreparePushResponse } from '../types';
 import { CopilotStudioWorkspace, tryRepairAgentManagementEndpoint } from './localWorkspaces';
 import { uploadKnowledgeFiles } from '../knowledgeFiles/uploadKnowledgeFiles';
 import { virtualKnowledgeFileSystemProvider } from '../knowledgeFiles/virtualKnowledgeFile';
 import { knowledgeTreeDataProvider } from '../knowledgeFiles/knowledgeFileTree';
-import { LspMethods, TelemetryEventsKeys } from '../constants';
+import { DefaultCoreServicesClusterCategory, LspMethods, TelemetryEventsKeys } from '../constants';
 import { lspClient, buildLspRequestPayload } from '../services/lspClient';
+import { createAgentConnections } from '../connections/connectionRepair';
 import logger from '../services/logger';
 
 let treeDataProvider: knowledgeTreeDataProvider | undefined;
@@ -68,7 +69,7 @@ export async function withSyncCommandBusy<T>(workspaceUri: string, body: () => P
 export interface WorkspaceSynchronizer {
     workspace: CopilotStudioWorkspace;
     syncState: SyncState;
-    push: (suppressErrorNotification?: boolean) => Promise<SyncResponse | undefined>;
+    push: (suppressErrorNotification?: boolean, connectionBindings?: ConnectionBinding[]) => Promise<SyncResponse | undefined>;
     pull: (virtualProvider: virtualKnowledgeFileSystemProvider) => Promise<SyncResponse | undefined >;
     fetch: () => Promise<void>;
     subscribe: (listener: SyncStateListener) => () => void;
@@ -117,10 +118,10 @@ function getSynchronizer(ws: CopilotStudioWorkspace): WorkspaceSynchronizer {
   return {
     workspace: ws,
     get syncState() { return currentState; },
-    push: async (suppressErrorNotification = false): Promise<SyncResponse> => {
+    push: async (suppressErrorNotification = false, connectionBindings: ConnectionBinding[] = []): Promise<SyncResponse> => {
       return await executeSyncOperation(async () => {
         await uploadKnowledgeFiles(ws);
-        return await sync(ws, 'applying changes', LspMethods.SYNC_PUSH, false, suppressErrorNotification);
+        return await sync(ws, 'applying changes', LspMethods.SYNC_PUSH, false, suppressErrorNotification, connectionBindings);
       }, SyncState.Pushing);
     },
     pull: async (virtualProvider: virtualKnowledgeFileSystemProvider): Promise<SyncResponse> => {
@@ -157,7 +158,7 @@ function getSynchronizer(ws: CopilotStudioWorkspace): WorkspaceSynchronizer {
   };
 }
 
-export async function sync(workspace: CopilotStudioWorkspace, displayText: string, methodName: string, silent: boolean, suppressErrorNotification = false): Promise<SyncResponse> {
+export async function sync(workspace: CopilotStudioWorkspace, displayText: string, methodName: string, silent: boolean, suppressErrorNotification = false, connectionBindings: ConnectionBinding[] = []): Promise<SyncResponse> {
   const { syncInfo, workspaceUri } = workspace;
   if (!syncInfo) {
     throw new Error(`${displayText} failed. Connection file .mcs::conn.json is missing, please clone again.`);
@@ -177,6 +178,7 @@ export async function sync(workspace: CopilotStudioWorkspace, displayText: strin
   const request: SyncRequest = {
     ...await buildLspRequestPayload(syncInfo),
     workspaceUri,
+    connectionBindings,
   };
 
   try {
@@ -188,14 +190,13 @@ export async function sync(workspace: CopilotStudioWorkspace, displayText: strin
     logger.logInfo(TelemetryEventsKeys.SyncWorkspaceSuccess, `Successfully completed ${displayText}`);
     logWorkflowIssues(result.workflowResponse);
     logAIPromptIssues(result.aiPromptResponse);
-    logNewCustomConnectors(result.newlyCreatedCustomConnectors, workspace);
     return result;
   } catch (error) {
     if ((error as Error).message?.includes("UserNotMemberOfOrg")) {
       logger.logError(TelemetryEventsKeys.SyncWorkspaceError, `Your current account does not have permission. Please sign in with the account <pii>(${accountInfo.accountEmail ?? accountInfo.accountId})</pii> to perform this operation.`);
       try {
         resetAccount();
-        return await sync(workspace, displayText, methodName, silent, suppressErrorNotification); // Retry sync with new log in
+        return await sync(workspace, displayText, methodName, silent, suppressErrorNotification, connectionBindings);
       } catch (error) {
         logger.logError(TelemetryEventsKeys.SyncWorkspaceError, `Re-authentication failed: ${(error as Error).message}`);
         throw error;
@@ -208,6 +209,63 @@ export async function sync(workspace: CopilotStudioWorkspace, displayText: strin
       throw error;
     }
   }
+}
+
+export type PreparePushConnectionsResult =
+  | { status: 'ready'; bindings: ConnectionBinding[] }
+  | { status: 'failed' }
+  | { status: 'incomplete'; bindings: ConnectionBinding[]; unfinished: string[] };
+
+export async function preparePushConnections(ws: CopilotStudioWorkspace): Promise<PreparePushConnectionsResult> {
+  const { syncInfo, workspaceUri } = ws;
+  if (!syncInfo) {
+    return { status: 'ready', bindings: [] };
+  }
+
+  const request: PreparePushRequest = {
+    ...await buildLspRequestPayload(syncInfo),
+    workspaceUri,
+  };
+
+  const prepareResult = await lspClient.sendRequest<PreparePushResponse>(LspMethods.PREPARE_PUSH, request);
+  if (prepareResult.code !== 200) {
+    logger.logError(TelemetryEventsKeys.ConnectionCreationError, `Prepare push for connections failed: ${prepareResult.message ?? 'Unknown error'}`);
+    return { status: 'failed' };
+  }
+
+  if (!prepareResult.agentConnections || prepareResult.agentConnections.length === 0) {
+    return { status: 'ready', bindings: [] };
+  }
+
+  const environmentInfo: EnvironmentInfo = {
+    environmentId: syncInfo.environmentId,
+    dataverseUrl: syncInfo.dataverseEndpoint,
+    agentManagementUrl: syncInfo.agentManagementEndpoint,
+    displayName: ''
+  };
+  const account = {
+    accountId: syncInfo.accountInfo.accountId,
+    accountEmail: syncInfo.accountInfo.accountEmail
+  };
+
+  let repair;
+  try {
+    repair = await createAgentConnections(
+      prepareResult.agentConnections,
+      environmentInfo,
+      syncInfo.accountInfo.clusterCategory ?? DefaultCoreServicesClusterCategory,
+      account
+    );
+  } catch (error) {
+    logger.logError(TelemetryEventsKeys.ConnectionCreationError, `Error creating agent connections: ${(error as Error).message}`);
+    return { status: 'failed' };
+  }
+
+  if (repair.unfinished.length > 0) {
+    return { status: 'incomplete', bindings: repair.bindings, unfinished: repair.unfinished };
+  }
+
+  return { status: 'ready', bindings: repair.bindings };
 }
 
 export function logWorkflowIssues(workflows: WorkflowResponse[] | undefined) {
@@ -234,10 +292,6 @@ export function logWorkflowIssues(workflows: WorkflowResponse[] | undefined) {
   }
 }
 
-export function logNewCustomConnectors(connectors: string[] | undefined, workspace: CopilotStudioWorkspace) {
-  logNewCustomConnectorsRaw(connectors, workspace.workspaceUri);
-}
-
 export function logAIPromptIssues(prompts: AIPromptResponse[] | undefined) {
   if (!prompts?.length) {
     return;
@@ -254,21 +308,6 @@ export function logAIPromptIssues(prompts: AIPromptResponse[] | undefined) {
     logger.logError(
       TelemetryEventsKeys.SyncWorkspaceError,
       `Failed to push AI Builder prompt(s): ${failed.join('; ')}`
-    );
-  }
-}
-
-export function logNewCustomConnectorsRaw(connectors: string[] | undefined, workspaceUri: string) {
-  if (!connectors?.length) {
-    return;
-  }
-  const agentName = workspaceUri.split(/[\\/]/).filter(Boolean).pop() ?? 'agent';
-  for (const connectorName of connectors) {
-    logger.logWarning(
-      TelemetryEventsKeys.SyncWorkspaceSuccess,
-      `New custom connector '${connectorName}' was created. ` +
-      `Go to Power Apps maker (https://make.powerapps.com) to create a Connection for this connector, ` +
-      `then update the connection reference in VS Code and apply the change.`
     );
   }
 }

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/types.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/types.ts
@@ -22,7 +22,6 @@ export interface AgentSyncInfo {
   environmentId: string;
 
   // TODO: This will break with component collections.
-  // This will break with component collections.
   agentId: string;
 
   accountInfo: AccountInfo;
@@ -32,13 +31,13 @@ export interface AgentSyncInfo {
 export interface SyncRequest extends RemoteApiRequest {
   // Workspace URI: get from vscode.WorkspaceFolder;
   workspaceUri: string;
+  connectionBindings?: ConnectionBinding[];
 }
 
 export interface SyncResponse extends RemoteApiResponse {
   localChanges: Change[];
   workflowResponse: WorkflowResponse[];
   aiPromptResponse?: AIPromptResponse[];
-  newlyCreatedCustomConnectors?: string[];
 }
 
 export interface GetFileRequest {
@@ -133,6 +132,10 @@ export interface ClonedAssets {
 
 export interface ReattachAgentRequest extends RemoteApiRequest {
   workspaceUri: string;
+  agentSyncInfo?: AgentSyncInfo;
+  connectionBindings?: ConnectionBinding[];
+  isNewAgent: boolean;
+  updateWorkspaceDirectory: boolean;
 }
 
 export interface ReattachAgentResponse extends RemoteApiResponse {
@@ -140,7 +143,38 @@ export interface ReattachAgentResponse extends RemoteApiResponse {
   isNewAgent: boolean;
   workflowResponse: WorkflowResponse[];
   aiPromptResponse?: AIPromptResponse[];
-  newlyCreatedCustomConnectors?: string[];
+}
+
+export interface PrepareReattachRequest extends RemoteApiRequest {
+  workspaceUri: string;
+}
+
+export interface PrepareReattachResponse extends RemoteApiResponse {
+  agentSyncInfo: AgentSyncInfo;
+  isNewAgent: boolean;
+  updateWorkspaceDirectory: boolean;
+  agentConnections?: ConnectionNeeded[];
+}
+
+export interface PreparePushRequest extends RemoteApiRequest {
+  workspaceUri: string;
+}
+
+export interface PreparePushResponse extends RemoteApiResponse {
+  agentConnections?: ConnectionNeeded[];
+}
+
+export interface ConnectionNeeded {
+  connectionReferenceLogicalName: string;
+  connectorId: string;
+  connectorName: string;
+  boundConnectionId: string;
+}
+
+export interface ConnectionBinding {
+  connectionReferenceLogicalName: string;
+  connectionLogicalName: string;
+  connectionDisplayName?: string;
 }
 
 export interface WorkflowResponse {

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/types.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/types.ts
@@ -132,7 +132,7 @@ export interface ClonedAssets {
 
 export interface ReattachAgentRequest extends RemoteApiRequest {
   workspaceUri: string;
-  agentSyncInfo?: AgentSyncInfo;
+  agentSyncInfo: AgentSyncInfo;
   connectionBindings?: ConnectionBinding[];
   isNewAgent: boolean;
   updateWorkspaceDirectory: boolean;

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/esbuild.js
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/esbuild.js
@@ -15,12 +15,6 @@ async function main() {
     mainFields: ['module', 'main'],
     outfile: 'dist/extension.js',
     external: ['vscode'],
-    define: {
-      'import.meta.url': 'importMetaUrl'
-    },
-    banner: {
-      js: "const importMetaUrl = require('url').pathToFileURL(__filename).href;"
-    },
     logLevel: 'warning',
     plugins: [
       /* add to the end of plugins array */

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/esbuild.js
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/esbuild.js
@@ -15,6 +15,12 @@ async function main() {
     mainFields: ['module', 'main'],
     outfile: 'dist/extension.js',
     external: ['vscode'],
+    define: {
+      'import.meta.url': 'importMetaUrl'
+    },
+    banner: {
+      js: "const importMetaUrl = require('url').pathToFileURL(__filename).href;"
+    },
     logLevel: 'warning',
     plugins: [
       /* add to the end of plugins array */

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/package.json
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/package.json
@@ -364,6 +364,7 @@
     "@types/semver": "^7.7.0",
     "@vscode/extension-telemetry": "^1.0.0",
     "jsonc-parser": "^3.3.1",
+    "open": "^10.2.0",
     "semver": "^7.7.2"
   },
   "overrides": {

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/package.json
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/package.json
@@ -364,7 +364,6 @@
     "@types/semver": "^7.7.0",
     "@vscode/extension-telemetry": "^1.0.0",
     "jsonc-parser": "^3.3.1",
-    "open": "^10.2.0",
     "semver": "^7.7.2"
   },
   "overrides": {

--- a/src/vscode-extensions/package-lock.json
+++ b/src/vscode-extensions/package-lock.json
@@ -17,7 +17,6 @@
         "@types/semver": "^7.7.0",
         "@vscode/extension-telemetry": "^1.0.0",
         "jsonc-parser": "^3.3.1",
-        "open": "^10.2.0",
         "semver": "^7.7.2"
       },
       "devDependencies": {
@@ -1361,20 +1360,6 @@
         "node": "18 || 20 || >=22"
       }
     },
-    "node_modules/bundle-name": {
-      "version": "4.1.0",
-      "integrity": "sha1-87lrNBYNZDGhnXaIE1r3z7h5eIk=",
-      "license": "MIT",
-      "dependencies": {
-        "run-applescript": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
       "integrity": "sha1-JKSDHs9aawHd6zL7caSyCIsNzjg=",
@@ -1497,43 +1482,6 @@
       "integrity": "sha1-pvLc5hL63S7x9Rm3NVHxfoUZmDE=",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/default-browser": {
-      "version": "5.5.0",
-      "integrity": "sha1-J5LohvJCKJRUWUfMgOGkRElsWXY=",
-      "license": "MIT",
-      "dependencies": {
-        "bundle-name": "^4.1.0",
-        "default-browser-id": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/default-browser-id": {
-      "version": "5.0.1",
-      "integrity": "sha1-96fMuPUQS/jg9xujscz6Xq/bIeg=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/define-lazy-prop": {
-      "version": "3.0.0",
-      "integrity": "sha1-27Ga37dG1/xtc0oGty9KANAhJV8=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -1895,20 +1843,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/is-docker": {
-      "version": "3.0.0",
-      "integrity": "sha1-kAk6oxBid9inelkQ265xdH4VogA=",
-      "license": "MIT",
-      "bin": {
-        "is-docker": "cli.js"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
@@ -1939,23 +1873,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-inside-container": {
-      "version": "1.0.0",
-      "integrity": "sha1-6B+6aZZi6zHb2vJnZqYdSBRxfqQ=",
-      "license": "MIT",
-      "dependencies": {
-        "is-docker": "^3.0.0"
-      },
-      "bin": {
-        "is-inside-container": "cli.js"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-interactive": {
       "version": "2.0.0",
       "integrity": "sha1-QMV2FFk4JtoRAK3mBZd41ZfxbpA=",
@@ -1963,20 +1880,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-wsl": {
-      "version": "3.1.1",
-      "integrity": "sha1-MniXsmgyo+sRfabCdJLQTKEyWU8=",
-      "license": "MIT",
-      "dependencies": {
-        "is-inside-container": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -2187,21 +2090,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/npm-run-all2/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/npm-run-all2/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/npm-run-all2/node_modules/isexe": {
       "version": "3.1.5",
       "integrity": "sha1-QuNo9o1eENrf7k/ae1ULwtiJLck=",
@@ -2209,21 +2097,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/npm-run-all2/node_modules/minimatch": {
-      "version": "9.0.9",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/npm-run-all2/node_modules/which": {
@@ -2248,23 +2121,6 @@
       "license": "MIT",
       "dependencies": {
         "mimic-function": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/open": {
-      "version": "10.2.0",
-      "integrity": "sha1-udhVvgB2IOgLb7BfrJgUH+Yttzw=",
-      "license": "MIT",
-      "dependencies": {
-        "default-browser": "^5.2.1",
-        "define-lazy-prop": "^3.0.0",
-        "is-inside-container": "^1.0.0",
-        "wsl-utils": "^0.1.0"
       },
       "engines": {
         "node": ">=18"
@@ -2537,17 +2393,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/run-applescript": {
-      "version": "7.1.0",
-      "integrity": "sha1-Lp5UxGZOwxBsW1Yw4knT1llcSRE=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/semver": {
       "version": "7.7.4",
       "integrity": "sha1-KEZONgYOmR+noR0CedLT87V6foo=",
@@ -2591,8 +2436,8 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.8.3",
+      "integrity": "sha1-VeQO8zz1xomQI1Oj2M0aZyXwi0s=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2852,20 +2697,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/wsl-utils": {
-      "version": "0.1.0",
-      "integrity": "sha1-h4PU32cdTVA2W+LuTHGRegVXuqs=",
-      "license": "MIT",
-      "dependencies": {
-        "is-wsl": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/y18n": {

--- a/src/vscode-extensions/package-lock.json
+++ b/src/vscode-extensions/package-lock.json
@@ -2090,6 +2090,21 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/npm-run-all2/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/npm-run-all2/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/npm-run-all2/node_modules/isexe": {
       "version": "3.1.5",
       "integrity": "sha1-QuNo9o1eENrf7k/ae1ULwtiJLck=",
@@ -2097,6 +2112,21 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/npm-run-all2/node_modules/minimatch": {
+      "version": "9.0.9",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/npm-run-all2/node_modules/which": {
@@ -2436,8 +2466,8 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "integrity": "sha1-VeQO8zz1xomQI1Oj2M0aZyXwi0s=",
+      "version": "1.8.4",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/src/vscode-extensions/package-lock.json
+++ b/src/vscode-extensions/package-lock.json
@@ -17,6 +17,7 @@
         "@types/semver": "^7.7.0",
         "@vscode/extension-telemetry": "^1.0.0",
         "jsonc-parser": "^3.3.1",
+        "open": "^10.2.0",
         "semver": "^7.7.2"
       },
       "devDependencies": {
@@ -1360,6 +1361,20 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "integrity": "sha1-87lrNBYNZDGhnXaIE1r3z7h5eIk=",
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
       "integrity": "sha1-JKSDHs9aawHd6zL7caSyCIsNzjg=",
@@ -1482,6 +1497,43 @@
       "integrity": "sha1-pvLc5hL63S7x9Rm3NVHxfoUZmDE=",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "integrity": "sha1-J5LohvJCKJRUWUfMgOGkRElsWXY=",
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "integrity": "sha1-96fMuPUQS/jg9xujscz6Xq/bIeg=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "integrity": "sha1-27Ga37dG1/xtc0oGty9KANAhJV8=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -1843,6 +1895,20 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "integrity": "sha1-kAk6oxBid9inelkQ265xdH4VogA=",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
@@ -1873,6 +1939,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "integrity": "sha1-6B+6aZZi6zHb2vJnZqYdSBRxfqQ=",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-interactive": {
       "version": "2.0.0",
       "integrity": "sha1-QMV2FFk4JtoRAK3mBZd41ZfxbpA=",
@@ -1880,6 +1963,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "integrity": "sha1-MniXsmgyo+sRfabCdJLQTKEyWU8=",
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -2159,6 +2256,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/open": {
+      "version": "10.2.0",
+      "integrity": "sha1-udhVvgB2IOgLb7BfrJgUH+Yttzw=",
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "integrity": "sha1-fqHBpdkddk+yghOciP4R4YKjpzQ=",
@@ -2416,6 +2530,17 @@
         "onetime": "^7.0.0",
         "signal-exit": "^4.1.0"
       },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "integrity": "sha1-Lp5UxGZOwxBsW1Yw4knT1llcSRE=",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -2727,6 +2852,20 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "integrity": "sha1-h4PU32cdTVA2W+LuTHGRegVXuqs=",
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/y18n": {


### PR DESCRIPTION
Auto create connections for reattach/push via connection creation page.
Fix reattach for child agent.
Fix: https://github.com/microsoft/vscode-copilotstudio/issues/285