### PR TITLE
Reduce log noise, refactor LSP logging and standardize output channel

### DIFF
--- a/src/LanguageServers/CLaSP/AbstractLanguageServer.cs
+++ b/src/LanguageServers/CLaSP/AbstractLanguageServer.cs
@@ -192,11 +192,18 @@ namespace Microsoft.CommonLanguageServerProtocol.Framework
         {
             var handlerProvider = HandlerProvider;
             var queue = new RequestExecutionQueue<TRequestContext>(this, Logger, handlerProvider);
-
+            queue.RequestIdAccessor = GetCurrentRequestId;
             queue.Start();
 
             return queue;
         }
+
+        /// <summary>
+        /// Returns the current request correlation ID from the caller's ambient context.
+        /// Override to provide application-specific request ID propagation (e.g., AsyncLocal).
+        /// The default returns 0 (no correlation).
+        /// </summary>
+        protected virtual int GetCurrentRequestId() => 0;
 
         protected IRequestExecutionQueue<TRequestContext> GetRequestExecutionQueue()
         {

--- a/src/LanguageServers/CLaSP/ILspLogger.cs
+++ b/src/LanguageServers/CLaSP/ILspLogger.cs
@@ -8,8 +8,8 @@ namespace Microsoft.CommonLanguageServerProtocol.Framework
 
     public interface ILspLogger
     {
-        void LogStartContext(string message, params object[] @params);
-        void LogEndContext(string message, params object[] @params);
+        void LogStartContext(string methodName);
+        void LogEndContext(string methodName, long durationMs = -1);
         void LogDebug(string message, params object[] @params);
         void LogInformation(string message, params object[] @params);
 
@@ -21,5 +21,12 @@ namespace Microsoft.CommonLanguageServerProtocol.Framework
         void LogWarning(string message, params object[] @params);
         void LogError(string message, params object[] @params);
         void LogException(Exception exception, string? message = null, params object[] @params);
+
+        /// <summary>
+        /// Sets the ambient request ID for the current execution context.
+        /// Called by the queue before handler execution to restore correlation context
+        /// that cannot flow via AsyncLocal across queue boundaries.
+        /// </summary>
+        void SetCurrentRequestId(int requestId) { }
     }
 }

--- a/src/LanguageServers/CLaSP/ILspLogger.cs
+++ b/src/LanguageServers/CLaSP/ILspLogger.cs
@@ -10,6 +10,7 @@ namespace Microsoft.CommonLanguageServerProtocol.Framework
     {
         void LogStartContext(string message, params object[] @params);
         void LogEndContext(string message, params object[] @params);
+        void LogDebug(string message, params object[] @params);
         void LogInformation(string message, params object[] @params);
 
         /// <summary>

--- a/src/LanguageServers/CLaSP/IQueueItem.cs
+++ b/src/LanguageServers/CLaSP/IQueueItem.cs
@@ -51,6 +51,12 @@ namespace Microsoft.CommonLanguageServerProtocol.Framework
         /// </summary>
         string MethodName { get; }
 
+        /// <summary>
+        /// The request correlation ID assigned at receive time.
+        /// Carried through the queue so handlers can restore ambient context.
+        /// </summary>
+        int RequestId { get; set; }
+
         object? SerializedRequest { get; }
     }
 }

--- a/src/LanguageServers/CLaSP/QueueItem.cs
+++ b/src/LanguageServers/CLaSP/QueueItem.cs
@@ -40,6 +40,8 @@ namespace Microsoft.CommonLanguageServerProtocol.Framework
 
         public string MethodName { get; }
 
+        public int RequestId { get; set; }
+
         public object? SerializedRequest { get; }
 
         private QueueItem(
@@ -136,7 +138,7 @@ namespace Microsoft.CommonLanguageServerProtocol.Framework
 
                 // End the request - the caller will return immediately if it cannot deserialize.
                 _requestTelemetryScope?.Dispose();
-                _logger.LogEndContext($"{MethodName}");
+                _logger.LogEndContext(MethodName);
 
                 // If the request is mutating, bubble the exception out so the queue shuts down.
                 if (isMutating)
@@ -159,7 +161,10 @@ namespace Microsoft.CommonLanguageServerProtocol.Framework
         public async Task StartRequestAsync<TRequest, TResponse>(TRequest request, TRequestContext? context, IMethodHandler handler, string language, CancellationToken cancellationToken)
         {
             _requestHandlingStarted = true;
-            _logger.LogStartContext($"{MethodName}");
+            // Restore the request ID into ambient context — it was captured at enqueue time
+            // but doesn't flow across the queue boundary via AsyncLocal.
+            _logger.SetCurrentRequestId(RequestId);
+            _logger.LogStartContext(MethodName);
             Stopwatch stopwatch = Stopwatch.StartNew();
 
             try
@@ -235,8 +240,7 @@ namespace Microsoft.CommonLanguageServerProtocol.Framework
             finally
             {
                 _requestTelemetryScope?.Dispose();
-                var time1 = stopwatch.ElapsedMilliseconds;
-                _logger.LogEndContext($"{MethodName}, duration={time1}ms");
+                _logger.LogEndContext(MethodName, stopwatch.ElapsedMilliseconds);
             }
 
             // Return the result of this completion source to the caller

--- a/src/LanguageServers/CLaSP/RequestExecutionQueue.cs
+++ b/src/LanguageServers/CLaSP/RequestExecutionQueue.cs
@@ -59,6 +59,12 @@ namespace Microsoft.CommonLanguageServerProtocol.Framework
         private readonly AbstractLanguageServer<TRequestContext> _languageServer;
 
         /// <summary>
+        /// Optional callback to capture the current request correlation ID at enqueue time.
+        /// The captured value is stored on the QueueItem and restored before handler execution.
+        /// </summary>
+        public Func<int>? RequestIdAccessor { get; set; }
+
+        /// <summary>
         /// The queue containing the ordered LSP requests along with the trace activityId (to associate logs with a request) and
         ///  a combined cancellation token representing the queue's cancellation token and the individual request cancellation token.
         /// </summary>
@@ -168,6 +174,10 @@ namespace Microsoft.CommonLanguageServerProtocol.Framework
                 lspServices,
                 _logger,
                 combinedCancellationToken);
+
+            // Capture the request correlation ID while still in the caller's async context.
+            // This value will be restored onto the handler's context in StartRequestAsync.
+            item.RequestId = RequestIdAccessor?.Invoke() ?? 0;
 
             // Run a continuation to ensure the cts is disposed of.
             // We pass CancellationToken.None as we always want to dispose of the source

--- a/src/LanguageServers/PowerPlatformLS/Contracts.Internal/Common/LspRequestContext.cs
+++ b/src/LanguageServers/PowerPlatformLS/Contracts.Internal/Common/LspRequestContext.cs
@@ -1,0 +1,24 @@
+namespace Microsoft.PowerPlatformLS.Contracts.Internal.Common
+{
+    using System.Threading;
+
+    /// <summary>
+    /// Provides ambient context for the current LSP request ID.
+    /// Set by JsonRpcStream when a custom method is received, read by any
+    /// downstream service (HTTP handler, operation logger) to correlate logs.
+    /// </summary>
+    public static class LspRequestContext
+    {
+        private static readonly AsyncLocal<int> _currentRequestId = new();
+
+        /// <summary>
+        /// Gets or sets the current LSP request ID for the executing async flow.
+        /// Returns 0 when no request is active.
+        /// </summary>
+        public static int CurrentRequestId
+        {
+            get => _currentRequestId.Value;
+            set => _currentRequestId.Value = value;
+        }
+    }
+}

--- a/src/LanguageServers/PowerPlatformLS/Contracts.Internal/Common/LspRequestContext.cs
+++ b/src/LanguageServers/PowerPlatformLS/Contracts.Internal/Common/LspRequestContext.cs
@@ -4,8 +4,9 @@ namespace Microsoft.PowerPlatformLS.Contracts.Internal.Common
 
     /// <summary>
     /// Provides ambient context for the current LSP request ID.
-    /// Set by JsonRpcStream when a custom method is received, read by any
-    /// downstream service (HTTP handler, operation logger) to correlate logs.
+    /// Set by JsonRpcStream at receive time, carried through the queue via
+    /// QueueItem.RequestId, and restored by SetCurrentRequestId before handler execution.
+    /// Read by downstream services (HTTP handler, operation logger) to correlate logs.
     /// </summary>
     public static class LspRequestContext
     {

--- a/src/LanguageServers/PowerPlatformLS/Contracts.LSP/Models/SetTraceParams.cs
+++ b/src/LanguageServers/PowerPlatformLS/Contracts.LSP/Models/SetTraceParams.cs
@@ -1,0 +1,12 @@
+namespace Microsoft.PowerPlatformLS.Contracts.Lsp.Models
+{
+    /// <summary>
+    /// Parameters for the $/setTrace notification.
+    /// Implements IDefaultContextRequest so the RequestContextFactory
+    /// does not log a warning about unresolved context.
+    /// </summary>
+    public sealed class SetTraceParams : IDefaultContextRequest
+    {
+        public string? Value { get; set; }
+    }
+}

--- a/src/LanguageServers/PowerPlatformLS/Impl.Core/DependencyInjection/CoreLspModule.cs
+++ b/src/LanguageServers/PowerPlatformLS/Impl.Core/DependencyInjection/CoreLspModule.cs
@@ -42,6 +42,7 @@
             services.AddHandler<CodeActionHandler>();
             services.AddHandler<DidRenameHandler>();
             services.AddHandler<ListWorkspacesHandler>();
+            services.AddHandler<SetTraceHandler>();
         }
     }
 }

--- a/src/LanguageServers/PowerPlatformLS/Impl.Core/DependencyInjection/HostApplicationBuilderExtensions.cs
+++ b/src/LanguageServers/PowerPlatformLS/Impl.Core/DependencyInjection/HostApplicationBuilderExtensions.cs
@@ -39,6 +39,18 @@ namespace Microsoft.PowerPlatformLS.Impl.Core.DependencyInjection
         {
             builder.Logging.ClearProviders();
             builder.Logging.Services.AddSingleton<ILoggerProvider, LspWindowLogMessageLoggerProvider>();
+
+            // Allow all levels for our code. The VS Code output channel dropdown
+            // controls which levels are displayed (user sets it to Info for normal use,
+            // switches to Trace/Debug when troubleshooting).
+            builder.Logging.AddFilter("Microsoft.PowerPlatformLS", LogLevel.Trace);
+
+            // Prevent recursive logging: BaseIpcTransport logs every send at Trace level,
+            // which would trigger another window/logMessage send, creating an infinite loop.
+            builder.Logging.AddFilter<LspWindowLogMessageLoggerProvider>(
+                "Microsoft.PowerPlatformLS.Impl.Core.IpcTransport.BaseIpcTransport",
+                LogLevel.Information);
+
             return builder;
         }
 

--- a/src/LanguageServers/PowerPlatformLS/Impl.Core/JsonRpcStream.cs
+++ b/src/LanguageServers/PowerPlatformLS/Impl.Core/JsonRpcStream.cs
@@ -5,8 +5,10 @@ namespace Microsoft.PowerPlatformLS.Impl.Core
     using Microsoft.CommonLanguageServerProtocol.Framework.JsonRpc;
     using Microsoft.Extensions.Logging;
     using Microsoft.PowerPlatformLS.Contracts.Internal;
+    using Microsoft.PowerPlatformLS.Contracts.Internal.Common;
     using Microsoft.PowerPlatformLS.Contracts.Lsp.Exceptions;
     using Microsoft.PowerPlatformLS.Contracts.Lsp.Models;
+    using Microsoft.PowerPlatformLS.Impl.Core.Lsp;
     using System;
     using System.Reflection;
     using System.Text.Json;
@@ -55,7 +57,12 @@ namespace Microsoft.PowerPlatformLS.Impl.Core
                 }
                 else if (message is LspJsonRpcMessage lspMessage)
                 {
-                    _logger.LogInformation($"Received Message: method={lspMessage.Method}, id={lspMessage.Id}");
+                    int reqId = 0;
+                    if (!LspLogger.IsBuiltInLspMethod(lspMessage.Method))
+                    {
+                        reqId = LspLogger.AllocateRequestId(lspMessage.Method);
+                        _logger.LogTrace("[Req: {ReqId}] LSP request received: {Method}", reqId, lspMessage.Method);
+                    }
 
                     // Release the LSP log-forwarding pump once the client is initialized.
                     if (string.Equals(lspMessage.Method, LspMethods.Initialized, StringComparison.Ordinal))
@@ -65,7 +72,7 @@ namespace Microsoft.PowerPlatformLS.Impl.Core
 
                     // Don't await processing task and let them run in parallel.
                     // Scheduling is done in the server queue.
-                    _ = ProcessJsonRpcMessageAsync(lspMessage, stoppingToken);
+                    _ = ProcessJsonRpcMessageAsync(lspMessage, reqId, stoppingToken);
                 }
                 else
                 {
@@ -79,12 +86,15 @@ namespace Microsoft.PowerPlatformLS.Impl.Core
             }
         }
 
