### PR TITLE
Fix push/reattach blocked for classic agents on non-default templates

### DIFF
--- a/src/CopilotStudio.McsCore/AgentClassifier.cs
+++ b/src/CopilotStudio.McsCore/AgentClassifier.cs
@@ -12,24 +12,20 @@ namespace Microsoft.CopilotStudio.McsCore
     /// Classification lives in one place so surfaces do not each re-implement detection.
     /// </summary>
     /// <remarks>
-    /// Authoring-shape evidence precedence (TDD D1-D4, D9, D15):
-    /// <list type="number">
-    /// <item>Declared authoring-model signal - deferred until consumable from a released
-    /// dependency (PRD R2, R3); the bridge evidence below is used meanwhile.</item>
-    /// <item>Native CLI configuration-shape evidence: a typed <c>AgentSettings</c> block
-    /// (preferred over template; D15). A legacy <c>CLIAgentRecognizer</c> without
-    /// <c>AgentSettings</c> is not CliCopilot (D9). This deliberately avoids
-    /// <c>BotEntity.IsCliAgent()</c>, which also returns true for that legacy recognizer.</item>
-    /// <item>Template-prefix evidence.</item>
-    /// </list>
-    /// An unrecognized but well-formed agent resolves to <see cref="AuthoringShape.Unknown"/>
-    /// with <see cref="SupportLevel.Provisional"/> (clone/pull best-effort to allow
-    /// bootstrapping; push/reattach fail closed) and preserves its raw value (PRD R3, R8).
+    /// Interim inference, pending a first-class authoring-shape signal on the entity: the shape
+    /// is inferred here from the entity's own configuration. A well-formed <see cref="BotEntity"/>
+    /// is <see cref="AuthoringShape.CliCopilot"/> when it carries a typed <c>AgentSettings</c>
+    /// block or a <c>cliagent-</c> template prefix; any other well-formed entity is
+    /// <see cref="AuthoringShape.Classic"/>. The <c>template</c> field is a gallery template name
+    /// (e.g. <c>default-</c>, <c>websiteqna-</c>, <c>empty-</c>), not an authoring shape, so it is
+    /// never used to fail an agent closed (issue #292). <see cref="AuthoringShape.Unknown"/> is
+    /// reserved for the cases with no usable shape evidence: no <see cref="BotEntity"/>
+    /// (<see cref="AgentClassification.None"/>) or an unreadable local workspace on the layout-only
+    /// path.
     /// </remarks>
     public static class AgentClassifier
     {
         private const string CliTemplatePrefix = "cliagent-";
-        private const string ClassicTemplatePrefix = "default-";
         private const string ClassicSettingsFileName = "settings.mcs.yml";
 
         /// <summary>
@@ -125,10 +121,10 @@ namespace Microsoft.CopilotStudio.McsCore
                 return AgentClassification.None;
             }
 
