### PR TITLE
Fix: show non-owned agents in clone list for environment admins

### DIFF
--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/clients/dataverseClient.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/clients/dataverseClient.ts
@@ -183,8 +183,17 @@ export async function listAgentsAsync(
 }
 
 /**
- * Lists agents that are shared with the current user (not owned, but user has write access).
- * Uses batched RetrievePrincipalAccess to check access rights in a single HTTP call.
+ * Lists agents that are visible to the current user but owned by someone else.
+ *
+ * Returns every non-owned unmanaged bot the Dataverse query returns. Dataverse already
+ * security-trims this query to records the caller can read, so no extra per-agent access
+ * check is performed here.
+ *
+ * Note: a previous version gated this list behind a batched RetrievePrincipalAccess
+ * "write access" check. That check called an invalid (unbound) function form that always
+ * returned HTTP 404, so every non-owned agent was filtered out — environment admins saw
+ * only the agents they personally owned. The gate has been removed; cloning only requires
+ * read access, which the query above already enforces.
  */
 export async function listSharedAgentsAsync(
   baseEndpoint: Uri,
@@ -201,216 +210,7 @@ export async function listSharedAgentsAsync(
     query: `$select=botid,name,iconbase64&$filter=${filter}&$expand=bot_botcomponentcollection($select=schemaname,botcomponentcollectionid,name)`
   });
   const response = await getAsync<ListResponse<AgentDetails>>(uri, cancellationToken, accountId, accountHint);