-        private async Task ProcessJsonRpcMessageAsync(LspJsonRpcMessage request, CancellationToken stoppingToken)
+        private async Task ProcessJsonRpcMessageAsync(LspJsonRpcMessage request, int reqId, CancellationToken stoppingToken)
         {
+            // Set the AsyncLocal so response logs in this task context use the correct ID.
+            LspRequestContext.CurrentRequestId = reqId;
+
             // Lookup the method by its RPC method name.
             if (!_rpcMethods.TryGetValue(request.Method, out var entry))
             {
-                _logger.LogWarning($"Method '{request.Method}' is not registered. Wont't process event with id '{request.Id}'");
+                _logger.LogWarning($"Method '{request.Method}' is not registered. Won't process event with id '{request.Id}'");
                 return;
             }
 
@@ -106,7 +116,11 @@ namespace Microsoft.PowerPlatformLS.Impl.Core
                     {
                         // Extract the result dynamically
                         object? result = returnType.GetProperty("Result")?.GetValue(task);
-                        _logger.LogTrace($"LSP Method Handler Task completed for {request.Method}({request.Id}) with result: {result ?? Constants.Null}");
+
+                        if (!LspLogger.IsBuiltInLspMethod(request.Method))
+                        {
+                            _logger.LogTrace("[Req: {ReqId}] LSP response sent: {Method}, result={Result}", reqId, request.Method, result ?? Constants.Null);
+                        }
 
                         if (request.Id.HasValue)
                         {
@@ -128,14 +142,17 @@ namespace Microsoft.PowerPlatformLS.Impl.Core
                     else
                     {
                         // Non-generic Task — handler returned no value.
+                        if (!LspLogger.IsBuiltInLspMethod(request.Method))
+                        {
+                            _logger.LogTrace("[Req: {ReqId}] LSP response sent: {Method}, result=none", reqId, request.Method);
+                        }
+
                         if (request.Id.HasValue)
                         {
-                            _logger.LogTrace($"LSP Method Handler Task completed for {request.Method}({request.Id}) with no result. Sending null response.");
                             response = new JsonRpcResponse { Id = request.Id, Result = JsonSerializer.SerializeToElement<object?>(null) };
                         }
                         else
                         {
-                            _logger.LogTrace($"LSP Notification Handler Task completed for {request.Method}.");
                             response = null;
                         }
                     }

--- a/src/LanguageServers/PowerPlatformLS/Impl.Core/JsonRpcStream.cs
+++ b/src/LanguageServers/PowerPlatformLS/Impl.Core/JsonRpcStream.cs
@@ -27,7 +27,6 @@ namespace Microsoft.PowerPlatformLS.Impl.Core
 
         public Func<object?, Task>? DisconnectServerAction { get; set; }
 
-        
         public void AddLocalRpcMethod(MethodInfo handler, object? target, string methodName)
         {
             _rpcMethods[methodName] = (handler, target);
@@ -60,7 +59,7 @@ namespace Microsoft.PowerPlatformLS.Impl.Core
                     int reqId = 0;
                     if (!LspLogger.IsBuiltInLspMethod(lspMessage.Method))
                     {
-                        reqId = LspLogger.AllocateRequestId(lspMessage.Method);
+                        reqId = LspLogger.AllocateRequestId();
                         _logger.LogTrace("[Req: {ReqId}] LSP request received: {Method}", reqId, lspMessage.Method);
                     }
 
@@ -88,7 +87,9 @@ namespace Microsoft.PowerPlatformLS.Impl.Core
 
         private async Task ProcessJsonRpcMessageAsync(LspJsonRpcMessage request, int reqId, CancellationToken stoppingToken)
         {
-            // Set the AsyncLocal so response logs in this task context use the correct ID.
+            // Set the AsyncLocal so the request ID flows to ExecuteAsync (same async context).
+            // The queue's RequestIdAccessor reads it there and stores it on the QueueItem,
+            // which then restores it in StartRequestAsync before handler execution.
             LspRequestContext.CurrentRequestId = reqId;
 
             // Lookup the method by its RPC method name.

--- a/src/LanguageServers/PowerPlatformLS/Impl.Core/LSP/DiagnosticsPublisher.cs
+++ b/src/LanguageServers/PowerPlatformLS/Impl.Core/LSP/DiagnosticsPublisher.cs
@@ -13,11 +13,13 @@
     {
         private readonly ILspServices _lspServices;
         private readonly ILspTransport _transport;
+        private readonly ILspLogger _logger;
 
-        public DiagnosticsPublisher(ILspServices lspServices, ILspTransport transport)
+        public DiagnosticsPublisher(ILspServices lspServices, ILspTransport transport, ILspLogger logger)
         {
             _lspServices = lspServices;
             _transport = transport;
+            _logger = logger;
         }
 
         async Task IDiagnosticsPublisher.ClearDiagnosticsAsync(Uri documentUri, CancellationToken cancellationToken)
@@ -73,6 +75,23 @@
             };
 
             await _transport.SendAsync(message, cancellationToken);
+
+            var fileName = Path.GetFileName(context.Document.Uri.LocalPath);
+            foreach (var diagnostic in diagnostics)
+            {
+                var line = (diagnostic.Range?.Start.Line ?? 0) + 1;
+                var col = (diagnostic.Range?.Start.Character ?? 0) + 1;
+
+                switch (diagnostic.Severity)
+                {
+                    case DiagnosticSeverity.Error:
+                        _logger.LogError($"textDocument/publishDiagnostics: {fileName}(ln {line}, col {col}): {diagnostic.Message}");
+                        break;
+                    case DiagnosticSeverity.Warning:
+                        _logger.LogWarning($"textDocument/publishDiagnostics: {fileName}(ln {line}, col {col}): {diagnostic.Message}");
+                        break;
+                }
+            }
         }
     }
 }

--- a/src/LanguageServers/PowerPlatformLS/Impl.Core/LSP/DiagnosticsPublisher.cs
+++ b/src/LanguageServers/PowerPlatformLS/Impl.Core/LSP/DiagnosticsPublisher.cs
@@ -85,10 +85,10 @@
                 switch (diagnostic.Severity)
                 {
                     case DiagnosticSeverity.Error:
-                        _logger.LogError($"textDocument/publishDiagnostics: {fileName}(ln {line}, col {col}): {diagnostic.Message}");
+                        _logger.LogDebug($"textDocument/publishDiagnostics: {fileName}(ln {line}, col {col}): {diagnostic.Message}");
                         break;
                     case DiagnosticSeverity.Warning:
-                        _logger.LogWarning($"textDocument/publishDiagnostics: {fileName}(ln {line}, col {col}): {diagnostic.Message}");
+                        _logger.LogDebug($"textDocument/publishDiagnostics: {fileName}(ln {line}, col {col}): {diagnostic.Message}");
                         break;
                 }
             }

--- a/src/LanguageServers/PowerPlatformLS/Impl.Core/LSP/Handlers/SetTraceHandler.cs
+++ b/src/LanguageServers/PowerPlatformLS/Impl.Core/LSP/Handlers/SetTraceHandler.cs
@@ -1,0 +1,24 @@
+namespace Microsoft.PowerPlatformLS.Impl.Core.Lsp.Handlers
+{
+    using Microsoft.CommonLanguageServerProtocol.Framework;
+    using Microsoft.PowerPlatformLS.Contracts.Internal.Models;
+    using Microsoft.PowerPlatformLS.Contracts.Lsp.Models;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Handles the $/setTrace notification sent by VS Code when the user changes the log level.
+    /// This is a standard LSP notification that servers should accept gracefully.
+    /// Our tracing is controlled via MEL log levels, so this is a no-op.
+    /// </summary>
+    [LanguageServerEndpoint("$/setTrace", LanguageServerConstants.DefaultLanguageName)]
+    internal class SetTraceHandler : INotificationHandler<SetTraceParams, RequestContext>
+    {
+        public bool MutatesSolutionState => false;
+
+        public Task HandleNotificationAsync(SetTraceParams request, RequestContext requestContext, CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/LanguageServers/PowerPlatformLS/Impl.Core/LSP/LanguageServer.cs
+++ b/src/LanguageServers/PowerPlatformLS/Impl.Core/LSP/LanguageServer.cs
@@ -8,6 +8,7 @@ namespace Microsoft.PowerPlatformLS.Impl.Core.Lsp
     using Microsoft.PowerPlatformLS.Contracts.Internal.Models;
     using Microsoft.CommonLanguageServerProtocol.Framework.JsonRpc;
     using Microsoft.CommonLanguageServerProtocol.Framework.Handlers;
+    using Microsoft.PowerPlatformLS.Contracts.Internal.Common;
     using Microsoft.PowerPlatformLS.Contracts.Internal.Common.DependencyInjection;
     using System.Diagnostics.CodeAnalysis;
     using Microsoft.PowerPlatformLS.Contracts.Internal.CodeAnalysis;
@@ -25,6 +26,8 @@ namespace Microsoft.PowerPlatformLS.Impl.Core.Lsp
             // This spins up the queue and ensure the LSP is ready to start receiving requests
             Initialize();
         }
+
+        protected override int GetCurrentRequestId() => LspRequestContext.CurrentRequestId;
 
         /// <inheritdoc/>
         /// <remarks>Largely inspired from https://github.com/dotnet/roslyn/blob/main/src/LanguageServer/Protocol/RoslynLanguageServer.cs</remarks>

--- a/src/LanguageServers/PowerPlatformLS/Impl.Core/LSP/LanguageServer.cs
+++ b/src/LanguageServers/PowerPlatformLS/Impl.Core/LSP/LanguageServer.cs
@@ -32,7 +32,6 @@ namespace Microsoft.PowerPlatformLS.Impl.Core.Lsp
         {
             if (serializedParameters == null)
             {
-                Logger.LogInformation("No request parameters given, using default language handler");
                 language = LanguageServerConstants.DefaultLanguageName;
                 return true;
             }
@@ -52,14 +51,10 @@ namespace Microsoft.PowerPlatformLS.Impl.Core.Lsp
 
             // Phase 1b: Use LspUriFactory for typed URI handling
             var typedLspUri = LspUriFactory.FromJsonElement(parameters, Logger);
-            
-            // Log with scheme preserved
-            Logger.LogInformation($"Processing request for URI: {typedLspUri.Raw}");
 
             // Handle unsupported URIs with default language
             if (!typedLspUri.IsSupported)
             {
-                Logger.LogInformation($"Using default language handler for unsupported URI: {typedLspUri.Raw}");
                 language = LanguageServerConstants.DefaultLanguageName;
                 return true;
             }

--- a/src/LanguageServers/PowerPlatformLS/Impl.Core/LSP/LspLogger.cs
+++ b/src/LanguageServers/PowerPlatformLS/Impl.Core/LSP/LspLogger.cs
@@ -5,11 +5,20 @@ namespace Microsoft.PowerPlatformLS.Impl.Core.Lsp
     using Microsoft.Extensions.Logging;
     using Microsoft.PowerPlatformLS.Contracts.Internal.Common;
     using System;
+    using System.Collections.Concurrent;
+    using System.Threading;
 
     internal class LspLogger : ILspLogger
     {
         private readonly ILogger<LspLogger> _logger;
         private readonly bool _isTestLogger;
+
+        // Sequential counter for custom LSP methods only — no gaps in output.
+        private static int _lspRequestCounter;
+
+        // Stores allocated IDs keyed by method name. LogStartContext picks them up
+        // and sets the AsyncLocal so downstream services (HTTP, Sync) can read it.
+        private static readonly ConcurrentDictionary<string, ConcurrentStack<int>> _pendingIds = new();
 
         public LspLogger(ILogger<LspLogger> logger, BuildVersionInfo? gitInfo = null, SessionInformation? sessionInformation = null)
         {
@@ -29,19 +38,107 @@ namespace Microsoft.PowerPlatformLS.Impl.Core.Lsp
             _isTestLogger = _logger.GetType().AssemblyQualifiedName?.StartsWith("Microsoft.PowerPlatformLS.UnitTests") == true;
         }
 
+        /// <summary>
+        /// Allocates the next sequential ID for a custom LSP method and stores it
+        /// for LogStartContext to pick up. Called by JsonRpcStream on receive.
+        /// </summary>
+        internal static int AllocateRequestId(string method)
+        {
+            int id = Interlocked.Increment(ref _lspRequestCounter);
+            var stack = _pendingIds.GetOrAdd(method, _ => new ConcurrentStack<int>());
+            stack.Push(id);
+            return id;
+        }
+
+        public void LogStartContext(string message, params object[] @params)
+        {
+            if (IsBuiltInLspMethod(message))
+            {
+                return;
+            }
+
+            // Pop the ID allocated by JsonRpcStream and set it on the AsyncLocal
+            // so downstream services (HTTP, Sync) in this handler's async flow can read it.
+            int reqId = 0;
+            if (_pendingIds.TryGetValue(message, out var stack))
+            {
+                stack.TryPop(out reqId);
+            }
+            LspRequestContext.CurrentRequestId = reqId;
+
+            _logger.LogInformation("[Req: {ReqId}] Started handler for: {Method}", reqId, message);
+        }
+
         public void LogEndContext(string message, params object[] @params)
         {
-            _logger.LogInformation($"EndContext: {message}", @params);
+            // message format from QueueItem: "methodName, duration=Xms"
+            var methodName = ExtractMethodName(message);
+            if (IsBuiltInLspMethod(methodName))
+            {
+                return;
+            }
+
+            int reqId = LspRequestContext.CurrentRequestId;
+            var durationMs = ExtractDurationMs(message);
+            _logger.LogInformation("[Req: {ReqId}] Completed handler for: {Method}, duration={Duration}ms", reqId, methodName, durationMs);
+        }
+
+        private static string ExtractMethodName(string message)
+        {
+            var commaIndex = message.IndexOf(',');
+            return commaIndex > 0 ? message[..commaIndex] : message;
+        }
+
+        private static string ExtractDurationMs(string message)
+        {
+            // Extract just the numeric value from "duration=Xms"
+            var durationIndex = message.IndexOf("duration=", StringComparison.Ordinal);
+            if (durationIndex < 0) return "?";
+            var start = durationIndex + "duration=".Length;
+            var end = message.IndexOf("ms", start, StringComparison.Ordinal);
+            return end > start ? message[start..end] : "?";
+        }
+
+        internal static bool IsBuiltInLspMethod(string message)
+        {
+            return message.StartsWith("textDocument/", StringComparison.Ordinal)
+                || message.StartsWith("$/", StringComparison.Ordinal)
+                || message.StartsWith("initialize", StringComparison.Ordinal)
+                || message.StartsWith("shutdown", StringComparison.Ordinal)
+                || message.StartsWith("exit", StringComparison.Ordinal)
+                || message.StartsWith("workspace/didChange", StringComparison.Ordinal)
+                || message.StartsWith("workspace/didRename", StringComparison.Ordinal);
         }
 
         public void LogError(string message, params object[] @params)
         {
-            _logger.LogError(message, @params);
+            int reqId = LspRequestContext.CurrentRequestId;
+            if (reqId > 0)
+            {
+                _logger.LogError($"[Req: {{ReqId}}] {message}", reqId);
+            }
+            else
+            {
+                _logger.LogError(message, @params);
+            }
         }
 
         public void LogException(Exception exception, string? message = null, params object[] @params)
         {
-            _logger.LogError(exception, message, @params);
+            int reqId = LspRequestContext.CurrentRequestId;
+            if (reqId > 0)
+            {
+                _logger.LogError(exception, $"[Req: {{ReqId}}] {message ?? exception.Message}", reqId);
+            }
+            else
+            {
+                _logger.LogError(exception, message ?? exception.Message, @params);
+            }
+        }
+
+        public void LogDebug(string message, params object[] @params)
+        {
+            _logger.LogDebug(message, @params);
         }
 
         public void LogInformation(string message, params object[] @params)
@@ -65,14 +162,17 @@ namespace Microsoft.PowerPlatformLS.Impl.Core.Lsp
 #endif
         }
 
-        public void LogStartContext(string message, params object[] @params)
-        {
-            _logger.LogInformation($"StartContext: {message}", @params);
-        }
-
         public void LogWarning(string message, params object[] @params)
         {
-            _logger.LogWarning(message, @params);
+            int reqId = LspRequestContext.CurrentRequestId;
+            if (reqId > 0)
+            {
+                _logger.LogWarning($"[Req: {{ReqId}}] {message}", reqId);
+            }
+            else
+            {
+                _logger.LogWarning(message, @params);
+            }
         }
     }
 }

--- a/src/LanguageServers/PowerPlatformLS/Impl.Core/LSP/LspLogger.cs
+++ b/src/LanguageServers/PowerPlatformLS/Impl.Core/LSP/LspLogger.cs
@@ -5,7 +5,6 @@ namespace Microsoft.PowerPlatformLS.Impl.Core.Lsp
     using Microsoft.Extensions.Logging;
     using Microsoft.PowerPlatformLS.Contracts.Internal.Common;
     using System;
-    using System.Collections.Concurrent;
     using System.Threading;
 
     internal class LspLogger : ILspLogger
@@ -13,12 +12,8 @@ namespace Microsoft.PowerPlatformLS.Impl.Core.Lsp
         private readonly ILogger<LspLogger> _logger;
         private readonly bool _isTestLogger;
 
-        // Sequential counter for custom LSP methods only — no gaps in output.
+        // Sequential counter for custom LSP request correlation.
         private static int _lspRequestCounter;
-
-        // Stores allocated IDs keyed by method name. LogStartContext picks them up
-        // and sets the AsyncLocal so downstream services (HTTP, Sync) can read it.
-        private static readonly ConcurrentDictionary<string, ConcurrentStack<int>> _pendingIds = new();
 
         public LspLogger(ILogger<LspLogger> logger, BuildVersionInfo? gitInfo = null, SessionInformation? sessionInformation = null)
         {
@@ -39,64 +34,43 @@ namespace Microsoft.PowerPlatformLS.Impl.Core.Lsp
         }
 
         /// <summary>
-        /// Allocates the next sequential ID for a custom LSP method and stores it
-        /// for LogStartContext to pick up. Called by JsonRpcStream on receive.
+        /// Allocates the next sequential ID for a custom LSP method.
+        /// Called by JsonRpcStream on receive; the ID flows through the
+        /// AsyncLocal → ExecuteAsync → QueueItem.RequestId → SetCurrentRequestId.
         /// </summary>
-        internal static int AllocateRequestId(string method)
+        internal static int AllocateRequestId()
         {
-            int id = Interlocked.Increment(ref _lspRequestCounter);
-            var stack = _pendingIds.GetOrAdd(method, _ => new ConcurrentStack<int>());
-            stack.Push(id);
-            return id;
+            return Interlocked.Increment(ref _lspRequestCounter);
         }
 
-        public void LogStartContext(string message, params object[] @params)
+        public void LogStartContext(string methodName)
         {
-            if (IsBuiltInLspMethod(message))
-            {
-                return;
-            }
-
-            // Pop the ID allocated by JsonRpcStream and set it on the AsyncLocal
-            // so downstream services (HTTP, Sync) in this handler's async flow can read it.
-            int reqId = 0;
-            if (_pendingIds.TryGetValue(message, out var stack))
-            {
-                stack.TryPop(out reqId);
-            }
-            LspRequestContext.CurrentRequestId = reqId;
-
-            _logger.LogInformation("[Req: {ReqId}] Started handler for: {Method}", reqId, message);
-        }
-
-        public void LogEndContext(string message, params object[] @params)
-        {
-            // message format from QueueItem: "methodName, duration=Xms"
-            var methodName = ExtractMethodName(message);
             if (IsBuiltInLspMethod(methodName))
             {
                 return;
             }
 
             int reqId = LspRequestContext.CurrentRequestId;
-            var durationMs = ExtractDurationMs(message);
-            _logger.LogInformation("[Req: {ReqId}] Completed handler for: {Method}, duration={Duration}ms", reqId, methodName, durationMs);
+
+            _logger.LogInformation("[Req: {ReqId}] Started handler for: {Method}", reqId, methodName);
         }
 
-        private static string ExtractMethodName(string message)
+        public void LogEndContext(string methodName, long durationMs = -1)
         {
-            var commaIndex = message.IndexOf(',');
-            return commaIndex > 0 ? message[..commaIndex] : message;
-        }
+            if (IsBuiltInLspMethod(methodName))
+            {
+                return;
+            }
 
-        private static string ExtractDurationMs(string message)
-        {
-            // Extract just the numeric value from "duration=Xms"
-            var durationIndex = message.IndexOf("duration=", StringComparison.Ordinal);
-            if (durationIndex < 0) return "?";
-            var start = durationIndex + "duration=".Length;
-            var end = message.IndexOf("ms", start, StringComparison.Ordinal);
-            return end > start ? message[start..end] : "?";
+            int reqId = LspRequestContext.CurrentRequestId;
+            if (durationMs >= 0)
+            {
+                _logger.LogInformation("[Req: {ReqId}] Completed handler for: {Method}, duration={Duration}ms", reqId, methodName, durationMs);
+            }
+            else
+            {
+                _logger.LogInformation("[Req: {ReqId}] Completed handler for: {Method}", reqId, methodName);
+            }
         }
 
         internal static bool IsBuiltInLspMethod(string message)
@@ -115,7 +89,7 @@ namespace Microsoft.PowerPlatformLS.Impl.Core.Lsp
             int reqId = LspRequestContext.CurrentRequestId;
             if (reqId > 0)
             {
-                _logger.LogError($"[Req: {{ReqId}}] {message}", reqId);
+                _logger.LogError("[Req: {ReqId}] {Message}", reqId, message);
             }
             else
             {
@@ -128,7 +102,7 @@ namespace Microsoft.PowerPlatformLS.Impl.Core.Lsp
             int reqId = LspRequestContext.CurrentRequestId;
             if (reqId > 0)
             {
-                _logger.LogError(exception, $"[Req: {{ReqId}}] {message ?? exception.Message}", reqId);
+                _logger.LogError(exception, "[Req: {ReqId}] {Message}", reqId, message ?? exception.Message);
             }
             else
             {
@@ -139,6 +113,11 @@ namespace Microsoft.PowerPlatformLS.Impl.Core.Lsp
         public void LogDebug(string message, params object[] @params)
         {
             _logger.LogDebug(message, @params);
+        }
+
+        public void SetCurrentRequestId(int requestId)
+        {
+            LspRequestContext.CurrentRequestId = requestId;
         }
 
         public void LogInformation(string message, params object[] @params)
@@ -167,7 +146,7 @@ namespace Microsoft.PowerPlatformLS.Impl.Core.Lsp
             int reqId = LspRequestContext.CurrentRequestId;
             if (reqId > 0)
             {
-                _logger.LogWarning($"[Req: {{ReqId}}] {message}", reqId);
+                _logger.LogWarning("[Req: {ReqId}] {Message}", reqId, message);
             }
             else
             {

--- a/src/LanguageServers/PowerPlatformLS/Impl.Core/LSP/LspWindowLogMessageLoggerProvider.cs
+++ b/src/LanguageServers/PowerPlatformLS/Impl.Core/LSP/LspWindowLogMessageLoggerProvider.cs
@@ -62,7 +62,7 @@ namespace Microsoft.PowerPlatformLS.Impl.Core.Lsp
 
         public ILogger CreateLogger(string categoryName)
         {
-            return _loggers.GetOrAdd(categoryName, name => new ForwardingLogger(ShortenCategory(name), this));
+            return _loggers.GetOrAdd(categoryName, name => new ForwardingLogger(this));
         }
 
         public void Dispose()
@@ -142,26 +142,6 @@ namespace Microsoft.PowerPlatformLS.Impl.Core.Lsp
             }
         }
 
-        private static string ShortenCategory(string categoryName)
-        {
-            if (string.IsNullOrEmpty(categoryName))
-            {
-                return categoryName;
-            }
-
-            // Strip generic arity / generic args so e.g. "Foo`1[[Bar]]" → "Foo".
-            int tick = categoryName.IndexOf('`');
-            if (tick >= 0)
-            {
-                categoryName = categoryName.Substring(0, tick);
-            }
-
-            int lastDot = categoryName.LastIndexOf('.');
-            return lastDot >= 0 && lastDot < categoryName.Length - 1
-                ? categoryName.Substring(lastDot + 1)
-                : categoryName;
-        }
-
         private readonly struct QueuedEntry
         {
             public QueuedEntry(int messageType, string message)
@@ -177,12 +157,10 @@ namespace Microsoft.PowerPlatformLS.Impl.Core.Lsp
 
         private sealed class ForwardingLogger : ILogger
         {
-            private readonly string _category;
             private readonly LspWindowLogMessageLoggerProvider _owner;
 
-            public ForwardingLogger(string category, LspWindowLogMessageLoggerProvider owner)
+            public ForwardingLogger(LspWindowLogMessageLoggerProvider owner)
             {
-                _category = category;
                 _owner = owner;
             }
 

--- a/src/LanguageServers/PowerPlatformLS/Impl.Core/LSP/LspWindowLogMessageLoggerProvider.cs
+++ b/src/LanguageServers/PowerPlatformLS/Impl.Core/LSP/LspWindowLogMessageLoggerProvider.cs
@@ -232,7 +232,7 @@ namespace Microsoft.PowerPlatformLS.Impl.Core.Lsp
                     _                    => 4,
                 };
 
-                _owner.Enqueue(new QueuedEntry(messageType, $"[{_category}] {message}"));
+                _owner.Enqueue(new QueuedEntry(messageType, message));
             }
 
             private sealed class NullScope : IDisposable

--- a/src/LanguageServers/PowerPlatformLS/Impl.Language.CopilotStudio/McsLanguage.cs
+++ b/src/LanguageServers/PowerPlatformLS/Impl.Language.CopilotStudio/McsLanguage.cs
@@ -63,7 +63,6 @@ namespace Microsoft.PowerPlatformLS.Impl.Language.CopilotStudio
             else
             {
                 agentDirectory = FindAgentDirectoryFolderAndCreate(directoryPath);
-                LogAgentResolvingInfoEvent($"Agent Directory initialized at: '{agentDirectory.FolderPath}'", "Agent Directory Initialized");
             }
 
             return agentDirectory;
@@ -76,14 +75,32 @@ namespace Microsoft.PowerPlatformLS.Impl.Language.CopilotStudio
             // only log agent selected event when changing agent directory, which should be rare in most cases
             if (!agentDirectory.Equals(_lastAgentSelected))
             {
-                LogAgentResolvingInfoEvent($"Agent Directory selected: '{agentDirectory}'" + (candidatesCount > 1 ? $" (Out of {candidatesCount} parent directories)" : string.Empty), "Changed Active Agent Directory");
+                var agentName = GetAgentName(agentDirectory);
+                LogAgentResolvingInfoEvent($"Agent Directory selected: '{agentDirectory}'" + (candidatesCount > 1 ? $" (Out of {candidatesCount} parent directories)" : string.Empty), $"Active agent directory changed to: {agentName}");
                 _lastAgentSelected = agentDirectory;
             }
         }
 
         private void LogAgentResolvingInfoEvent(string sensitiveMsg, string altSafeMsg)
         {
-            _logger.LogSensitiveInformation("[AgentResolvingEvent] " + sensitiveMsg, "[AgentResolvingEvent] " + altSafeMsg);
+            _logger.LogSensitiveInformation("[AgentResolving] " + sensitiveMsg, "[AgentResolving] " + altSafeMsg);
+        }
+
+        private void LogAgentResolvingDebugEvent(string message)
+        {
+            _logger.LogDebug("[AgentResolving] " + message);
+        }
+
+        /// <summary>
+        /// Extracts the agent folder name from a directory path (last segment before trailing slash).
+        /// </summary>
+        private static string GetAgentName(DirectoryPath directoryPath)
+        {
+            var path = directoryPath.ToString();
+            if (path.Length < 2) return path;
+            var trimmed = path.TrimEnd('/');
+            var lastSlash = trimmed.LastIndexOf('/');
+            return lastSlash >= 0 ? trimmed.Substring(lastSlash + 1) : trimmed;
         }
 
         private McsWorkspace FindAgentDirectoryFolderAndCreate(DirectoryPath documentDirectory)
@@ -119,7 +136,7 @@ namespace Microsoft.PowerPlatformLS.Impl.Language.CopilotStudio
                 {
                     if (selector(currentFolder))
                     {
-                        LogAgentResolvingInfoEvent($"Valid agent directory detected: '{currentFolder}'", "Valid Agent Directory detected");
+                        LogAgentResolvingDebugEvent($"Valid agent directory detected: '{currentFolder}'");
                         validDirectory = currentFolder;
                         return true;
                     }
@@ -136,23 +153,33 @@ namespace Microsoft.PowerPlatformLS.Impl.Language.CopilotStudio
         {
             // currentFolder must be a valid directory path
             var agentDirectory = new McsWorkspace(currentFolderPath, _lspServices);
+            int documentCount = 0;
 
             if (isFolderOpened)
             {
-                AddLocalFilesToAgent(agentDirectory);
+                documentCount = AddLocalFilesToAgent(agentDirectory);
             }
+
+            var agentName = GetAgentName(currentFolderPath);
+            LogAgentResolvingInfoEvent(
+                $"Agent directory initialized with {documentCount} documents tracked: '{currentFolderPath}'",
+                $"Agent directory initialized with {documentCount} documents tracked for {agentName}");
 
             _agentDirectories.Add(currentFolderPath, agentDirectory);
             NotifyClientOfAgentDirectoryChange();
             return agentDirectory;
         }
 
-        private void AddLocalFilesToAgent(McsWorkspace agentDirectory)
+        private int AddLocalFilesToAgent(McsWorkspace agentDirectory)
         {
             var agentDirectoryPath = agentDirectory.FolderPath;
+            var agentName = GetAgentName(agentDirectoryPath);
+            int totalDocumentCount = 0;
+
             void AddDocumentToAgent(IFileInfo fileInfo, FilePath documentPath)
             {
                 agentDirectory.UpsertDocumentFromFile(documentPath, fileInfo, this, _clientInfo.CultureInfo);
+                ++totalDocumentCount;
             }
 
             // SubAgents are in /agents/{name}/*
@@ -178,7 +205,7 @@ namespace Microsoft.PowerPlatformLS.Impl.Language.CopilotStudio
                         }
                         if (fileCount > 0)
                         {
-                            LogAgentResolvingInfoEvent($"{fileCount} files added under {relativePath} in MCS directory {folder}", "Document(s) added to parent agent directory");
+                            LogAgentResolvingDebugEvent($"{fileCount} files added under {relativePath} for {agentName}");
                         }
                     }
                     else
@@ -190,6 +217,7 @@ namespace Microsoft.PowerPlatformLS.Impl.Language.CopilotStudio
                             if (fileInfo.Exists)
                             {
                                 AddDocumentToAgent(fileInfo, pathWithoutExt);
+                                LogAgentResolvingDebugEvent($"{fileInfo.Name} added to root directory for {agentName}");
                             }
                         }
 
@@ -198,13 +226,14 @@ namespace Microsoft.PowerPlatformLS.Impl.Language.CopilotStudio
                             // per TryGetMcsFilePath, file must exist
                             var fileInfo = _fileProvider.GetFileInfo(path);
                             AddDocumentToAgent(fileInfo, path);
-                            LogAgentResolvingInfoEvent($"{relativePath} file added to MCS directory root {folder}", "Root document added to agent directory");
+                            LogAgentResolvingDebugEvent($"{path.FileName} added to root directory for {agentName}");
                         }
                     }
                 }
             }
 
             agentDirectory.BuildCompilationModel();