-            // Native CLI configuration-shape evidence: a typed AgentSettings block is the
-            // K2 discriminator (CliAgentExplore D8) and the authoring-shape signal D15
-            // prefers. This is NOT bot.IsCliAgent(), which also returns true for a legacy
-            // CLIAgentRecognizer and would violate D9.
+            // Interim shape inference from the entity's own configuration (no first-class
+            // authoring-shape signal yet). Native CLI evidence: a typed AgentSettings block marks
+            // the CliCopilot shape. This deliberately avoids bot.IsCliAgent(), which also returns
+            // true for a legacy CLIAgentRecognizer.
             if (bot.Configuration?.AgentSettings != null)
             {
                 return AgentClassification.Recognized(
@@ -136,29 +132,22 @@ namespace Microsoft.CopilotStudio.McsCore
             }
 
             var template = bot.Template;
-            if (!string.IsNullOrEmpty(template))
+            if (!string.IsNullOrEmpty(template) &&
+                template!.StartsWith(CliTemplatePrefix, StringComparison.OrdinalIgnoreCase))
             {
-                if (template!.StartsWith(CliTemplatePrefix, StringComparison.OrdinalIgnoreCase))
-                {
-                    return AgentClassification.Recognized(
-                        AuthoringShape.CliCopilot, WorkspaceLayout.Unknown, "template-prefix:" + template);
-                }
-
-                if (template.StartsWith(ClassicTemplatePrefix, StringComparison.OrdinalIgnoreCase))
-                {
-                    return AgentClassification.Recognized(
-                        AuthoringShape.Classic, WorkspaceLayout.Unknown, "template-prefix:" + template);
-                }
-
-                // Well-formed agent, unrecognized template -> provisional, preserve raw value.
-                return AgentClassification.Provisional(
-                    rawShapeValue: template, WorkspaceLayout.Unknown, "unrecognized-template:" + template);
+                // CLI agent whose AgentSettings block is not (yet) materialized: the cliagent-
+                // template is an explicit CLI marker, so it still resolves to CliCopilot.
+                return AgentClassification.Recognized(
+                    AuthoringShape.CliCopilot, WorkspaceLayout.Unknown, "template-prefix:" + template);
             }
 
-            // A bot entity with no recognizable shape evidence is still a well-formed
-            // agent envelope; treat it as provisional rather than fully unsupported.
-            return AgentClassification.Provisional(
-                rawShapeValue: null, WorkspaceLayout.Unknown, "no-shape-evidence");
+            // No native CLI evidence. A well-formed BotEntity is a classic (Dataverse-authored)
+            // agent. The template is a gallery template name (default-, websiteqna-, empty-, ...),
+            // not an authoring shape, so a non-CLI template is never used to fail the agent closed
+            // (issue #292): classic is the correct shape and keeps push/reattach available.
+            return AgentClassification.Recognized(
+                AuthoringShape.Classic, WorkspaceLayout.Unknown,
+                string.IsNullOrEmpty(template) ? "classic-no-template" : "classic-template:" + template);
         }
 
         /// <summary>
@@ -302,13 +291,10 @@ namespace Microsoft.CopilotStudio.McsCore
                 return cloud.WithLayout(layout);
             }
 
-            // No recognized cloud shape. Fall back to the layout-inferred shape ONLY when the
-            // cloud carried no explicit shape evidence (RawShapeValue == null): a plain classic
-            // agent with no template / AgentSettings ("no-shape-evidence") is legitimately
-            // Supported via its ClassicMcs layout. An EXPLICITLY unrecognized shape
-            // (RawShapeValue != null, e.g. an unknown template) must NOT be promoted to
-            // Supported just because the folder content falls back to ClassicMcs - push and
-            // reattach must fail closed for it (D35). Preserve its Provisional verdict.
+            // The only Unknown cloud verdict is "no cloud entity" (None, no raw shape value): the
+            // create/reattach path for an agent that does not yet exist in the cloud. Infer the
+            // shape from the local workspace layout so a classic/CLI folder is Supported; an
+            // unreadable workspace (Unknown layout) stays Unknown/Unsupported.
             if (cloud.RawShapeValue == null)
             {
                 var inferred = InferAuthoringShape(layout);
@@ -318,8 +304,8 @@ namespace Microsoft.CopilotStudio.McsCore
                 }
             }
 
-            // Preserve any raw cloud evidence; remain provisional/unsupported per the cloud
-            // verdict (fail closed for an explicitly unrecognized shape).
+            // No cloud entity and no readable local workspace: remain Unknown/Unsupported per the
+            // cloud verdict.
             return cloud.WithLayout(layout);
         }
     }

--- a/src/CopilotStudio.Sync.UnitTests/AgentClassifierTests.cs
+++ b/src/CopilotStudio.Sync.UnitTests/AgentClassifierTests.cs
@@ -8,9 +8,8 @@ using Xunit;
 namespace Microsoft.CopilotStudio.Sync.UnitTests;
 
 /// <summary>