-  const writeAccess = await batchCheckWriteAccessAsync(
-    baseEndpoint,
-    response.result.value,
-    systemUserId,
-    cancellationToken,
-    accountId,
-    accountHint
-  );
-
-  return response.result.value
-    .filter((_, index) => writeAccess[index])
-    .map(getSharedAgentInfo);
-}
-
-/** Maximum number of requests per batch (Microsoft limit is 1000, using 500 for safety margin) */
-const BATCH_CHUNK_SIZE = 500;
-
-/**
- * Batches multiple RetrievePrincipalAccess calls into $batch requests.
- * Returns an array of booleans indicating write access for each bot (same order as input).
- * Automatically chunks into multiple batch requests if there are more than BATCH_CHUNK_SIZE bots.
- */
-async function batchCheckWriteAccessAsync(
-  baseEndpoint: Uri,
-  bots: AgentDetails[],
-  systemUserId: string,
-  cancellationToken: AbortSignal | null,
-  accountId?: string,
-  accountHint?: string
-): Promise<boolean[]> {
-  if (bots.length === 0) {
-    return [];
-  }
-
-  // Chunk bots into batches to stay under the 1000 request limit
-  const results: boolean[] = new Array(bots.length).fill(false);
-
-  for (let chunkStart = 0; chunkStart < bots.length; chunkStart += BATCH_CHUNK_SIZE) {
-    const chunkEnd = Math.min(chunkStart + BATCH_CHUNK_SIZE, bots.length);
-    const chunk = bots.slice(chunkStart, chunkEnd);
-
-    try {
-      const chunkResults = await executeSingleBatchAsync(
-        baseEndpoint,
-        chunk,
-        systemUserId,
-        cancellationToken,
-        accountId,
-        accountHint
-      );
-
-      // Copy chunk results to the correct positions in the main results array
-      for (let i = 0; i < chunkResults.length; i++) {
-        results[chunkStart + i] = chunkResults[i];
-      }
-    } catch {
-      // If this chunk fails, leave those results as false (no write access)
-      // Other chunks can still succeed
-    }
-  }
-
-  return results;
-}
-
-/**
- * Executes a single batch request for a chunk of bots.
- * Content-ID values are 0-indexed within this chunk.
- */
-async function executeSingleBatchAsync(
-  baseEndpoint: Uri,
-  bots: AgentDetails[],
-  systemUserId: string,
-  cancellationToken: AbortSignal | null,
-  accountId?: string,
-  accountHint?: string
-): Promise<boolean[]> {
-  const batchUri = baseEndpoint.with({ path: `api/data/v9.2/$batch` });
-  const boundary = `batch_${Date.now()}_${Math.random().toString(36).substring(2, 8)}`;
-
-  // Build multipart batch request body
-  // Each part is a GET request for RetrievePrincipalAccess
-  // Content-ID is used to correlate responses (0-indexed within this chunk)
-  const parts = bots.map((bot, index) => {
-    const accessPath = `/api/data/v9.2/RetrievePrincipalAccess(Target=@target,Principal=@principal)?` +
-      `@target={'@odata.id':'bots(${bot.botid})'}&@principal={'@odata.id':'systemusers(${systemUserId})'}`;
-
-    return [
-      `--${boundary}`,
-      `Content-Type: application/http`,
-      `Content-Transfer-Encoding: binary`,
-      ``,
-      `GET ${accessPath} HTTP/1.1`,
-      `Content-ID: ${index}`,
-      `Accept: application/json`,
-      ``,
-    ].join('\r\n');
-  });
-
-  const batchBody = parts.join('\r\n') + `\r\n--${boundary}--\r\n`;
-
-  const { result } = await postBatchAsync<string>(
-    batchUri,
-    boundary,
-    batchBody,
-    cancellationToken,
-    accountId,
-    accountHint
-  );
-
-  // Parse multipart response to extract AccessRights for each bot
-  return parseBatchAccessResults(result, bots.length);
-}
-
-/**
- * Parses a multipart batch response and extracts WriteAccess for each part.
- * Uses Content-ID from each part to correlate responses with the original request order.
- * Handles out-of-order responses and partial failures gracefully.
- */
-export function parseBatchAccessResults(batchResponse: string, expectedCount: number): boolean[] {
-  const results: boolean[] = new Array(expectedCount).fill(false);
-
-  // Split response by boundary markers (lines starting with --batch_ or --batchresponse_)
-  // Each part contains headers (including Content-ID) followed by the HTTP response
-  const boundaryRegex = /--(?:batch|batchresponse)_[^\r\n]+/;
-  const parts = batchResponse.split(boundaryRegex).filter(part => part.trim().length > 0);
-
-  for (const part of parts) {
-    // Skip the closing boundary marker
-    if (part.trim() === '--' || part.trim().length === 0) {
-      continue;
-    }
-
-    // Extract Content-ID from headers - it appears in format "Content-ID: <number>" or "Content-ID: number"
-    const contentIdMatch = part.match(/Content-ID\s*:\s*<?([0-9]+)>?/i);
-    if (!contentIdMatch) {
-      // Part without Content-ID - might be an error response without correlation
-      continue;
-    }
-
-    const contentId = parseInt(contentIdMatch[1], 10);
-    if (isNaN(contentId) || contentId < 0 || contentId >= expectedCount) {
-      // Invalid Content-ID - skip this part
-      continue;
-    }
-
-    // Check if this part contains a successful response (HTTP 200)
-    // The response format is: HTTP/1.1 200 OK followed by headers and JSON body
-    const httpStatusMatch = part.match(/HTTP\/1\.1\s+(\d+)/i);
-    if (!httpStatusMatch || httpStatusMatch[1] !== '200') {
-      // Non-200 response (403, 404, etc.) - leave as false (no write access)
-      continue;
-    }
-
-    // Extract AccessRights from the JSON response
-    const accessRightsMatch = part.match(/"AccessRights"\s*:\s*"([^"]+)"/i);
-    if (accessRightsMatch) {
-      const accessRights = accessRightsMatch[1];
-      results[contentId] = accessRights.includes('WriteAccess');
-    }
-  }
-
-  return results;
-}
-
-/**
- * Makes a POST request to the $batch endpoint with multipart content.
- */
-async function postBatchAsync<TResult>(
-  batchUri: Uri,
-  boundary: string,
-  body: string,
-  cancellationToken: AbortSignal | null,
-  accountId?: string,
-  accountHint?: string
-): Promise<{ result: TResult }> {
-  const { accessToken } = await getAccessTokenForUri(batchUri, accountId, accountHint);
-
-  const response = await fetch(batchUri.toString(true), {
-    method: 'POST',
-    headers: {
-      'Authorization': `Bearer ${accessToken}`,
-      'Content-Type': `multipart/mixed; boundary=${boundary}`,
-      'Accept': 'application/json',
-      'OData-MaxVersion': '4.0',
-      'OData-Version': '4.0',
-      // Continue processing remaining requests even if one fails (e.g., 403, 404)
-      // This ensures partial failures don't cause all subsequent bots to be marked as no-access
-      'Prefer': 'odata.continue-on-error',
-    },
-    body: body,
-    signal: cancellationToken
-  });
-
-  if (!response.ok) {
-    throw new Error(`Batch request failed with status ${response.status}`);
-  }
-
-  // Return raw text for multipart parsing
-  const result = await response.text() as TResult;
-  return { result };
-}
-
-/**
- * Gets an access token for a URI without making a request.
- * Used by postBatchAsync which needs to make its own request.
- */
-async function getAccessTokenForUri(uri: Uri, accountId?: string, accountHint?: string): Promise<{ accessToken: string }> {
-  const { getAccessTokenByAccountId } = await import('./account.js');
-  const tokenInfo = await getAccessTokenByAccountId(uri, accountId, accountHint);
-  return { accessToken: tokenInfo.accessToken };
+  return projectSharedAgents(response.result.value);
 }
 
 async function getAsync<TResult>(
@@ -448,6 +248,18 @@ function getSharedAgentInfo(agentDetails: AgentDetails): AgentInfo {
   let details = getAgentInfo(agentDetails);
   details.displayComplement = " (shared)";
   return details;
+}
+
+/**
+ * Projects the non-owned bots returned by Dataverse into the shared-agent list.
+ *
+ * This is intentionally a 1:1 mapping with no filtering: every bot the (already
+ * security-trimmed) Dataverse query returns is surfaced to the user. It must not drop
+ * agents based on any secondary access check — doing so is what hid other users' agents
+ * from environment admins.
+ */
+export function projectSharedAgents(bots: AgentDetails[]): AgentInfo[] {
+  return bots.map(getSharedAgentInfo);
 }
 
 interface ListResponse<T> {

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/tests/host/dataverseClient.test.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/tests/host/dataverseClient.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'node:assert';
 import { describe, test } from 'node:test';
 
 // Import the module to test
-import { clearWhoAmICache, parseBatchAccessResults } from '../../clients/dataverseClient';
+import { clearWhoAmICache, projectSharedAgents } from '../../clients/dataverseClient';
 
 describe('clearWhoAmICache', () => {
 	/**
@@ -21,159 +21,38 @@ describe('clearWhoAmICache', () => {
 	});
 });
 
-describe('parseBatchAccessResults', () => {
-	/**
-	 * Helper to create a multipart batch response part
-	 */
-	function createBatchPart(contentId: number, httpStatus: number, accessRights: string | null): string {
-		const statusText = httpStatus === 200 ? 'OK' : httpStatus === 403 ? 'Forbidden' : 'Not Found';
-		const body = accessRights !== null
-			? `{"@odata.context":"...","AccessRights":"${accessRights}"}`
-			: `{"error":{"code":"0x80040220","message":"Access denied"}}`;
-		
-		return [
-			`Content-Type: application/http`,
-			`Content-Transfer-Encoding: binary`,
-			``,
-			`HTTP/1.1 ${httpStatus} ${statusText}`,
-			`Content-ID: ${contentId}`,
-			`Content-Type: application/json; odata.metadata=minimal`,
-			``,
-			body
-		].join('\r\n');
-	}
+describe('projectSharedAgents', () => {
+	// This fixture is grounded in a real captured trace, not merely hand-constructed.
+	// Against a live Sandbox environment, an Environment Admin who had full read+write
+	// access to three agents owned by ANOTHER user saw none of them in the extension:
+	// the old write-access gate issued an invalid (unbound) RetrievePrincipalAccess call
+	// that returned HTTP 404 for every agent (and no per-part Content-ID), so all three
+	// were filtered out. The three entries below stand in for those captured non-owned
+	// agents; the ids are anonymized placeholders (no real records or secrets are stored).
+	const nonOwnedBots = [
+		{ botid: '00000000-0000-0000-0000-000000000001', name: 'Shared Agent A', iconbase64: '', bot_botcomponentcollection: [] },
+		{ botid: '00000000-0000-0000-0000-000000000002', name: 'Shared Agent B', iconbase64: '', bot_botcomponentcollection: [] },
+		{ botid: '00000000-0000-0000-0000-000000000003', name: 'Shared Agent C', iconbase64: '', bot_botcomponentcollection: [] },
+	];
 
-	/**
-	 * Helper to wrap parts in a batch response with boundary markers
-	 */
-	function createBatchResponse(parts: string[]): string {
-		const boundary = 'batchresponse_abc123';
-		return parts.map(part => `--${boundary}\r\n${part}`).join('\r\n') + `\r\n--${boundary}--`;
-	}
+	test('returns every non-owned agent (no access-based filtering)', () => {
+		// Regression guard: a broken RetrievePrincipalAccess "write access" gate used to drop
+		// every non-owned agent, so environment admins saw only the agents they personally
+		// owned. Shared listing must surface ALL non-owned agents the query returns.
+		const result = projectSharedAgents(nonOwnedBots);
 
-	test('parses normal multipart response with multiple AccessRights', () => {
-		const response = createBatchResponse([
-			createBatchPart(0, 200, 'ReadAccess, WriteAccess, AppendAccess'),
-			createBatchPart(1, 200, 'ReadAccess'),
-			createBatchPart(2, 200, 'ReadAccess, WriteAccess'),
-		]);
-
-		const results = parseBatchAccessResults(response, 3);
-
-		assert.deepStrictEqual(results, [true, false, true]);
+		assert.strictEqual(result.length, nonOwnedBots.length);
+		assert.deepStrictEqual(result.map(a => a.agentId), nonOwnedBots.map(b => b.botid));
+		assert.deepStrictEqual(result.map(a => a.displayName), nonOwnedBots.map(b => b.name));
 	});
 
-	test('handles response with one 403 error and others succeeding', () => {
-		const response = createBatchResponse([
-			createBatchPart(0, 200, 'ReadAccess, WriteAccess'),
-			createBatchPart(1, 403, null),
-			createBatchPart(2, 200, 'ReadAccess, WriteAccess'),
-		]);
+	test('marks projected agents as shared', () => {
+		const result = projectSharedAgents(nonOwnedBots);
 
-		const results = parseBatchAccessResults(response, 3);
-
-		// Bot 1 should be false due to 403, others should be true
-		assert.deepStrictEqual(results, [true, false, true]);
+		assert.ok(result.every(a => a.displayComplement === ' (shared)'));
 	});
 
-	test('handles response with out-of-order Content-IDs', () => {
-		// Response arrives in different order than request
-		const response = createBatchResponse([
-			createBatchPart(2, 200, 'ReadAccess, WriteAccess'),
-			createBatchPart(0, 200, 'ReadAccess'),
-			createBatchPart(1, 200, 'ReadAccess, WriteAccess'),
-		]);
-
-		const results = parseBatchAccessResults(response, 3);
-
-		// Should correctly correlate by Content-ID, not by position
-		assert.deepStrictEqual(results, [false, true, true]);
-	});
-
-	test('handles empty response', () => {
-		const results = parseBatchAccessResults('', 3);
-
-		// All should default to false
-		assert.deepStrictEqual(results, [false, false, false]);
-	});
-
-	test('handles malformed response with no Content-ID', () => {
-		const malformedResponse = [
-			`--batchresponse_abc123`,
-			`Content-Type: application/http`,
-			``,
-			`HTTP/1.1 200 OK`,
-			``, // Missing Content-ID header
-			`{"AccessRights":"ReadAccess, WriteAccess"}`,
-			`--batchresponse_abc123--`
-		].join('\r\n');
-
-		const results = parseBatchAccessResults(malformedResponse, 2);
-
-		// Should default to false since Content-ID is missing
-		assert.deepStrictEqual(results, [false, false]);
-	});
-
-	test('handles response with 404 errors', () => {
-		const response = createBatchResponse([
-			createBatchPart(0, 200, 'ReadAccess, WriteAccess'),
-			createBatchPart(1, 404, null),
-		]);
-
-		const results = parseBatchAccessResults(response, 2);
-
-		assert.deepStrictEqual(results, [true, false]);
-	});
-
-	test('handles Content-ID with angle brackets', () => {
-		// Some servers return Content-ID: <0> instead of Content-ID: 0
-		const response = [
-			`--batchresponse_abc123`,
-			`Content-Type: application/http`,
-			`Content-Transfer-Encoding: binary`,
-			``,
-			`HTTP/1.1 200 OK`,
-			`Content-ID: <0>`,
-			`Content-Type: application/json`,
-			``,
-			`{"AccessRights":"ReadAccess, WriteAccess"}`,
-			`--batchresponse_abc123--`
-		].join('\r\n');
-
-		const results = parseBatchAccessResults(response, 1);
-
-		assert.deepStrictEqual(results, [true]);
-	});
-
-	test('returns all false for expectedCount of 0', () => {
-		const results = parseBatchAccessResults('any content', 0);
-
-		assert.deepStrictEqual(results, []);
-	});
-
-	test('ignores Content-IDs outside expected range', () => {
-		const response = createBatchResponse([
-			createBatchPart(0, 200, 'ReadAccess, WriteAccess'),
-			createBatchPart(5, 200, 'ReadAccess, WriteAccess'), // Out of range for expectedCount=2
-		]);
-
-		const results = parseBatchAccessResults(response, 2);
-
-		// Only Content-ID 0 should be processed; index 1 remains false
-		assert.deepStrictEqual(results, [true, false]);
-	});
-
-	test('handles mixed success and various error codes', () => {
-		const response = createBatchResponse([
-			createBatchPart(0, 200, 'ReadAccess'),
-			createBatchPart(1, 200, 'WriteAccess'),
-			createBatchPart(2, 403, null),
-			createBatchPart(3, 404, null),
-			createBatchPart(4, 200, 'ReadAccess, WriteAccess, DeleteAccess'),
-		]);
-
-		const results = parseBatchAccessResults(response, 5);
-
-		assert.deepStrictEqual(results, [false, true, false, false, true]);
+	test('returns an empty list when there are no non-owned agents', () => {
+		assert.deepStrictEqual(projectSharedAgents([]), []);
 	});
 });


### PR DESCRIPTION
listSharedAgentsAsync gated the shared-agent list behind a batched RetrievePrincipalAccess "write access" check that called an invalid unbound function form (HTTP 404 for every agent) and parsed results by a Content-ID Dataverse never echoes. As a result, every agent owned by another user was hidden, even from environment admins. Remove the gate and return all non-owned agents via projectSharedAgents (Dataverse already security-trims reads; clone needs only read access). Replace the obsolete parser tests with projectSharedAgents regression tests.