+            return totalDocumentCount;
         }
 
         private void RemoveDocumentFromPreviousAgent(FilePath file)
@@ -219,11 +248,11 @@ namespace Microsoft.PowerPlatformLS.Impl.Language.CopilotStudio
                 var previousAgent = candidate.Value;
                 if (previousAgent.RemoveDocument(file))
                 {
-                    LogAgentResolvingInfoEvent($"Document '{file}' removed from previous MCS directory '{previousAgent.FolderPath}'", "Document transferring from existing agent directory.");
+                    LogAgentResolvingDebugEvent($"Document '{file}' removed from previous MCS directory '{previousAgent.FolderPath}'");
 
                     if (previousAgent.IsEmpty)
                     {
-                        LogAgentResolvingInfoEvent($"Deleting previous MCS directory '{previousAgent.FolderPath}'. All documents ownership have been transferred to a new valid agent directory.", "Obsolete agent directory is empty and will be removed");
+                        LogAgentResolvingDebugEvent($"Deleting previous MCS directory '{previousAgent.FolderPath}'. All documents ownership have been transferred to a new valid agent directory.");
                         emptyAgentDirectories.Add(candidate.Key);
                     }
                 }

--- a/src/LanguageServers/PowerPlatformLS/Impl.Language.CopilotStudio/McsLanguage.cs
+++ b/src/LanguageServers/PowerPlatformLS/Impl.Language.CopilotStudio/McsLanguage.cs
@@ -83,12 +83,12 @@ namespace Microsoft.PowerPlatformLS.Impl.Language.CopilotStudio
 
         private void LogAgentResolvingInfoEvent(string sensitiveMsg, string altSafeMsg)
         {
-            _logger.LogSensitiveInformation("[AgentResolving] " + sensitiveMsg, "[AgentResolving] " + altSafeMsg);
+            _logger.LogSensitiveInformation("[AgentInit] " + sensitiveMsg, "[AgentInit] " + altSafeMsg);
         }
 
         private void LogAgentResolvingDebugEvent(string message)
         {
-            _logger.LogDebug("[AgentResolving] " + message);
+            _logger.LogDebug("[AgentInit] " + message);
         }
 
         /// <summary>
@@ -189,6 +189,7 @@ namespace Microsoft.PowerPlatformLS.Impl.Language.CopilotStudio
             // Read all expected files in the workspace, create a document for each of them.
             // Expected files are the ones following predefined structure.
             // All documents have a semantic model and a single semantic model is created to merge each of the file semantic through the workspace
+            var rootFiles = new List<string>();
             foreach (var folder in folders)
             {
                 foreach (var relativePath in LspProjectionLayout.FileStructureMap.Keys)
@@ -217,7 +218,7 @@ namespace Microsoft.PowerPlatformLS.Impl.Language.CopilotStudio
                             if (fileInfo.Exists)
                             {
                                 AddDocumentToAgent(fileInfo, pathWithoutExt);
-                                LogAgentResolvingDebugEvent($"{fileInfo.Name} added to root directory for {agentName}");
+                                rootFiles.Add(fileInfo.Name);
                             }
                         }
 
@@ -226,10 +227,15 @@ namespace Microsoft.PowerPlatformLS.Impl.Language.CopilotStudio
                             // per TryGetMcsFilePath, file must exist
                             var fileInfo = _fileProvider.GetFileInfo(path);
                             AddDocumentToAgent(fileInfo, path);
-                            LogAgentResolvingDebugEvent($"{path.FileName} added to root directory for {agentName}");
+                            rootFiles.Add(path.FileName);
                         }
                     }
                 }
+            }
+
+            if (rootFiles.Count > 0)
+            {
+                LogAgentResolvingDebugEvent($"{rootFiles.Count} files ({string.Join(", ", rootFiles)}) added to root directory for {agentName}");
             }
 
             agentDirectory.BuildCompilationModel();

--- a/src/LanguageServers/PowerPlatformLS/Impl.Language.CopilotStudio/Models/McsWorkspace.cs
+++ b/src/LanguageServers/PowerPlatformLS/Impl.Language.CopilotStudio/Models/McsWorkspace.cs
@@ -67,9 +67,6 @@ namespace Microsoft.PowerPlatformLS.Impl.Language.CopilotStudio.Models
         public override void AddDocument(LspDocument document)
         {
             base.AddDocument(document);
-
-            int len = document.Text.Length;
-            _logger.LogInformation($"Document {document.Uri.AbsoluteUri}, len={len}, tracked in current workspace.");
         }
 
         public IExpressionCheckerOperationContext GetOperationContext()