-/// Classification-contract validation for the structured <see cref="AgentClassification"/>
-/// (PRD R1, R2, R3, R8; TDD D1, D4, D9, D15, D19). Exercises only released
-/// dependencies, proving the bridge classifier needs no unreleased declared signal.
+/// Classification-contract validation for the structured <see cref="AgentClassification"/>.
+/// Exercises only released dependencies.
 /// </summary>
 public class AgentClassifierTests
 {
@@ -100,15 +99,22 @@ language: 1033
         Assert.Equal(AuthoringShape.Classic, AgentClassifier.DetectAuthoringShape(Definition(yaml)));
     }
 
-    // R3/R8/D19: an unrecognized but well-formed shape is Provisional and preserves its raw value.
-    [Fact]
-    public void UnrecognizedTemplate_IsUnknown_Provisional_PreservesRawValue()
+    // Issue #292: a well-formed classic agent created from any gallery template (websiteqna-,
+    // sdkagent-, empty-, default-, ...) has no native CLI evidence, so it is Classic and
+    // Supported. The template name is a template, not an authoring shape, and must not fail the
+    // agent closed.
+    [Theory]
+    [InlineData("websiteqna-1.0.0")]
+    [InlineData("sdkagent-1.0.0")]
+    [InlineData("empty-1.0.0")]
+    [InlineData("default-2.1.0")]
+    public void NonCliTemplate_IsClassic_Supported(string template)
     {
-        var yaml = "kind: Bot\ndisplayName: x\nschemaName: x\ntemplate: sdkagent-1.0.0\n";
+        var yaml = $"kind: Bot\ndisplayName: x\nschemaName: x\ntemplate: {template}\n";
         var c = AgentClassifier.ClassifyCloud(Definition(yaml));
-        Assert.Equal(AuthoringShape.Unknown, c.AuthoringShape);
-        Assert.Equal(SupportLevel.Provisional, c.Support);
-        Assert.Equal("sdkagent-1.0.0", c.RawShapeValue);
+        Assert.Equal(AuthoringShape.Classic, c.AuthoringShape);
+        Assert.Equal(SupportLevel.Supported, c.Support);
+        Assert.Null(c.RawShapeValue);
     }
 
     // ---- Per-operation gate (the flexible fail-closed, D19) ----
@@ -133,8 +139,12 @@ language: 1033
     [InlineData(SyncOperation.Reattach, false)]
     public void Provisional_AllowsCloneAndPull_BlocksDestructive(SyncOperation op, bool expected)
     {
-        var yaml = "kind: Bot\ndisplayName: x\nschemaName: x\ntemplate: sdkagent-1.0.0\n";
-        var c = AgentClassifier.ClassifyCloud(Definition(yaml));
+        // ClassifyCloud no longer produces a Provisional verdict (every well-formed entity
+        // resolves to Classic/CliCopilot), but the graded gate still governs the SupportLevel,
+        // so construct the verdict directly to lock the matrix.
+        var c = new AgentClassification(
+            AuthoringShape.Unknown, WorkspaceLayout.Unknown, SupportLevel.Provisional,
+            "raw-shape", "test-provisional");
         Assert.Equal(SupportLevel.Provisional, c.Support);
         Assert.Equal(expected, c.Allows(op));
     }
@@ -207,33 +217,30 @@ language: 1033
         });
     }
 
-    // ---- D35 fail-closed: layout must NOT promote an explicitly unrecognized shape ----
-
-    private const string UnrecognizedTemplateYaml =
-        "kind: Bot\ndisplayName: x\nschemaName: x\ntemplate: sdkagent-1.0.0\n";
+    // ---- Issue #292: a non-default classic template must resolve to Classic, not Unknown ----
 
     private const string NoShapeEvidenceClassicYaml =
         "kind: Bot\ndisplayName: x\nschemaName: x\n";
 
-    // An EXPLICITLY unrecognized shape (unknown template) stays Provisional even when the
-    // local folder content falls back to a classic layout, so push/reattach fail closed (D35).
-    // This is the integrated path the gate-matrix tests bypass.
+    // A classic agent created from a non-default gallery template (here the Website Q&A template,
+    // template: websiteqna-1.0.0) with a matching classic folder resolves to Classic/Supported, so
+    // push and reattach are allowed. The narrow default- allowlist previously mis-resolved this to
+    // Unknown/Provisional and blocked the push (issue #292).
     [Fact]