--- a/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/CloneAgentHandler.cs
+++ b/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/CloneAgentHandler.cs
@@ -1,7 +1,6 @@
 namespace Microsoft.PowerPlatformLS.Impl.PullAgent
 {
     using Microsoft.Agents.Platform.Content;
-    using Microsoft.Agents.Platform.Content.Exceptions;
     using Microsoft.CommonLanguageServerProtocol.Framework;
     using Microsoft.CopilotStudio.Sync;
     using Microsoft.CopilotStudio.Sync.Dataverse;
@@ -173,7 +172,7 @@ namespace Microsoft.PowerPlatformLS.Impl.PullAgent
                         }
                         catch (Exception ex)
                         {
-                            _logger.LogException(ex);
+                            LspExceptionHandler.Handle(ex, _logger);
                         }
                     }
                 }
@@ -186,22 +185,13 @@ namespace Microsoft.PowerPlatformLS.Impl.PullAgent
                     AuthoringShape = detectedShape,
                 };
             }
-            catch (DataverseBadRequestException ex)
-            {
-                _logger.LogException(ex);
-                return new CloneAgentResponse()
-                {
-                    Code = ex.StatusCode,
-                    Message = ex.Message
-                };
-            }
             catch (Exception ex)
             {
-                _logger.LogException(ex);
+                var (code, message) = LspExceptionHandler.Handle(ex, _logger, cancellationToken);
                 return new CloneAgentResponse()
                 {
-                    Code = -1,
-                    Message = ex.Message
+                    Code = code,
+                    Message = message
                 };
             }
         }

--- a/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/DependencyInjection/PullAgentLspModule.cs
+++ b/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/DependencyInjection/PullAgentLspModule.cs
@@ -13,6 +13,7 @@
     using Microsoft.CommonLanguageServerProtocol.Framework;
     using Microsoft.CopilotStudio.Sync;
     using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Logging;
     using Microsoft.PowerPlatformLS.Contracts.Internal.Common;
     using Microsoft.PowerPlatformLS.Contracts.Internal.Common.DependencyInjection;
     using Microsoft.PowerPlatformLS.Impl.PullAgent.Auth;
@@ -26,16 +27,27 @@
     public class PullAgentLspModule : ILspModule
     {
         private readonly BuildVersionInfo _versionInfo;
+        private readonly ILoggerFactory? _loggerFactory;
 
-        public PullAgentLspModule(BuildVersionInfo versionInfo)
+        public PullAgentLspModule(BuildVersionInfo versionInfo, ILoggerFactory? loggerFactory = null)
         {
             _versionInfo = versionInfo;
+            _loggerFactory = loggerFactory;
         }
 
         public void ConfigureServices(IServiceCollection services)
         {
             string userAgent = $"MCSVSCode-{_versionInfo.VsixVersion ?? "unknown"}";
             ServiceRegistrations.AddServices(services, userAgent);
+
+            // Register only the specific ILogger<T> instances our code needs.
+            // Do NOT register ILoggerFactory or open ILogger<> — that would let framework
+            // internals (HttpClientFactory, SDK classes) resolve loggers and flood output.
+            if (_loggerFactory != null)
+            {
+                services.AddSingleton(_loggerFactory.CreateLogger<LspOperationLogger>());
+                services.AddSingleton(_loggerFactory.CreateLogger<LoggingHttpHandler>());
+            }
 
             // Bridge types: host-specific implementations required before AddSyncServices()
             services.AddSingleton<TokenManager>();
@@ -95,7 +107,7 @@
                     {
                         handlers.Add(sp.GetRequiredService<THandler>());
                         
-                        var logger = sp.GetRequiredService<ILspLogger>();
+                        var logger = sp.GetRequiredService<ILogger<LoggingHttpHandler>>();
                         handlers.Add(new LoggingHttpHandler(logger));
                     });
             }

--- a/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/GetLocalChangeHandler.cs
+++ b/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/GetLocalChangeHandler.cs
@@ -19,17 +19,20 @@ namespace Microsoft.PowerPlatformLS.Impl.PullAgent
         private readonly ISyncDataverseClient _dataverseClient;
         private readonly LspDataverseHttpClientAccessor _dataverseHttpClientAccessor;
         private readonly ITokenManager _dataverseTokenManager;
+        private readonly ILspLogger _logger;
 
         public GetLocalChangeHandler(
             CopilotStudio.Sync.IWorkspaceSynchronizer workspaceSynchronizer,
             ISyncDataverseClient dataverseClient,
             LspDataverseHttpClientAccessor dataverseHttpClientAccessor,
-            ITokenManager dataverseTokenManager)
+            ITokenManager dataverseTokenManager,
+            ILspLogger logger)
         {
             _workspaceSynchronizer = workspaceSynchronizer;
             _dataverseClient = dataverseClient ?? throw new ArgumentNullException(nameof(dataverseClient));
             _dataverseHttpClientAccessor = dataverseHttpClientAccessor ?? throw new ArgumentNullException(nameof(dataverseHttpClientAccessor));
             _dataverseTokenManager = dataverseTokenManager ?? throw new ArgumentNullException(nameof(dataverseTokenManager));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
         public bool MutatesSolutionState => false;
@@ -55,10 +58,11 @@ namespace Microsoft.PowerPlatformLS.Impl.PullAgent
             }
             catch (Exception ex)
             {
+                var (code, message) = LspExceptionHandler.Handle(ex, _logger, cancellationToken);
                 return new SyncAgentResponse
                 {
-                    Code = 500,
-                    Message = ex.Message,
+                    Code = code,
+                    Message = message,
                 };
             }
         }

--- a/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/GetRemoteChangeHandler.cs
+++ b/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/GetRemoteChangeHandler.cs
@@ -69,10 +69,11 @@ namespace Microsoft.PowerPlatformLS.Impl.PullAgent
             }
             catch (Exception ex)
             {
+                var (code, message) = LspExceptionHandler.Handle(ex, _logger, cancellationToken);
                 return new SyncAgentResponse
                 {
-                    Code = 500,
-                    Message = ex.Message,
+                    Code = code,
+                    Message = message,
                 };
             }
         }

--- a/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/GetRemoteFileHandler.cs
+++ b/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/GetRemoteFileHandler.cs
@@ -145,10 +145,11 @@ namespace Microsoft.PowerPlatformLS.Impl.PullAgent
             }
             catch (Exception ex)
             {
+                var (code, message) = LspExceptionHandler.Handle(ex, _logger, cancellationToken);
                 return new GetFileResponse
                 {
-                    Code = 500,
-                    Message = ex.Message,
+                    Code = code,
+                    Message = message,
                 };
             }
         }

--- a/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/GetWorkspaceDetailsHandler.cs
+++ b/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/GetWorkspaceDetailsHandler.cs
@@ -47,7 +47,8 @@ namespace Microsoft.PowerPlatformLS.Impl.PullAgent
             }
             catch (Exception exception)
             {
-                _logger.LogException(exception);
+                // Log appropriately but don't fail the request — return partial data.
+                var (_, _) = LspExceptionHandler.Handle(exception, _logger);
             }
 
             if (syncInfo != null && (syncInfo.AuthoringShape == null || syncInfo.AuthoringShape == AuthoringShape.Unknown))

--- a/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/LoggingHttpHandler.cs
+++ b/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/LoggingHttpHandler.cs
@@ -7,8 +7,7 @@
     using System.Threading.Tasks;
 
     /// <summary>
-    /// Logs HTTP requests at Info level for diagnostics.
-    /// Errors (network failures) are always logged at Error level.
+    /// Logs HTTP requests at Info level and network failures at Error level.
     /// </summary>
     internal class LoggingHttpHandler : DelegatingHandler
     {

--- a/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/LoggingHttpHandler.cs
+++ b/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/LoggingHttpHandler.cs
@@ -1,45 +1,52 @@
 ﻿namespace Microsoft.PowerPlatformLS.Impl.PullAgent
 {
-    using Microsoft.CommonLanguageServerProtocol.Framework;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.PowerPlatformLS.Contracts.Internal.Common;
     using System;
     using System.Diagnostics;
     using System.Threading.Tasks;
 
-    // Log Http requests to a ILspLogger.
-    // Useful to find long-running requests, network failures, etc. 
+    /// <summary>
+    /// Logs HTTP requests at Info level for diagnostics.
+    /// Errors (network failures) are always logged at Error level.
+    /// </summary>
     internal class LoggingHttpHandler : DelegatingHandler
     {
-        private readonly ILspLogger _logger;
+        private readonly ILogger<LoggingHttpHandler> _logger;
 
-        public LoggingHttpHandler(ILspLogger logger)
+        public LoggingHttpHandler(ILogger<LoggingHttpHandler> logger)
         {
             _logger = logger;
         }
 
-        // Random Id to correlate start and end messages. 
-        private static int _randomId;
+        private static int _requestId;
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            int counter = Interlocked.Increment(ref _randomId);
+            int httpId = Interlocked.Increment(ref _requestId);
+            int reqId = LspRequestContext.CurrentRequestId;
+            var shortUri = GetPathAndQuery(request.RequestUri);
 
-            _logger.LogInformation($"HTTP: Start id={counter}, {request.Method} {request.RequestUri}");
+            _logger.LogInformation("[Req: {ReqId}] HTTP request #{HttpId} started: {Method} {Uri}", reqId, httpId, request.Method, shortUri);
             Stopwatch sw = Stopwatch.StartNew();
 
             try
             {
                 var response = await base.SendAsync(request, cancellationToken);
-
-                _logger.LogInformation($"HTTP: End id={counter}, result={response.StatusCode}, ms={sw.ElapsedMilliseconds},");
-
+                _logger.LogInformation("[Req: {ReqId}] HTTP response #{HttpId} completed: {Method} {Uri}, duration={Duration}ms, status={StatusCode}", reqId, httpId, request.Method, shortUri, sw.ElapsedMilliseconds, (int)response.StatusCode);
                 return response;
             }
             catch (Exception e)
             {
-                // This would be a network failure. 
-                _logger.LogError($"HTTP: Exception, id={counter}, msg ={e.Message}, ms={sw.ElapsedMilliseconds},");
+                _logger.LogError("[Req: {ReqId}] HTTP request #{HttpId} failed: {Method} {Uri}, duration={Duration}ms, error={Message}", reqId, httpId, request.Method, shortUri, sw.ElapsedMilliseconds, e.Message);
                 throw;
             }
+        }
+
+        private static string GetPathAndQuery(Uri? uri)
+        {
+            if (uri == null) return string.Empty;
+            return uri.PathAndQuery;
         }
     }
 }

--- a/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/LspExceptionHandler.cs
+++ b/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/LspExceptionHandler.cs
@@ -1,0 +1,98 @@
+namespace Microsoft.PowerPlatformLS.Impl.PullAgent
+{
+    using Microsoft.Agents.Platform.Content.Exceptions;
+    using Microsoft.CommonLanguageServerProtocol.Framework;
+    using System;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading;
+
+    /// <summary>
+    /// Classifies exceptions and logs them at the appropriate level.
+    /// Provides consistent error handling across all LSP request handlers.
+    /// </summary>
+    internal static class LspExceptionHandler
+    {
+        /// <summary>
+        /// Classifies the exception, logs it at the appropriate severity, and returns
+        /// a status code and user-facing message suitable for the LSP response.
+        /// All failures are logged at Error level (matching the UI's failure display)
+        /// but only unexpected exceptions include the full stack trace.
+        /// </summary>
+        /// <param name="ex">The caught exception.</param>
+        /// <param name="logger">The LSP logger instance.</param>
+        /// <param name="cancellationToken">The request's cancellation token, used to distinguish user cancellation from timeouts.</param>
+        public static (int Code, string Message) Handle(Exception ex, ILspLogger logger, CancellationToken cancellationToken = default)
+        {
+            return ex switch
+            {
+                // User-recoverable: the user can fix this by performing an action (resync, reclone, etc.).
+                // Log at Error (message only, no stack trace) to match failure indicators in the UI.
+                FileNotFoundException fnf =>
+                    LogErrorMessage(logger, 400, fnf.Message),
+
+                DirectoryNotFoundException dnf =>
+                    LogErrorMessage(logger, 400, dnf.Message),
+
+                // Connection binding failed during reattach (e.g., missing connector config).
+                ConnectionBindingException cbe =>
+                    LogErrorMessage(logger, 400, cbe.Message),
+
+                // User validation: caller explicitly threw to signal bad input.
+                InvalidOperationException ioe =>
+                    LogErrorMessage(logger, 400, ioe.Message),
+
+                // Service rejected the request (known Dataverse error with status code).
+                DataverseBadRequestException dbre =>
+                    LogErrorMessage(logger, dbre.StatusCode, dbre.Message),
+
+                // Service temporarily unavailable.
+                DataverseServiceUnavailableException =>
+                    LogErrorMessage(logger, 503, "The Copilot Studio service is temporarily unavailable. Please try again in a moment."),
+
+                // Network/HTTP failures.
+                HttpRequestException hre =>
+                    LogErrorMessage(logger, MapHttpStatusCode(hre), $"Network error: {hre.Message}"),
+
+                // Cancellation: distinguish user-initiated from timeout.
+                OperationCanceledException when cancellationToken.IsCancellationRequested =>
+                    LogErrorMessage(logger, 499, "Operation was cancelled."),
+
+                OperationCanceledException oce =>
+                    LogErrorMessage(logger, 504, $"Operation timed out: {oce.Message}"),
+
+                // Unexpected: genuine bugs or unhandled conditions.
+                // Log at Error WITH full stack trace for diagnostics.
+                _ => LogErrorWithTrace(logger, ex),
+            };
+        }
+
+        private static (int Code, string Message) LogErrorMessage(ILspLogger logger, int code, string message)
+        {
+            logger.LogError(message);
+            return (code, message);
+        }
+
+        private static (int Code, string Message) LogErrorWithTrace(ILspLogger logger, Exception ex)
+        {
+            logger.LogException(ex);
+            return (500, ex.Message);
+        }
+
+        private static int MapHttpStatusCode(HttpRequestException hre)
+        {
+            if (hre.StatusCode.HasValue)
+            {
+                return (int)hre.StatusCode.Value switch
+                {
+                    401 or 403 => 401,
+                    429 => 429,
+                    >= 500 => 502,
+                    _ => 502,
+                };
+            }
+
+            return 502;
+        }
+    }
+}

--- a/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/OperationLogger.cs
+++ b/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/OperationLogger.cs
@@ -10,7 +10,7 @@
     using System.Threading.Tasks;
 
     /// <summary>
-    /// Logs SDK operation timings at Trace level with consistent format.
+    /// Logs SDK operation timings at Information level with consistent format.
     /// Failures are always logged at Error level.
     /// </summary>
     internal class LspOperationLogger : IOperationLogger

--- a/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/OperationLogger.cs
+++ b/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/OperationLogger.cs
@@ -1,90 +1,95 @@
 ﻿namespace Microsoft.PowerPlatformLS.Impl.PullAgent
 {
     using Microsoft.Agents.ObjectModel.Telemetry;
-    using Microsoft.CommonLanguageServerProtocol.Framework;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.PowerPlatformLS.Contracts.Internal.Common;
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
+    using System.Threading;
     using System.Threading.Tasks;
 
-    // Log from a IOperationLogger to a ILspLogger.
+    /// <summary>
+    /// Logs SDK operation timings at Trace level with consistent format.
+    /// Failures are always logged at Error level.
+    /// </summary>
     internal class LspOperationLogger : IOperationLogger
     {
-        private readonly ILspLogger _logger;
+        private readonly ILogger<LspOperationLogger> _logger;
 
-        public LspOperationLogger(ILspLogger logger)
+        public LspOperationLogger(ILogger<LspOperationLogger> logger)
         {
             _logger = logger;
         }
 
         public T Execute<T>(string operation, Func<T> function)
         {
+            int reqId = LspRequestContext.CurrentRequestId;
+            _logger.LogInformation("[Req: {ReqId}] Sync operation started: {Operation}", reqId, operation);
             Stopwatch stopwatch = Stopwatch.StartNew();
             try
             {
                 T result = function();
-
-                var ms = stopwatch.ElapsedMilliseconds;
-                _logger.LogInformation($"Operation: {operation}, duration={ms}ms");
+                _logger.LogInformation("[Req: {ReqId}] Sync operation completed: {Operation}, duration={Duration}ms", reqId, operation, stopwatch.ElapsedMilliseconds);
                 return result;
             }
             catch(Exception ex)
             {
-                _logger.LogException(ex, operation);
+                _logger.LogError(ex, "[Req: {ReqId}] Sync operation failed: {Operation}, duration={Duration}ms", reqId, operation, stopwatch.ElapsedMilliseconds);
                 throw;
             }
         }
 
         public T Execute<T>(string activity, Func<T> function, IEnumerable<KeyValuePair<string, string>> dimensions)
         {
+            int reqId = LspRequestContext.CurrentRequestId;
+            _logger.LogInformation("[Req: {ReqId}] Sync operation started: {Activity}", reqId, activity);
             Stopwatch stopwatch = Stopwatch.StartNew();
             try
             {
                 T result = function();
-
-                var ms = stopwatch.ElapsedMilliseconds;
-                _logger.LogInformation($"Activity: {activity}, duration={ms}ms");
+                _logger.LogInformation("[Req: {ReqId}] Sync operation completed: {Activity}, duration={Duration}ms", reqId, activity, stopwatch.ElapsedMilliseconds);
                 return result;
             }
             catch (Exception ex)
             {
-                _logger.LogException(ex, activity);
+                _logger.LogError(ex, "[Req: {ReqId}] Sync operation failed: {Activity}, duration={Duration}ms", reqId, activity, stopwatch.ElapsedMilliseconds);
                 throw;
             }
         }
 
         public async Task<T> ExecuteAsync<T>(string activity, Func<Task<T>> function)
         {
+            int reqId = LspRequestContext.CurrentRequestId;
+            _logger.LogInformation("[Req: {ReqId}] Sync operation started: {Activity}", reqId, activity);
             Stopwatch stopwatch = Stopwatch.StartNew();
             try
             {
                 T result = await function();
-
-                var ms = stopwatch.ElapsedMilliseconds;
-                _logger.LogInformation($"Activity: {activity}, duration={ms}ms");
+                _logger.LogInformation("[Req: {ReqId}] Sync operation completed: {Activity}, duration={Duration}ms", reqId, activity, stopwatch.ElapsedMilliseconds);
                 return result;
             }
             catch (Exception ex)
             {
-                _logger.LogException(ex, activity);
+                _logger.LogError(ex, "[Req: {ReqId}] Sync operation failed: {Activity}, duration={Duration}ms", reqId, activity, stopwatch.ElapsedMilliseconds);
                 throw;
             }
         }
 
         public async Task<T> ExecuteAsync<T>(string activity, Func<Task<T>> function, IEnumerable<KeyValuePair<string, string>> dimensions)
         {
+            int reqId = LspRequestContext.CurrentRequestId;
+            _logger.LogInformation("[Req: {ReqId}] Sync operation started: {Activity}", reqId, activity);
             Stopwatch stopwatch = Stopwatch.StartNew();
             try
             {
                 T result = await function();
-
-                var ms = stopwatch.ElapsedMilliseconds;
-                _logger.LogInformation($"Activity: {activity}, duration={ms}ms");
+                _logger.LogInformation("[Req: {ReqId}] Sync operation completed: {Activity}, duration={Duration}ms", reqId, activity, stopwatch.ElapsedMilliseconds);
                 return result;
             }
             catch (Exception ex)
             {
-                _logger.LogException(ex, activity);
+                _logger.LogError(ex, "[Req: {ReqId}] Sync operation failed: {Activity}, duration={Duration}ms", reqId, activity, stopwatch.ElapsedMilliseconds);
                 throw;
             }
         }

--- a/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/ReattachAgentHandler.cs
+++ b/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/ReattachAgentHandler.cs
@@ -137,33 +137,13 @@ namespace Microsoft.PowerPlatformLS.Impl.PullAgent
                     AIPromptResponse = aiPromptResponse,
                 };
             }
-            catch (DataverseBadRequestException ex)
-            {
-                _logger.LogException(ex);
-                return new ReattachAgentResponse()
-                {
-                    Code = ex.StatusCode,
-                    Message = ex.Message,
-                    AgentSyncInfo = defaultSyncInfo
-                };
-            }
-            catch (ConnectionBindingException ex)
-            {
-                _logger.LogException(ex);
-                return new ReattachAgentResponse()
-                {
-                    Code = 400,
-                    Message = ex.Message,
-                    AgentSyncInfo = defaultSyncInfo
-                };
-            }
             catch (Exception ex)
             {
-                _logger.LogException(ex);
+                var (code, message) = LspExceptionHandler.Handle(ex, _logger, cancellationToken);
                 return new ReattachAgentResponse()
                 {
-                    Code = 500,
-                    Message = ex.Message,
+                    Code = code,
+                    Message = message,
                     AgentSyncInfo = defaultSyncInfo
                 };
             }

--- a/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/SyncHandler.cs
+++ b/src/LanguageServers/PowerPlatformLS/Impl.PullAgent/SyncHandler.cs
@@ -2,7 +2,6 @@ namespace Microsoft.PowerPlatformLS.Impl.PullAgent
 {
     using Microsoft.Agents.ObjectModel;
     using Microsoft.Agents.Platform.Content;
-    using Microsoft.Agents.Platform.Content.Exceptions;
     using Microsoft.CommonLanguageServerProtocol.Framework;
     using Microsoft.CopilotStudio.Sync;
     using Microsoft.CopilotStudio.Sync.Dataverse;
@@ -72,31 +71,13 @@ namespace Microsoft.PowerPlatformLS.Impl.PullAgent
                     AIPromptResponse = aiPromptResponse,
                 };
             }
-            catch (InvalidOperationException ex)
-            {
-                // User errors
-                return new SyncAgentResponse
-                {
-                    Code = 400,
-                    Message = ex.Message,
-                };
-            }
-            catch (DataverseServiceUnavailableException ex)
-            {
-                _logger.LogException(ex);
-                return new SyncAgentResponse
-                {
-                    Code = 503,
-                    Message = "The Copilot Studio service is temporarily unavailable. Please try again in a moment.",
-                };
-            }
             catch (Exception ex)
             {
-                _logger.LogException(ex);
+                var (code, message) = LspExceptionHandler.Handle(ex, _logger, cancellationToken);
                 return new SyncAgentResponse
                 {
-                    Code = 500,
-                    Message = ex.Message,
+                    Code = code,
+                    Message = message,
                 };
             }
         }

--- a/src/LanguageServers/PowerPlatformLS/LanguageServerHost/AppInsightsConfiguration.cs
+++ b/src/LanguageServers/PowerPlatformLS/LanguageServerHost/AppInsightsConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿namespace Microsoft.PowerPlatformLS.LanguageServerHost
 {
     using Microsoft.ApplicationInsights.Channel;
+    using Microsoft.Extensions.Logging;
 
     internal static class AppInsightsConfiguration
     {
@@ -32,6 +33,11 @@
                         },
                         configureApplicationInsightsLoggerOptions: _ => { }
                     );
+
+                    // Only send Information and above to App Insights.
+                    // Trace/Debug logs are diagnostic-only and stay in the output channel.
+                    builder.AddFilter<Microsoft.Extensions.Logging.ApplicationInsights.ApplicationInsightsLoggerProvider>(
+                        null, LogLevel.Information);
                 });
             }
         }

--- a/src/LanguageServers/PowerPlatformLS/LanguageServerHost/Program.cs
+++ b/src/LanguageServers/PowerPlatformLS/LanguageServerHost/Program.cs
@@ -52,7 +52,6 @@ try
     ConsoleLog("Building host...");
     var host = builder.Build();
 
-    ConsoleLog("Host is starting!");
     var lspLogger = host.Services.GetRequiredService<ILspLogger>();
     LogStartup(lspLogger, isDebuggerRequested, sessionId, isTelemetryEnabled);
 
@@ -77,8 +76,10 @@ void LogStartup(ILspLogger logger, bool isDev, string? sessionId, bool isTelemet
     string osArch = System.Runtime.InteropServices.RuntimeInformation.OSArchitecture.ToString(); // "X64", etc 
     string processArch = System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture.ToString();
     string os = System.Runtime.InteropServices.RuntimeInformation.OSDescription; // "Windows 10 Pro", etc
+    string sid = sessionId ?? string.Empty;
+    string telemetry = isTelemetryEnabled ? "enabled" : "disabled";
 
-    logger.LogInformation("MCS-LSP Startup: pid={id}, sessionId={sessionId}, telemetryStatus={telemetry}, dev={isDev}, os={os}, osVersion={osver}, dotnet={dotnetver}, arch={osArch}/{processArch}", id, sessionId, isTelemetryEnabled ? "enabled" : "disabled", isDev, os, osver, dotnetver, osArch, processArch);
+    logger.LogInformation("MCS-LSP Startup: pid={id}, sessionId={sid}, telemetry={telemetry}, dev={isDev}, os={os}, osVersion={osver}, dotnet={dotnetver}, arch={osArch}/{processArch}", id, sid, telemetry, isDev, os, osver, dotnetver, osArch, processArch);
 }
 
 // Helper method to parse sessionId from command line arguments

--- a/src/LanguageServers/PowerPlatformLS/LanguageServerHost/Program.cs
+++ b/src/LanguageServers/PowerPlatformLS/LanguageServerHost/Program.cs
@@ -1,5 +1,6 @@
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.CommonLanguageServerProtocol.Framework;
+using Microsoft.Extensions.Logging;
 using Microsoft.PowerPlatformLS.Contracts.Internal.Common;
 using Microsoft.PowerPlatformLS.Contracts.Internal.Common.DependencyInjection;
 using Microsoft.PowerPlatformLS.Impl.Core.DependencyInjection;
@@ -15,7 +16,7 @@ using var channel = new InMemoryChannel();
 
 try
 {
-    Console.WriteLine("Configuring Services...");
+    ConsoleLog("Configuring services...");
     var builder = Host.CreateApplicationBuilder(args);
     builder.AddLsp(args);
 
@@ -29,7 +30,9 @@ try
     builder.Services.AddSingleton<ILspModule, PowerFxLspModule>();
     builder.Services.AddSingleton<ILspModule, YamlLspModule>();
     builder.Services.AddSingleton<ILspModule, McsLspModule>();
-    builder.Services.AddSingleton<ILspModule>(sp => new PullAgentLspModule(sp.GetRequiredService<BuildVersionInfo>()));
+    builder.Services.AddSingleton<ILspModule>(sp => new PullAgentLspModule(
+        sp.GetRequiredService<BuildVersionInfo>(),
+        sp.GetRequiredService<ILoggerFactory>()));
 
     // Forward MEL entries to the LSP client via window/logMessage so the
     // extension renders them in its LogOutputChannel with [error]/[warning]/[info]
@@ -37,23 +40,21 @@ try
     builder.UseLspWindowLogMessageLogging();
 
     var isTelemetryEnabled = ParseTelemetryEnabledFromArgs(args);
-    Console.WriteLine($"Telemetry Status: {(isTelemetryEnabled ? "Enabled" : "Disabled")}");
     builder.Services.ConfigureAppInsightsLogging(channel, isTelemetryEnabled);
 
     var sessionId = ParseSessionIdFromArgs(args);
-    Console.WriteLine($"Session Id: {sessionId}");
     var sessionInfo = new SessionInformation
     {
         SessionId = sessionId
     };
     builder.Services.AddSingleton(sessionInfo);
 
-    Console.WriteLine("Building Host...");
+    ConsoleLog("Building host...");
     var host = builder.Build();
 
-    Console.WriteLine("Host is starting!");
+    ConsoleLog("Host is starting!");
     var lspLogger = host.Services.GetRequiredService<ILspLogger>();
-    LogStartup(lspLogger, isDebuggerRequested);
+    LogStartup(lspLogger, isDebuggerRequested, sessionId, isTelemetryEnabled);
 
     host.Run();
 }
@@ -67,7 +68,7 @@ finally
 
 // Log a startup message. This can be used to determine unique machines.
 // Most logging is done via ILspLogger, so use that. 
-void LogStartup(ILspLogger logger, bool isDev)
+void LogStartup(ILspLogger logger, bool isDev, string? sessionId, bool isTelemetryEnabled)
 {
     // AppInsights will automatically capture machine name as "cloud_RoleInstance";
     var id = System.Diagnostics.Process.GetCurrentProcess().Id;
@@ -77,7 +78,7 @@ void LogStartup(ILspLogger logger, bool isDev)
     string processArch = System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture.ToString();
     string os = System.Runtime.InteropServices.RuntimeInformation.OSDescription; // "Windows 10 Pro", etc
 
-    logger.LogInformation("MCS-LSP Startup x8: pid={id}, dev={isDev}, os={os}, osVersion={osver}, dotnetver={dotnetver}, osArch={osArch}, processArch={processArch}", id, isDev, os, osver, dotnetver, osArch, processArch);
+    logger.LogInformation("MCS-LSP Startup: pid={id}, sessionId={sessionId}, telemetryStatus={telemetry}, dev={isDev}, os={os}, osVersion={osver}, dotnet={dotnetver}, arch={osArch}/{processArch}", id, sessionId, isTelemetryEnabled ? "enabled" : "disabled", isDev, os, osver, dotnetver, osArch, processArch);
 }
 
 // Helper method to parse sessionId from command line arguments
@@ -106,4 +107,12 @@ bool ParseTelemetryEnabledFromArgs(string[] args)
         }
     }
     return false;
+}
+
+// Writes a message to stdout for early bootstrap diagnostics
+// (before the MEL/LSP logging pipeline is available).
+// VS Code's LogOutputChannel adds its own timestamp and level prefix.
+void ConsoleLog(string message)
+{
+    Console.WriteLine(message);
 }

--- a/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.Core/ChangeMethodTests.cs
+++ b/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.Core/ChangeMethodTests.cs
@@ -226,7 +226,6 @@
 
             // both request completed without error
             Assert.Empty(logs.Error);
-            Assert.Equal(2, logs.Info.Count(x => x.Contains("EndContext: workspace/didChangeWatchedFiles")));
         }
 
         /// <summary>
@@ -261,7 +260,6 @@
 
             Assert.Empty(logs.Error);
             Assert.Contains(logs.Warning, x => x.EndsWith("The file does not exist."));
-            Assert.Single(logs.Info.Where(x => x.Contains("EndContext: workspace/didChangeWatchedFiles")));
         }
 
         /// <summary>
@@ -394,7 +392,6 @@
 
             // request completed without error
             Assert.Empty(logs.Error);
-            Assert.Single(logs.Info.Where(x => x.Contains("EndContext: workspace/didChangeWatchedFiles")));
         }
 
         private async Task AssertDiagnosticsAsync(TestHost context, (string uriEnd, int count)[] expected)