-    public void Classify_UnrecognizedTemplate_WithClassicLookingFolder_StaysProvisional_BlocksDestructive()
+    public void Classify_NonDefaultClassicTemplate_WithClassicFolder_IsClassicSupported()
     {
-        WithFolder(("settings.mcs.yml", UnrecognizedTemplateYaml), dir =>
+        var yaml = "kind: Bot\ndisplayName: x\nschemaName: x\ntemplate: websiteqna-1.0.0\n";
+        WithFolder(("settings.mcs.yml", yaml), dir =>
         {
-            var bot = CodeSerializer.Deserialize<BotEntity>(UnrecognizedTemplateYaml);
+            var bot = CodeSerializer.Deserialize<BotEntity>(yaml);
             var c = AgentClassifier.Classify(bot, dir);
 
             Assert.Equal(WorkspaceLayout.ClassicMcs, c.WorkspaceLayout);
-            Assert.Equal(AuthoringShape.Unknown, c.AuthoringShape);
-            Assert.Equal(SupportLevel.Provisional, c.Support);
-            Assert.Equal("sdkagent-1.0.0", c.RawShapeValue);
-            Assert.True(c.Allows(SyncOperation.Clone));
-            Assert.True(c.Allows(SyncOperation.Pull));
-            Assert.False(c.Allows(SyncOperation.Push));
-            Assert.False(c.Allows(SyncOperation.Reattach));
+            Assert.Equal(AuthoringShape.Classic, c.AuthoringShape);
+            Assert.Equal(SupportLevel.Supported, c.Support);
+            Assert.Null(c.RawShapeValue);
+            Assert.True(c.Allows(SyncOperation.Push));
+            Assert.True(c.Allows(SyncOperation.Reattach));
         });
     }
 

--- a/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.PullAgent/Methods/PreparePushHandlerTests.cs
+++ b/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.PullAgent/Methods/PreparePushHandlerTests.cs
@@ -64,17 +64,20 @@ namespace Microsoft.PowerPlatformLS.UnitTests.Impl.PullAgent.Methods
         }
 
         [Fact]
-        public async Task PreparePushUnrecognizedTemplateBlockedWith400NoProvisioningTest()
+        public async Task PreparePush_NonCliTemplate_ProceedsAsClassic()
         {
+            // Issue #292: a classic agent created from a non-default gallery template (the
+            // fixture's template: sdkagent-1.0.0) has no native CLI evidence, so it is
+            // Classic/Supported. The push gate allows it and prepare proceeds to provisioning -
+            // the template is a template, not an authoring shape, and must not fail closed.
             var (requestContext, request) = CreateSetup("Workspace/UnrecognizedTemplateWorkspace");
             var synchronizer = new PreparePushProvisionTrackingSynchronizer();
             var handler = CreateHandler(new MockDataverseClient(), synchronizer);
 
             var response = await handler.HandleRequestAsync(request, requestContext, CancellationToken.None);
 
-            Assert.Equal(400, response.Code);
-            Assert.Contains(SyncOperation.Push.ToString(), response.Message);
-            Assert.False(synchronizer.ProvisionAttempted);
+            Assert.Equal(200, response.Code);
+            Assert.True(synchronizer.ProvisionAttempted);
         }
 
         [Fact]

--- a/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.PullAgent/Methods/PrepareReattachHandlerTests.cs
+++ b/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.PullAgent/Methods/PrepareReattachHandlerTests.cs
@@ -179,21 +179,19 @@ namespace Microsoft.PowerPlatformLS.UnitTests.Impl.PullAgent.Methods
         }
 
         [Fact]