--- a/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.Core/ListWorkspacesHandlerTest.cs
+++ b/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.Core/ListWorkspacesHandlerTest.cs
@@ -240,7 +240,7 @@
 
         private class FakeLogger : ILspLogger
         {
-            public void LogEndContext(string message, params object[] @params) { }
+            public void LogEndContext(string methodName, long durationMs = -1) { }
 
             public void LogError(string message) { }
 
@@ -256,7 +256,7 @@
 
             public void LogSensitiveInformation(string message, string? altSafeMessage = null) { }
 
-            public void LogStartContext(string message, params object[] @params) { }
+            public void LogStartContext(string methodName) { }
 
             public void LogWarning(string message) { }
 

--- a/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.Core/ListWorkspacesHandlerTest.cs
+++ b/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.Core/ListWorkspacesHandlerTest.cs
@@ -250,6 +250,8 @@
 
             public void LogInfo(string message) { }
 
+            public void LogDebug(string message, params object[] @params) { }
+
             public void LogInformation(string message, params object[] @params) { }
 
             public void LogSensitiveInformation(string message, string? altSafeMessage = null) { }

--- a/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.Core/LspLoggerTests.cs
+++ b/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.Core/LspLoggerTests.cs
@@ -1,0 +1,153 @@
+namespace Microsoft.PowerPlatformLS.UnitTests.Impl.Core
+{
+    using Microsoft.PowerPlatformLS.Contracts.Internal.Common;
+    using Microsoft.PowerPlatformLS.Impl.Core.Lsp;
+    using Microsoft.PowerPlatformLS.UnitTests.TestUtilities;
+    using System;
+    using System.Collections.Concurrent;
+    using System.Linq;
+    using System.Reflection;
+    using Xunit;
+
+    [Collection("LoggingTestsCollection")]
+    public class LspLoggerTests : IDisposable
+    {
+        private readonly TestLogger _testLogger = new();
+        private readonly LspLogger _logger;
+
+        public LspLoggerTests()
+        {
+            ResetLspLoggerState();
+            _logger = new LspLogger(new TestLogger<LspLogger>(_testLogger));
+        }
+
+        public void Dispose()
+        {
+            LspRequestContext.CurrentRequestId = 0;
+            ResetLspLoggerState();
+        }
+
+        [Fact]
+        public void LogDebug_Writes_At_Debug_Level()
+        {
+            _logger.LogDebug("debug value {Value}", 123);
+
+            var debugLog = Assert.Single(_testLogger.Debug);
+            Assert.Contains("debug value 123", debugLog);
+        }
+
+        [Fact]
+        public void LogStartContext_Skips_BuiltIn_Lsp_Methods()
+        {
+            foreach (var method in new[]
+            {
+                "textDocument/completion",
+                "$/progress",
+                "initialize",
+                "shutdown",
+                "exit",
+                "workspace/didChangeConfiguration",
+                "workspace/didRenameFiles",
+            })
+            {
+                _logger.LogStartContext(method);
+            }
+
+            Assert.Empty(_testLogger.Info);
+            Assert.Equal(0, LspRequestContext.CurrentRequestId);
+        }
+
+        [Fact]
+        public void LogStartContext_Logs_Custom_Methods_At_Information()
+        {
+            var requestId = LspLogger.AllocateRequestId("powerplatformls/syncPull");
+
+            _logger.LogStartContext("powerplatformls/syncPull");
+
+            var infoLog = Assert.Single(_testLogger.Info);
+            Assert.Contains($"[Req: {requestId}] Started handler for: powerplatformls/syncPull", infoLog);
+        }
+
+        [Fact]
+        public void LogEndContext_Skips_BuiltIn_Lsp_Methods()
+        {
+            LspRequestContext.CurrentRequestId = 19;
+
+            foreach (var method in new[]
+            {
+                "textDocument/completion, duration=2ms",
+                "$/progress, duration=3ms",
+                "initialize, duration=4ms",
+            })
+            {
+                _logger.LogEndContext(method);
+            }
+
+            Assert.Empty(_testLogger.Info);
+        }
+
+        [Fact]
+        public void LogEndContext_Logs_Custom_Methods_With_Duration()
+        {
+            LspRequestContext.CurrentRequestId = 19;
+
+            _logger.LogEndContext("powerplatformls/syncPull, duration=17ms");
+
+            var infoLog = Assert.Single(_testLogger.Info);
+            Assert.Contains("[Req: 19] Completed handler for: powerplatformls/syncPull, duration=17ms", infoLog);
+        }
+
+        [Theory]
+        [InlineData("textDocument/completion")]
+        [InlineData("$/progress")]
+        [InlineData("initialize")]
+        [InlineData("shutdown")]
+        [InlineData("exit")]
+        [InlineData("workspace/didChangeConfiguration")]
+        [InlineData("workspace/didRenameFiles")]
+        public void IsBuiltInLspMethod_Returns_True_For_Known_Prefixes(string method)
+        {
+            Assert.True(LspLogger.IsBuiltInLspMethod(method));
+        }
+
+        [Theory]
+        [InlineData("powerplatformls/syncPull")]
+        [InlineData("workspace/listWorkspaces")]
+        [InlineData("copilotstudio/customMethod")]
+        public void IsBuiltInLspMethod_Returns_False_For_Custom_Methods(string method)
+        {
+            Assert.False(LspLogger.IsBuiltInLspMethod(method));
+        }
+
+        [Fact]
+        public void AllocateRequestId_Increments_Sequentially()
+        {
+            var first = LspLogger.AllocateRequestId("powerplatformls/one");
+            var second = LspLogger.AllocateRequestId("powerplatformls/two");
+
+            Assert.Equal(first + 1, second);
+        }
+
+        [Fact]
+        public void LogStartContext_Sets_LspRequestContext_CurrentRequestId()
+        {
+            var requestId = LspLogger.AllocateRequestId("powerplatformls/syncPush");
+
+            _logger.LogStartContext("powerplatformls/syncPush");
+
+            Assert.Equal(requestId, LspRequestContext.CurrentRequestId);
+        }
+
+        private static void ResetLspLoggerState()
+        {
+            var counterField = typeof(LspLogger).GetField("_lspRequestCounter", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(counterField);
+            counterField!.SetValue(null, 0);
+
+            var pendingIdsField = typeof(LspLogger).GetField("_pendingIds", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(pendingIdsField);
+            var pendingIds = (ConcurrentDictionary<string, ConcurrentStack<int>>)pendingIdsField!.GetValue(null)!;
+            pendingIds.Clear();
+        }
+    }
+}

--- a/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.Core/LspLoggerTests.cs
+++ b/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.Core/LspLoggerTests.cs
@@ -4,7 +4,6 @@ namespace Microsoft.PowerPlatformLS.UnitTests.Impl.Core
     using Microsoft.PowerPlatformLS.Impl.Core.Lsp;
     using Microsoft.PowerPlatformLS.UnitTests.TestUtilities;
     using System;
-    using System.Collections.Concurrent;
     using System.Linq;
     using System.Reflection;
     using Xunit;
@@ -60,7 +59,8 @@ namespace Microsoft.PowerPlatformLS.UnitTests.Impl.Core
         [Fact]
         public void LogStartContext_Logs_Custom_Methods_At_Information()
         {
-            var requestId = LspLogger.AllocateRequestId("powerplatformls/syncPull");
+            var requestId = LspLogger.AllocateRequestId();
+            _logger.SetCurrentRequestId(requestId);
 
             _logger.LogStartContext("powerplatformls/syncPull");
 
@@ -75,12 +75,12 @@ namespace Microsoft.PowerPlatformLS.UnitTests.Impl.Core
 
             foreach (var method in new[]
             {
-                "textDocument/completion, duration=2ms",
-                "$/progress, duration=3ms",
-                "initialize, duration=4ms",
+                "textDocument/completion",
+                "$/progress",
+                "initialize",
             })
             {
-                _logger.LogEndContext(method);
+                _logger.LogEndContext(method, 5);
             }
 
             Assert.Empty(_testLogger.Info);
@@ -91,7 +91,7 @@ namespace Microsoft.PowerPlatformLS.UnitTests.Impl.Core
         {
             LspRequestContext.CurrentRequestId = 19;
 
-            _logger.LogEndContext("powerplatformls/syncPull, duration=17ms");
+            _logger.LogEndContext("powerplatformls/syncPull", 17);
 
             var infoLog = Assert.Single(_testLogger.Info);
             Assert.Contains("[Req: 19] Completed handler for: powerplatformls/syncPull, duration=17ms", infoLog);
@@ -122,20 +122,32 @@ namespace Microsoft.PowerPlatformLS.UnitTests.Impl.Core
         [Fact]
         public void AllocateRequestId_Increments_Sequentially()
         {
-            var first = LspLogger.AllocateRequestId("powerplatformls/one");
-            var second = LspLogger.AllocateRequestId("powerplatformls/two");
+            var first = LspLogger.AllocateRequestId();
+            var second = LspLogger.AllocateRequestId();
 
             Assert.Equal(first + 1, second);
         }
 
         [Fact]
-        public void LogStartContext_Sets_LspRequestContext_CurrentRequestId()
+        public void LogStartContext_Reads_RequestId_From_AsyncLocal()
         {
-            var requestId = LspLogger.AllocateRequestId("powerplatformls/syncPush");
+            var requestId = LspLogger.AllocateRequestId();
+            // Simulate the queue calling SetCurrentRequestId (which sets the AsyncLocal)
+            // as QueueItem.StartRequestAsync does before LogStartContext.
+            _logger.SetCurrentRequestId(requestId);
 
             _logger.LogStartContext("powerplatformls/syncPush");
 
-            Assert.Equal(requestId, LspRequestContext.CurrentRequestId);
+            var infoLog = Assert.Single(_testLogger.Info);
+            Assert.Contains($"[Req: {requestId}]", infoLog);
+        }
+
+        [Fact]
+        public void SetCurrentRequestId_Sets_AsyncLocal()
+        {
+            _logger.SetCurrentRequestId(42);
+
+            Assert.Equal(42, LspRequestContext.CurrentRequestId);
         }
 
         private static void ResetLspLoggerState()
@@ -143,11 +155,6 @@ namespace Microsoft.PowerPlatformLS.UnitTests.Impl.Core
             var counterField = typeof(LspLogger).GetField("_lspRequestCounter", BindingFlags.NonPublic | BindingFlags.Static);
             Assert.NotNull(counterField);
             counterField!.SetValue(null, 0);
-
-            var pendingIdsField = typeof(LspLogger).GetField("_pendingIds", BindingFlags.NonPublic | BindingFlags.Static);
-            Assert.NotNull(pendingIdsField);
-            var pendingIds = (ConcurrentDictionary<string, ConcurrentStack<int>>)pendingIdsField!.GetValue(null)!;
-            pendingIds.Clear();
         }
     }
 }

--- a/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.Core/LspWindowLogMessageLoggerProviderTests.cs
+++ b/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.Core/LspWindowLogMessageLoggerProviderTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.PowerPlatformLS.UnitTests.Impl.Core
         }
 
         [Fact]
-        public async Task Log_Forwards_WindowLogMessage_With_Category_Prefix_After_ClientReady()
+        public async Task Log_Forwards_WindowLogMessage_After_ClientReady()
         {
             _transport.Activate();
             LspWindowLogMessageLoggerProvider.SignalClientReady();
@@ -50,7 +50,7 @@ namespace Microsoft.PowerPlatformLS.UnitTests.Impl.Core
             Assert.Equal(LspMethods.WindowLogMessage, sent.Method);
             var payload = sent.Params!.Value.Deserialize<LogMessageParams>(Constants.DefaultSerializationOptions)!;
             Assert.Equal(3, payload.Type); // Information => 3
-            Assert.Equal("[Foo] hello world", payload.Message);
+            Assert.Equal("hello world", payload.Message);
         }
 
         [Fact]
@@ -70,7 +70,7 @@ namespace Microsoft.PowerPlatformLS.UnitTests.Impl.Core
             _transport.Activate();
 
             var sent = await _transport.WaitForOneAsync();
-            Assert.Equal("[Cat] before transport", DeserializeMessage(sent));
+            Assert.Equal("before transport", DeserializeMessage(sent));
         }
 
         [Fact]
@@ -88,7 +88,7 @@ namespace Microsoft.PowerPlatformLS.UnitTests.Impl.Core
             LspWindowLogMessageLoggerProvider.SignalClientReady();
 
             var sent = await _transport.WaitForOneAsync();
-            Assert.Equal("[Cat] before initialized", DeserializeMessage(sent));
+            Assert.Equal("before initialized", DeserializeMessage(sent));
         }
 
         [Theory]
@@ -123,7 +123,7 @@ namespace Microsoft.PowerPlatformLS.UnitTests.Impl.Core
             logger.LogInformation("real");
 
             var sent = await _transport.WaitForOneAsync();
-            Assert.Equal("[Cat] real", DeserializeMessage(sent));
+            Assert.Equal("real", DeserializeMessage(sent));
             await Task.Delay(100);
             Assert.Empty(_transport.Sent);
         }
@@ -140,7 +140,7 @@ namespace Microsoft.PowerPlatformLS.UnitTests.Impl.Core
 
             var sent = await _transport.WaitForOneAsync();
             var message = DeserializeMessage(sent);
-            Assert.StartsWith("[Cat] failed", message);
+            Assert.StartsWith("failed", message);
             Assert.Contains("InvalidOperationException", message);
             Assert.Contains("boom", message);
         }
@@ -162,11 +162,11 @@ namespace Microsoft.PowerPlatformLS.UnitTests.Impl.Core
         }
 
         [Theory]
-        [InlineData("A.B.C", "[C] msg")]
-        [InlineData("OnlyOne", "[OnlyOne] msg")]
-        [InlineData("Generic`1[[X]]", "[Generic] msg")]
-        [InlineData("Ns.Generic`2[[X],[Y]]", "[Generic] msg")]
-        public async Task CreateLogger_Shortens_Category(string fullName, string expectedPrefixedMessage)
+        [InlineData("A.B.C", "msg")]
+        [InlineData("OnlyOne", "msg")]
+        [InlineData("Generic`1[[X]]", "msg")]
+        [InlineData("Ns.Generic`2[[X],[Y]]", "msg")]
+        public async Task CreateLogger_Forwards_Message_Without_Category_Prefix(string fullName, string expectedMessage)
         {
             _transport.Activate();
             LspWindowLogMessageLoggerProvider.SignalClientReady();
@@ -175,7 +175,7 @@ namespace Microsoft.PowerPlatformLS.UnitTests.Impl.Core
             logger.LogInformation("msg");
 
             var sent = await _transport.WaitForOneAsync();
-            Assert.Equal(expectedPrefixedMessage, DeserializeMessage(sent));
+            Assert.Equal(expectedMessage, DeserializeMessage(sent));
         }
 
         [Fact]
@@ -198,7 +198,7 @@ namespace Microsoft.PowerPlatformLS.UnitTests.Impl.Core
             logger.LogInformation("second"); // must still go through
 
             var sent = await _transport.WaitForOneAsync();
-            Assert.Equal("[Cat] second", DeserializeMessage(sent));
+            Assert.Equal("second", DeserializeMessage(sent));
         }
 
         [Fact]

--- a/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.Language.CopilotStudio/Methods/OpenMethodTests.cs
+++ b/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.Language.CopilotStudio/Methods/OpenMethodTests.cs
@@ -26,7 +26,7 @@
                 var documentUri = new Uri("file:///c:/ws/topics/test.mcs.yml");
                 var diagParams = await context.OpenDocumentWithTextAsync(documentUri, "kind: AdaptiveDialog");
                 Assert.Empty(diagParams.Diagnostics.Where(x => x.Severity < DiagnosticSeverity.Warning));
-                AssertAgentResolvingEvent(context, "Agent Directory initialized at: 'c:/ws/topics/'");
+                AssertAgentResolvingEvent(context, "Agent directory initialized with 1 documents tracked: 'c:/ws/topics/'");
                 AssertAgentDirectoryChangeNotification(context);
                 context.Logs.Clear();
             }
@@ -36,7 +36,7 @@
                 var documentUri = new Uri("file:///c:/ws/test.mcs.yml");
                 var diagParams = await context.OpenDocumentWithTextAsync(documentUri, "kind: AdaptiveDialog");
                 Assert.Empty(diagParams.Diagnostics.Where(x => x.Severity < DiagnosticSeverity.Warning));
-                AssertAgentResolvingEvent(context, "Agent Directory initialized at: 'c:/ws/'");
+                AssertAgentResolvingEvent(context, "Agent directory initialized with 1 documents tracked: 'c:/ws/'");
                 AssertAgentDirectoryChangeNotification(context);
                 context.Logs.Clear();
             }
@@ -116,7 +116,7 @@
             var diagParams2 = await context.OpenDocumentWithTextAsync(documentUri, "kind: AdaptiveDialog");
             Assert.Equal(diagParams.Uri, diagParams2.Uri);
             Assert.Equal(diagParams.Diagnostics.Select(x => x.Message), diagParams2.Diagnostics.Select(x => x.Message));
-            Assert.Equal(1, context.Logs.Info.Count(x => x.StartsWith("[AgentResolvingEvent]")));
+            Assert.Equal(1, context.Logs.Info.Count(x => x.StartsWith("[AgentResolving]")));
             AssertAgentResolvingEvent(context, "Agent Directory selected: 'c:/ws/topics/'");
             context.Logs.Clear();
 
@@ -474,9 +474,10 @@ beginDialog:
 
         private static void AssertAgentResolvingEvent(TestHost context, string expectedEventLog, int expectedCount = 1)
         {
-            var agentResolvingEvents = context.Logs.Info
-                .Where(x => x.StartsWith("[AgentResolvingEvent]"))
-                .Select(x => x.Substring("[AgentResolvingEvent] ".Length))
+            const string prefix = "[AgentResolving] ";
+            var agentResolvingEvents = context.Logs.Info.Concat(context.Logs.Debug)
+                .Where(x => x.StartsWith(prefix))
+                .Select(x => x.Substring(prefix.Length))
                 .ToArray();
             var actualCount = agentResolvingEvents.Count(x => x == expectedEventLog);
 
@@ -488,7 +489,7 @@ beginDialog:
                 if (agentResolvingEventsCount > 0)
                 {
                     var agentResolvingEventsString = string.Join("\n", agentResolvingEvents);
-                    additionalInformation += $"{agentResolvingEvents.Count()} Total [AgentResolvingEvent]s: \n" + agentResolvingEventsString;
+                    additionalInformation += $"{agentResolvingEvents.Count()} Total [AgentResolving] events: \n" + agentResolvingEventsString;
                 }
                 else
                 {

--- a/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.Language.CopilotStudio/Methods/OpenMethodTests.cs
+++ b/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.Language.CopilotStudio/Methods/OpenMethodTests.cs
@@ -116,7 +116,7 @@
             var diagParams2 = await context.OpenDocumentWithTextAsync(documentUri, "kind: AdaptiveDialog");
             Assert.Equal(diagParams.Uri, diagParams2.Uri);
             Assert.Equal(diagParams.Diagnostics.Select(x => x.Message), diagParams2.Diagnostics.Select(x => x.Message));
-            Assert.Equal(1, context.Logs.Info.Count(x => x.StartsWith("[AgentResolving]")));
+            Assert.Equal(1, context.Logs.Info.Count(x => x.StartsWith("[AgentInit]")));
             AssertAgentResolvingEvent(context, "Agent Directory selected: 'c:/ws/topics/'");
             context.Logs.Clear();
 
@@ -474,7 +474,7 @@ beginDialog:
 
         private static void AssertAgentResolvingEvent(TestHost context, string expectedEventLog, int expectedCount = 1)
         {
-            const string prefix = "[AgentResolving] ";
+            const string prefix = "[AgentInit] ";
             var agentResolvingEvents = context.Logs.Info.Concat(context.Logs.Debug)
                 .Where(x => x.StartsWith(prefix))
                 .Select(x => x.Substring(prefix.Length))
@@ -489,7 +489,7 @@ beginDialog:
                 if (agentResolvingEventsCount > 0)
                 {
                     var agentResolvingEventsString = string.Join("\n", agentResolvingEvents);
-                    additionalInformation += $"{agentResolvingEvents.Count()} Total [AgentResolving] events: \n" + agentResolvingEventsString;
+                    additionalInformation += $"{agentResolvingEvents.Count()} Total [AgentInit] events: \n" + agentResolvingEventsString;
                 }
                 else
                 {

--- a/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.PullAgent/LoggingHttpHandlerTests.cs
+++ b/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.PullAgent/LoggingHttpHandlerTests.cs
@@ -1,0 +1,146 @@
+namespace Microsoft.PowerPlatformLS.UnitTests.Impl.PullAgent
+{
+    using Microsoft.PowerPlatformLS.Contracts.Internal.Common;
+    using Microsoft.PowerPlatformLS.Impl.PullAgent;
+    using Microsoft.PowerPlatformLS.UnitTests.TestUtilities;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+    using System.Reflection;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Xunit;
+
+    [Collection("LoggingTestsCollection")]
+    public class LoggingHttpHandlerTests : IDisposable
+    {
+        private readonly TestLogger _testLogger = new();
+
+        public void Dispose()
+        {
+            LspRequestContext.CurrentRequestId = 0;
+            ResetHttpRequestCounter();
+        }
+
+        [Fact]
+        public async Task SendAsync_Logs_Request_Start_At_Information_Level()
+        {
+            using var response = new HttpResponseMessage(HttpStatusCode.OK);
+            using var request = new HttpRequestMessage(HttpMethod.Get, "https://contoso.crm.dynamics.com/api/data/v9.2/accounts?foo=bar");
+            using var invoker = CreateInvoker((_, _) => Task.FromResult(response));
+
+            using var result = await invoker.SendAsync(request, CancellationToken.None);
+
+            var infoLogs = _testLogger.Info.ToList();
+            Assert.Equal(2, infoLogs.Count);
+            Assert.Contains("HTTP request #", infoLogs[0]);
+            Assert.Contains("started: GET /api/data/v9.2/accounts?foo=bar", infoLogs[0]);
+            Assert.DoesNotContain("contoso.crm.dynamics.com", infoLogs[0]);
+        }
+
+        [Fact]
+        public async Task SendAsync_Logs_Response_Completion_With_StatusCode_And_Duration()
+        {
+            using var response = new HttpResponseMessage(HttpStatusCode.Accepted);
+            using var request = new HttpRequestMessage(HttpMethod.Post, "https://contoso.crm.dynamics.com/api/data/v9.2/accounts?foo=bar");
+            using var invoker = CreateInvoker((_, _) => Task.FromResult(response));
+
+            using var result = await invoker.SendAsync(request, CancellationToken.None);
+
+            var completionLog = _testLogger.Info.ToList()[1];
+            Assert.Contains("HTTP response #", completionLog);
+            Assert.Contains("completed: POST /api/data/v9.2/accounts?foo=bar", completionLog);
+            Assert.Contains("duration=", completionLog);
+            Assert.Contains("status=202", completionLog);
+        }
+
+        [Fact]
+        public async Task SendAsync_Logs_Error_On_Exception()
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Delete, "https://contoso.crm.dynamics.com/api/data/v9.2/accounts(1)");
+            using var invoker = CreateInvoker((_, _) => throw new HttpRequestException("network failure"));
+
+            var exception = await Assert.ThrowsAsync<HttpRequestException>(() => invoker.SendAsync(request, CancellationToken.None));
+
+            Assert.Equal("network failure", exception.Message);
+            var errorLog = Assert.Single(_testLogger.Error);
+            Assert.Contains("HTTP request #", errorLog);
+            Assert.Contains("failed: DELETE /api/data/v9.2/accounts(1)", errorLog);
+            Assert.Contains("duration=", errorLog);
+            Assert.Contains("error=network failure", errorLog);
+        }
+
+        [Fact]
+        public void GetPathAndQuery_Strips_Host_From_Full_Url()
+        {
+            var method = typeof(LoggingHttpHandler).GetMethod("GetPathAndQuery", BindingFlags.NonPublic | BindingFlags.Static);
+
+            Assert.NotNull(method);
+            var result = (string)method!.Invoke(null, [new Uri("https://contoso.crm.dynamics.com/api/data/v9.2/accounts?foo=bar")])!;
+
+            Assert.Equal("/api/data/v9.2/accounts?foo=bar", result);
+        }
+
+        [Fact]
+        public void GetPathAndQuery_Returns_Empty_For_Null_Uri()
+        {
+            var method = typeof(LoggingHttpHandler).GetMethod("GetPathAndQuery", BindingFlags.NonPublic | BindingFlags.Static);
+
+            Assert.NotNull(method);
+            var result = (string)method!.Invoke(null, [null])!;
+
+            Assert.Equal(string.Empty, result);
+        }
+
+        [Fact]
+        public async Task SendAsync_Includes_RequestId_From_LspRequestContext()
+        {
+            LspRequestContext.CurrentRequestId = 42;
+
+            using var response = new HttpResponseMessage(HttpStatusCode.OK);
+            using var request = new HttpRequestMessage(HttpMethod.Get, "https://contoso.crm.dynamics.com/api/data/v9.2/accounts");
+            using var invoker = CreateInvoker((_, _) => Task.FromResult(response));
+
+            using var result = await invoker.SendAsync(request, CancellationToken.None);
+
+            Assert.All(_testLogger.Info, log => Assert.Contains("[Req: 42]", log));
+        }
+
+        private HttpMessageInvoker CreateInvoker(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> sendAsync)
+        {
+            var handler = new LoggingHttpHandler(new TestLogger<LoggingHttpHandler>(_testLogger))
+            {
+                InnerHandler = new StubHttpMessageHandler(sendAsync)
+            };
+
+            return new HttpMessageInvoker(handler);
+        }
+
+        private static void ResetHttpRequestCounter()
+        {
+            var field = typeof(LoggingHttpHandler).GetField("_requestId", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(field);
+            field!.SetValue(null, 0);
+        }
+
+        private sealed class StubHttpMessageHandler : HttpMessageHandler
+        {
+            private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> _sendAsync;
+
+            public StubHttpMessageHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> sendAsync)
+            {
+                _sendAsync = sendAsync;
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                return _sendAsync(request, cancellationToken);
+            }
+        }
+    }
+
+    [CollectionDefinition("LoggingTestsCollection", DisableParallelization = true)]
+    public sealed class LoggingTestsCollection { }
+}

--- a/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.PullAgent/Methods/ReattachAgentHandlerTests.cs
+++ b/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.PullAgent/Methods/ReattachAgentHandlerTests.cs
@@ -196,7 +196,7 @@
 
             Assert.Equal(400, response.Code);
             Assert.Contains("BadRequest", response.Message);
-            mockLogger.Verify(l => l.LogException(It.IsAny<DataverseBadRequestException>(), It.IsAny<string>(), It.IsAny<object[]>()), Times.Once);
+            mockLogger.Verify(l => l.LogError(It.IsAny<string>(), It.IsAny<object[]>()), Times.Once);
         }
 
         [Fact]
@@ -209,7 +209,7 @@
 
             var response = await handler.HandleRequestAsync(context.Request, context.RequestContext, CancellationToken.None);
 
-            Assert.Equal(500, response.Code);
+            Assert.Equal(400, response.Code);
             Assert.Contains("exception", response.Message);
         }
 