-        public async Task PrepareReattach_UnrecognizedTemplate_BlockedWith400_NoMutationTest()
+        public async Task PrepareReattach_NonCliTemplate_ProceedsAsClassic()
         {
+            // Issue #292: a classic agent created from a non-default gallery template (the
+            // fixture's template: sdkagent-1.0.0) has no native CLI evidence, so it is
+            // Classic/Supported. Prepare-reattach proceeds and creates the new agent instead of
+            // failing closed - the template is a template, not an authoring shape.
             var context = CreatePrepareTestSetup("Workspace/UnrecognizedTemplateWorkspace");
-            var dataverse = new Mock<ISyncDataverseClient>();
-            dataverse.Setup(c => c.GetAgentIdBySchemaNameAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(Guid.Empty);
-            var handler = TestHandlerFactory.CreatePrepareHandler(dataverse.Object, new TestWorkspaceSynchronizer());
+            var handler = TestHandlerFactory.CreatePrepareHandler(new MockDataverseClient(), new TestWorkspaceSynchronizer());
 
             var response = await handler.HandleRequestAsync(context.Request, context.RequestContext, CancellationToken.None);
 
-            Assert.Equal(400, response.Code);
-            Assert.False(response.IsNewAgent);
-            Assert.Equal(Guid.Empty, response.AgentSyncInfo?.AgentId);
-            Assert.Contains(SyncOperation.Reattach.ToString(), response.Message);
-            dataverse.Verify(c => c.GetAgentIdBySchemaNameAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
-            dataverse.Verify(c => c.CreateNewAgentAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<AuthoringShape>(), It.IsAny<CancellationToken>()), Times.Never);
+            Assert.Equal(200, response.Code);
+            Assert.True(response.IsNewAgent);
         }
 
         [Fact]

--- a/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.PullAgent/Methods/SyncPushHandlerTests.cs
+++ b/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.PullAgent/Methods/SyncPushHandlerTests.cs
@@ -32,21 +32,20 @@ namespace Microsoft.PowerPlatformLS.UnitTests.Impl.PullAgent.Methods
         private const string TopicsPath = "topics/Goodbye.mcs.yml";
 
         [Fact]
-        public async Task SyncPush_UnrecognizedTemplate_BlockedWith400_NoPushTest()
+        public async Task SyncPush_NonCliTemplate_ProceedsAsClassic()
         {
-            // D35 (primary): an EXPLICITLY unrecognized authoring shape (unknown template) whose
-            // folder merely falls back to a classic layout must NOT be promoted to Supported.
-            // Push fails closed (400) before any synchronizer work runs.
+            // Issue #292: a classic agent created from a non-default gallery template (the
+            // fixture's template: sdkagent-1.0.0) has no native CLI evidence, so it is
+            // Classic/Supported. The push gate allows it and the synchronizer push runs - the
+            // template is a template, not an authoring shape, and must not fail the agent closed.
             var (requestContext, request) = CreateSetup("Workspace/UnrecognizedTemplateWorkspace");
             var synchronizer = new PushTrackingSynchronizer();
             var handler = CreateHandler(new MockDataverseClient(), synchronizer);
 
             var response = await handler.HandleRequestAsync(request, requestContext, CancellationToken.None);
 
-            Assert.Equal(400, response.Code);
-            Assert.Contains(SyncOperation.Push.ToString(), response.Message);
-            // No mutation: the gate throws before the first synchronizer push call.
-            Assert.False(synchronizer.PushAttempted);
+            Assert.Equal(200, response.Code);
+            Assert.True(synchronizer.PushAttempted);
         }
 
         private (RequestContext, SyncAgentRequest) CreateSetup(string workspaceRelativePath)


### PR DESCRIPTION
AgentClassifier recognized the Classic authoring shape only when the cloud entity template started with default-, so a classic agent created from a gallery template (e.g. Website Q&A, websiteqna-1.0.0) fell through to Unknown/Provisional and failed closed on push and reattach.

Treat any well-formed BotEntity without native CLI evidence (a typed AgentSettings block or a cliagent- template) as Classic. The template is a gallery template name, not an authoring shape, so it is no longer used to fail an agent closed. Unknown now means only no BotEntity or an unreadable local workspace; the graded gate Provisional handling is retained.

Fixes #292