--- a/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.PullAgent/OperationLoggerTests.cs
+++ b/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.PullAgent/OperationLoggerTests.cs
@@ -1,0 +1,97 @@
+namespace Microsoft.PowerPlatformLS.UnitTests.Impl.PullAgent
+{
+    using Microsoft.PowerPlatformLS.Contracts.Internal.Common;
+    using Microsoft.PowerPlatformLS.Impl.PullAgent;
+    using Microsoft.PowerPlatformLS.UnitTests.TestUtilities;
+    using System;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Xunit;
+
+    [Collection("LoggingTestsCollection")]
+    public class OperationLoggerTests : IDisposable
+    {
+        private readonly TestLogger _testLogger = new();
+        private readonly LspOperationLogger _logger;
+
+        public OperationLoggerTests()
+        {
+            _logger = new LspOperationLogger(new TestLogger<LspOperationLogger>(_testLogger));
+        }
+
+        public void Dispose()
+        {
+            LspRequestContext.CurrentRequestId = 0;
+        }
+
+        [Fact]
+        public void Execute_Logs_Start_And_Completion_At_Information()
+        {
+            var result = _logger.Execute("syncPull", () => 7);
+
+            Assert.Equal(7, result);
+            var infoLogs = _testLogger.Info.ToList();
+            Assert.Equal(2, infoLogs.Count);
+            Assert.Contains("Sync operation started: syncPull", infoLogs[0]);
+            Assert.Contains("Sync operation completed: syncPull", infoLogs[1]);
+            Assert.Contains("duration=", infoLogs[1]);
+        }
+
+        [Fact]
+        public void Execute_Logs_Error_On_Exception()
+        {
+            var exception = Assert.Throws<InvalidOperationException>(() => _logger.Execute<int>("syncPush", () => throw new InvalidOperationException("boom")));
+
+            Assert.Equal("boom", exception.Message);
+            var errorLog = Assert.Single(_testLogger.Error);
+            Assert.Contains("InvalidOperationException", errorLog);
+            Assert.Contains("boom", errorLog);
+            Assert.Contains("Sync operation failed: syncPush", errorLog);
+            Assert.Contains("duration=", errorLog);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_Logs_Start_And_Completion_At_Information()
+        {
+            var result = await _logger.ExecuteAsync("syncPull", async () =>
+            {
+                await Task.Yield();
+                return 11;
+            });
+
+            Assert.Equal(11, result);
+            var infoLogs = _testLogger.Info.ToList();
+            Assert.Equal(2, infoLogs.Count);
+            Assert.Contains("Sync operation started: syncPull", infoLogs[0]);
+            Assert.Contains("Sync operation completed: syncPull", infoLogs[1]);
+            Assert.Contains("duration=", infoLogs[1]);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_Logs_Error_On_Exception()
+        {
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => _logger.ExecuteAsync<int>("syncPush", async () =>
+            {
+                await Task.Yield();
+                throw new InvalidOperationException("boom");
+            }));
+
+            Assert.Equal("boom", exception.Message);
+            var errorLog = Assert.Single(_testLogger.Error);
+            Assert.Contains("InvalidOperationException", errorLog);
+            Assert.Contains("boom", errorLog);
+            Assert.Contains("Sync operation failed: syncPush", errorLog);
+            Assert.Contains("duration=", errorLog);
+        }
+
+        [Fact]
+        public void Execute_Includes_RequestId_From_LspRequestContext()
+        {
+            LspRequestContext.CurrentRequestId = 73;
+
+            _logger.Execute("syncPull", () => 5);
+
+            Assert.All(_testLogger.Info, log => Assert.Contains("[Req: 73]", log));
+        }
+    }
+}

--- a/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/TestUtilities/TestLogger.cs
+++ b/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/TestUtilities/TestLogger.cs
@@ -9,6 +9,7 @@
     internal class TestLogger : ILogger
     {
         public IEnumerable<string> Info => _logs.TryGetValue(LogLevel.Information, out var logs) ? logs : [];
+        public IEnumerable<string> Debug => _logs.TryGetValue(LogLevel.Debug, out var logs) ? logs : [];
         public IEnumerable<string> Warning => _logs.TryGetValue(LogLevel.Warning, out var logs) ? logs : [];
         public IEnumerable<string> Error => _logs.TryGetValue(LogLevel.Error, out var logs) ? logs : [];
         public IEnumerable<string> Critical => _logs.TryGetValue(LogLevel.Critical, out var logs) ? logs : [];

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/clients/account.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/clients/account.ts
@@ -339,6 +339,7 @@ export async function getPreferredAccountId(clusterCategory: CoreServicesCluster
  * Uses coalescing to prevent multiple concurrent consent dialogs.
  */
 export async function switchAccount(clusterCategory: CoreServicesClusterCategory): Promise<boolean> {
+    logger.info('Auth', 'Switch account initiated');
     signInCancelled.clear();
     while (pendingInteractiveAuth) {
         await pendingInteractiveAuth;
@@ -367,6 +368,7 @@ export async function switchAccount(clusterCategory: CoreServicesClusterCategory
                     accountId: session.account.id,
                     accountEmail: session.account.label
                 };
+                logger.info('Auth', `Switched to account: ${session.account.label}`);
                 try {
                     const { clearWhoAmICache } = await import('./dataverseClient.js');
                     clearWhoAmICache();
@@ -377,9 +379,11 @@ export async function switchAccount(clusterCategory: CoreServicesClusterCategory
         } catch (error) {
             // User cancelled or auth failed
             if (isCancellationError(error)) {
+                logger.info('Auth', 'Switch account cancelled by user');
                 logger.logInfo(TelemetryEventsKeys.SwitchAccountError, 'Switch account cancelled by user.');
             } else {
                 const message = error instanceof Error ? error.message : String(error);
+                logger.error('Auth', `Switch account failed: ${message}`);
                 logger.logError(TelemetryEventsKeys.SwitchAccountError, `Failed to switch account: ${message}`);
             }
             return false; // Cancelled or failed

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/clients/bapClient.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/clients/bapClient.ts
@@ -117,7 +117,8 @@ export async function listEnvironmentsBySkuAsync(
     accountHint?: string
 ): Promise<EnvironmentInfo[]> {
     const query = SKU_QUERIES[sku];
-    
+    logger.trace('BapClient', `Fetching ${sku} environments`);
+
     const response = await getAsync<EnvironmentResponse>(
         clusterCategory,
         'environments',
@@ -137,6 +138,7 @@ export async function listEnvironmentsBySkuAsync(
         .map(toEnvironmentInfo)
         .filter((env): env is EnvironmentInfo => env !== null);
     
+    logger.trace('BapClient', `Fetched ${permissionFilteredEnvs.length} ${sku} environment(s)`);
     return permissionFilteredEnvs;
 }
 

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/clients/bapClient.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/clients/bapClient.ts
@@ -117,7 +117,7 @@ export async function listEnvironmentsBySkuAsync(
     accountHint?: string
 ): Promise<EnvironmentInfo[]> {
     const query = SKU_QUERIES[sku];
-    logger.trace('BapClient', `Fetching ${sku} environments`);
+    logger.debug('BapClient', `Fetching ${sku} environments`);
 
     const response = await getAsync<EnvironmentResponse>(
         clusterCategory,
@@ -138,7 +138,7 @@ export async function listEnvironmentsBySkuAsync(
         .map(toEnvironmentInfo)
         .filter((env): env is EnvironmentInfo => env !== null);
     
-    logger.trace('BapClient', `Fetched ${permissionFilteredEnvs.length} ${sku} environment(s)`);
+    logger.debug('BapClient', `Fetched ${permissionFilteredEnvs.length} ${sku} environment(s)`);
     return permissionFilteredEnvs;
 }
 

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/clients/dataverseClient.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/clients/dataverseClient.ts
@@ -169,7 +169,7 @@ export async function listAgentsAsync(
   accountId?: string,
   accountHint?: string
 ): Promise<AgentInfo[]> {
-  logger.trace('Dataverse', `Listing owned agents from: ${baseEndpoint.authority}`);
+  logger.debug('Dataverse', `Listing owned agents from: ${baseEndpoint.authority}`);
   const systemUserId = await whoAmIAsync(baseEndpoint, cancellationToken, accountId, accountHint);
 
   const filter = `ismanaged eq false and _ownerid_value eq ${systemUserId}`;
@@ -204,7 +204,7 @@ export async function listSharedAgentsAsync(
   accountId?: string,
   accountHint?: string
 ): Promise<AgentInfo[]> {
-  logger.trace('Dataverse', `Listing shared agents from: ${baseEndpoint.authority}`);
+  logger.debug('Dataverse', `Listing shared agents from: ${baseEndpoint.authority}`);
   const systemUserId = await whoAmIAsync(baseEndpoint, cancellationToken, accountId, accountHint);
 
   // Get all unmanaged bots the user can see, excluding ones they own
@@ -214,7 +214,9 @@ export async function listSharedAgentsAsync(
     query: `$select=botid,name,iconbase64&$filter=${filter}&$expand=bot_botcomponentcollection($select=schemaname,botcomponentcollectionid,name)`
   });
   const response = await getAsync<ListResponse<AgentDetails>>(uri, cancellationToken, accountId, accountHint);
-  return projectSharedAgents(response.result.value);
+  const sharedAgents = projectSharedAgents(response.result.value);
+  logger.trace('Dataverse', `Found ${sharedAgents.length} shared agent(s)`);
+  return sharedAgents;
 }
 
 async function getAsync<TResult>(

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/clients/dataverseClient.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/clients/dataverseClient.ts
@@ -2,6 +2,7 @@ import { Uri } from "vscode";
 import { FetchAccessToken, TokenInfo } from "./account";
 import { AgentInfo, SolutionInfo } from "../types";
 import { solutionList } from "../generated/schema";
+import logger from "../services/logger";
 
 const PowerVirtualAgentsSolutionName = "PowerVirtualAgents";
 const additionalSolutions: ReadonlyArray<string> = [
@@ -168,6 +169,7 @@ export async function listAgentsAsync(
   accountId?: string,
   accountHint?: string
 ): Promise<AgentInfo[]> {
+  logger.trace('Dataverse', `Listing owned agents from: ${baseEndpoint.authority}`);
   const systemUserId = await whoAmIAsync(baseEndpoint, cancellationToken, accountId, accountHint);
 
   const filter = `ismanaged eq false and _ownerid_value eq ${systemUserId}`;
@@ -179,6 +181,7 @@ export async function listAgentsAsync(
   });
 
   const response = await getAsync<ListResponse<AgentDetails>>(uri, cancellationToken, accountId, accountHint);
+  logger.trace('Dataverse', `Found ${response.result.value.length} owned agent(s)`);
   return response.result.value.map(getAgentInfo);
 }
 
@@ -201,6 +204,7 @@ export async function listSharedAgentsAsync(
   accountId?: string,
   accountHint?: string
 ): Promise<AgentInfo[]> {
+  logger.trace('Dataverse', `Listing shared agents from: ${baseEndpoint.authority}`);
   const systemUserId = await whoAmIAsync(baseEndpoint, cancellationToken, accountId, accountHint);
 
   // Get all unmanaged bots the user can see, excluding ones they own

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/clone/tree.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/clone/tree.ts
@@ -215,7 +215,7 @@ export class AgentTreeDataProvider implements TreeDataProvider<CopilotStudioTree
             return this.envsBySku.get(sku) || [];
         }
 
-        logger.trace('AgentTree', `Loading ${sku} environments`);
+        logger.info('AgentTree', `Loading ${sku} environments`);
         const preferred = getPreferredTreeAccount();
         const projectAccounts = getAllProjectAccounts();
 
@@ -287,7 +287,7 @@ export class AgentTreeDataProvider implements TreeDataProvider<CopilotStudioTree
 
             this.envsBySku.set(sku, merged);
             this.loadedSkus.add(sku);
-            logger.trace('AgentTree', `Loaded ${merged.length} ${sku} environment(s)`);
+            logger.info('AgentTree', `Loaded ${merged.length} ${sku} environment(s)`);
             return merged;
         } catch (e: any) {
             logger.error('AgentTree', `Failed to load ${sku} environments: ${e?.message || e}`);
@@ -398,14 +398,14 @@ export class AgentTreeDataProvider implements TreeDataProvider<CopilotStudioTree
                 try {
                     // Load owned and shared agents in parallel, combine into single list
 					const storeAccount = envItem.sourceAccount ?? getActiveAgentAccount();
-					logger.trace('AgentTree', `Loading agents for environment: ${envItem.environment.displayName}`);
+					logger.info('AgentTree', `Loading agents for environment: ${envItem.environment.displayName}`);
 					const [ownedAgents, sharedAgents] = await Promise.all([
                         listAgentsAsync(Uri.parse(envItem.environment.dataverseUrl), null, storeAccount?.accountId, storeAccount?.accountEmail),
                         listSharedAgentsAsync(Uri.parse(envItem.environment.dataverseUrl), null, storeAccount?.accountId, storeAccount?.accountEmail)
 					]);
 					
 					const allAgents = [...ownedAgents, ...sharedAgents];
-					logger.trace('AgentTree', `Loaded ${allAgents.length} agent(s) for environment: ${envItem.environment.displayName}`);
+					logger.info('AgentTree', `Loaded ${allAgents.length} agent(s) for environment: ${envItem.environment.displayName}`);
 					const agents: CopilotStudioTreeItem[] = allAgents.map((agent) => {
                         return { kind: TreeItemKind.Agent, environment: envItem.environment, agent: agent, sourceAccount: storeAccount } as AgentTreeItem;
 					});

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/clone/tree.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/clone/tree.ts
@@ -107,16 +107,21 @@ export async function configureTreeView(context: ExtensionContext) {
 
     // Register the refresh command (full tree)
     const refreshCommand = commands.registerCommand('microsoft-copilot-studio.refreshAgentTreeView', async () => {
+        logger.info('AgentTree', 'Refresh agents requested');
         treeDataProvider.refresh();
         await resetTreeExpansion(treeView);
     });
 
     // Register the switch account command (same behavior as button in clone flow)
     const switchAccountCommand = commands.registerCommand('microsoft-copilot-studio.switchAccount', async () => {
+        logger.info('AgentTree', 'Switch account requested');
         const switched = await switchAccount(DefaultCoreServicesClusterCategory);
         if (switched) {
+            logger.info('AgentTree', 'Account switched successfully, reloading tree');
             treeDataProvider.invalidateCache();
             await resetTreeExpansion(treeView);
+        } else {
+            logger.debug('AgentTree', 'Switch account cancelled or failed');
         }
     });
 
@@ -210,6 +215,7 @@ export class AgentTreeDataProvider implements TreeDataProvider<CopilotStudioTree
             return this.envsBySku.get(sku) || [];
         }
 
+        logger.trace('AgentTree', `Loading ${sku} environments`);
         const preferred = getPreferredTreeAccount();
         const projectAccounts = getAllProjectAccounts();
 
@@ -259,6 +265,7 @@ export class AgentTreeDataProvider implements TreeDataProvider<CopilotStudioTree
                             sourceAccount: acct
                         }));
                     } catch (e: any) {
+                        logger.error('AgentTree', `Failed to load ${sku} environments for account ${acct?.accountId ?? 'default'}: ${e?.message || e}`);
                         logger.logError(TelemetryEventsKeys.LoadEnvironmentError, `[TreeView] Failed to load ${sku} environments for ${acct?.accountId ?? 'default'}: ${e?.message || e}`);
                         return [] as EnvironmentTreeItem[];
                     }
@@ -280,8 +287,10 @@ export class AgentTreeDataProvider implements TreeDataProvider<CopilotStudioTree
 
             this.envsBySku.set(sku, merged);
             this.loadedSkus.add(sku);
+            logger.trace('AgentTree', `Loaded ${merged.length} ${sku} environment(s)`);
             return merged;
         } catch (e: any) {
+            logger.error('AgentTree', `Failed to load ${sku} environments: ${e?.message || e}`);
             logger.logError(TelemetryEventsKeys.LoadEnvironmentError, `[TreeView] Failed to load ${sku} environments: ${e?.message || e}`);
             this.loadedSkus.add(sku); // Mark as loaded to avoid retry loops
             return [];
@@ -380,6 +389,7 @@ export class AgentTreeDataProvider implements TreeDataProvider<CopilotStudioTree
 						resolve(envItems);
 					}
 				} catch (e: any) {
+					logger.error('AgentTree', `Failed to load ${skuItem.sku} environments: ${e?.message || e}`);
 					logger.logError(TelemetryEventsKeys.LoadEnvironmentError, `[TreeView] Failed to load ${skuItem.sku} environments: ${e?.message || e}`);
 					resolve([{ kind: TreeItemKind.Error, message: "Failed to load environments" } as ErrorTreeItem]);
 				}
@@ -388,17 +398,20 @@ export class AgentTreeDataProvider implements TreeDataProvider<CopilotStudioTree
                 try {
                     // Load owned and shared agents in parallel, combine into single list
 					const storeAccount = envItem.sourceAccount ?? getActiveAgentAccount();
+					logger.trace('AgentTree', `Loading agents for environment: ${envItem.environment.displayName}`);
 					const [ownedAgents, sharedAgents] = await Promise.all([
                         listAgentsAsync(Uri.parse(envItem.environment.dataverseUrl), null, storeAccount?.accountId, storeAccount?.accountEmail),
                         listSharedAgentsAsync(Uri.parse(envItem.environment.dataverseUrl), null, storeAccount?.accountId, storeAccount?.accountEmail)
 					]);
 					
 					const allAgents = [...ownedAgents, ...sharedAgents];
+					logger.trace('AgentTree', `Loaded ${allAgents.length} agent(s) for environment: ${envItem.environment.displayName}`);
 					const agents: CopilotStudioTreeItem[] = allAgents.map((agent) => {
                         return { kind: TreeItemKind.Agent, environment: envItem.environment, agent: agent, sourceAccount: storeAccount } as AgentTreeItem;
 					});
 					resolve(agents);
 				} catch (e: any) {
+					logger.error('AgentTree', `Failed to load agents for environment: ${envItem.environment.displayName}: ${e?.message || e}`);
 					logger.logError(TelemetryEventsKeys.LoadEnvironmentError, `[TreeView] Failed to load agents for ${envItem.environment.displayName}: ${e?.message || e}`);
 					const errorMessage = e?.message?.includes('403') || e?.message?.includes('not a member')
 						? "Access denied - not a member of this organization"

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/extension.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/extension.ts
@@ -46,6 +46,7 @@ export async function activate(context: vscode.ExtensionContext) {
   // Using `createLogOutputChannel` gives each line a timestamp and a color-coded
   // [error]/[warning]/[info] prefix.
   const outputChannel = vscode.window.createOutputChannel("Copilot Studio Language Server", { log: true });
+  logger.setOutputChannel(outputChannel);
   if (isDebugging) {
     outputChannel.show();
   }

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/services/logger.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/services/logger.ts
@@ -31,6 +31,7 @@ class Logger {
   private static instance: Logger;
   private reporter!: TelemetryReporter;
   private sessionId!: string;
+  private outputChannel: vscode.LogOutputChannel | undefined;
 
   private constructor() { }
 
@@ -45,6 +46,58 @@ class Logger {
     this.reporter = new TelemetryReporter(TELEMETRY_CONNECTION_STRING);
     this.sessionId = sessionId;
     context.subscriptions.push(this.reporter);
+  }
+
+  /**
+   * Sets the output channel for writing diagnostic logs.
+   * Must be called after the output channel is created.
+   */
+  public setOutputChannel(channel: vscode.LogOutputChannel) {
+    this.outputChannel = channel;
+  }
+
+  // --- Output channel logging (diagnostics only, no telemetry) ---
+  // Log level filtering is handled natively by VS Code's LogOutputChannel.
+  // The user controls visibility via the output panel dropdown (defaults to Info).
+
+  /**
+   * Writes a trace-level message to the output channel.
+   * Use for detailed flow tracking (e.g., HTTP requests, intermediate steps).
+   */
+  public trace(category: string, message: string): void {
+    this.outputChannel?.trace(`[${category}] ${message}`);
+  }
+
+  /**
+   * Writes a debug-level message to the output channel.
+   * Use for debugging context that's slightly more important than trace.
+   */
+  public debug(category: string, message: string): void {
+    this.outputChannel?.debug(`[${category}] ${message}`);
+  }
+
+  /**
+   * Writes an info-level message to the output channel.
+   * Use for significant user-initiated actions and outcomes.
+   */
+  public info(category: string, message: string): void {
+    this.outputChannel?.info(`[${category}] ${message}`);
+  }
+
+  /**
+   * Writes a warning-level message to the output channel.
+   * Use for recoverable issues that don't block the user flow.
+   */
+  public warn(category: string, message: string): void {
+    this.outputChannel?.warn(`[${category}] ${message}`);
+  }
+
+  /**
+   * Writes an error-level message to the output channel.
+   * Use for failures that block the current operation.
+   */
+  public error(category: string, message: string): void {
+    this.outputChannel?.error(`[${category}] ${message}`);
   }
 
   public async dispose() {

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/services/lspClient.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/services/lspClient.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import { spawnSync } from 'child_process';
-import { ServerOptions, TransportKind, LanguageClient, LanguageClientOptions, Trace, State, LogMessageNotification } from "vscode-languageclient/node";
+import { ServerOptions, TransportKind, LanguageClient, LanguageClientOptions, State, LogMessageNotification, Trace } from "vscode-languageclient/node";
 import { TELEMETRY_CONNECTION_STRING, TelemetryEventsKeys } from '../constants';
 import { AccountInfo, AgentSyncInfo, EnvironmentInfo, RemoteApiRequest } from '../types';
 import { getAccessTokenByAccountId, getCopilotStudioAccessTokenByAccountId } from '../clients/account';
@@ -200,6 +200,9 @@ class LspClientService {
     // so this handler is wired first and takes precedence over vscode-languageclient's
     // built-in default, which would otherwise prepend a duplicate
     // "[Error|Warning|Info - h:mm:ss AM/PM]" prefix.
+    //
+    // Log level filtering is handled natively by VS Code's LogOutputChannel.
+    // The user controls visibility via the output panel dropdown (defaults to Info).
     const logChannel = outputChannel as Partial<vscode.LogOutputChannel>;
     const writeLog = (level: 'error' | 'warn' | 'info' | 'trace' | 'debug', message: string) => {
       const fn = logChannel[level];
@@ -209,6 +212,7 @@ class LspClientService {
         outputChannel.appendLine(message);
       }
     };
+
     this._client.onNotification(LogMessageNotification.type, (params: { type: number; message: string }) => {
       const message = params?.message ?? '';
       switch (params?.type) {


### PR DESCRIPTION
[Issue #198](https://github.com/microsoft/vscode-copilotstudio/issues/198) - Redesigns logging across .NET and TypeScript to reduce telemetry noise and improve debuggability via the VS Code output channel.