### PR TITLE
Exclude agent.sync.yaml out of Yaml diagnostic

### DIFF
--- a/src/CopilotStudio.McsCore/PathTypes.cs
+++ b/src/CopilotStudio.McsCore/PathTypes.cs
@@ -437,6 +437,8 @@ internal static class WorkspacePath
         return false;
     }
 
+    public static bool IsWorkspaceLayoutMarkerFile(FilePath path) => string.Equals(path.FileName, AgentClassifier.WorkspaceLayoutMarkerFileName, StringComparison.OrdinalIgnoreCase);
+
     public static FilePath RemoveExtension(FilePath path)
     {
         var extension = GetExtension(path);

--- a/src/LanguageServers/PowerPlatformLS/Impl.Language.Yaml/Framework/DiagnosticsProvider.cs
+++ b/src/LanguageServers/PowerPlatformLS/Impl.Language.Yaml/Framework/DiagnosticsProvider.cs
@@ -19,6 +19,11 @@
 
         public IEnumerable<Diagnostic> ComputeDiagnostics(RequestContext requestContext, YamlLspDocument document)
         {
+            if (document.IsWorkspaceLayoutMarker)
+            {
+                return [];
+            }
+
             var semanticModel = document.FileModel;
 
             if (semanticModel == null)

--- a/src/LanguageServers/PowerPlatformLS/Impl.Language.Yaml/YamlLspDocument.cs
+++ b/src/LanguageServers/PowerPlatformLS/Impl.Language.Yaml/YamlLspDocument.cs
@@ -13,12 +13,21 @@
             : base(path, text, Constants.LanguageIds.Yaml, workspacePath)
         {
             IndentationInfo = IndentationInfo.FromText(text);
+            IsWorkspaceLayoutMarker = WorkspacePath.IsWorkspaceLayoutMarkerFile(path);
         }
 
         public IndentationInfo IndentationInfo { get; }
 
+        public bool IsWorkspaceLayoutMarker { get; }
+
         protected override YamlSemanticModel? ComputeModel()
         {
+            if (IsWorkspaceLayoutMarker)
+            {
+                ParsingInfo.Diagnostic = null;
+                return null;
+            }
+
             YamlSemanticModel result;
             try
             {

--- a/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.Language.CopilotStudio/McsWorkspaceCompilerCliTests.cs
+++ b/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.Language.CopilotStudio/McsWorkspaceCompilerCliTests.cs
@@ -128,6 +128,17 @@ namespace Microsoft.PowerPlatformLS.UnitTests.Impl.Language.CopilotStudio
             AssertLanguage("settings.mcs.yml", LanguageType.CopilotStudio);
         }
 
+        [Theory]
+        [InlineData("agent.sync.yaml", true)]
+        [InlineData("c:/agent/agent.sync.yaml", true)]
+        [InlineData("infrastructure/connections/shared_x.sync.yaml", false)]
+        [InlineData("topics/Greeting.mcs.yml", false)]
+        [InlineData("settings.yaml", false)]
+        public void WorkspaceLayoutMarker_IsDetected_OnlyForAgentSyncYaml(string relativePath, bool expected)
+        {
+            Assert.Equal(expected, WorkspacePath.IsWorkspaceLayoutMarkerFile(new FilePath(relativePath)));
+        }
+
         [Fact]
         public void ClassicWorkspace_ShapeDetection_AndCompile_Unchanged()
         {

--- a/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.Language.Yml/YamlLanguageTests.cs
+++ b/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.Language.Yml/YamlLanguageTests.cs
@@ -46,11 +46,28 @@
             Assert.StartsWith("Failed to compute semantic model. Unhandled exception: System.InvalidOperationException: Sequence contains no elements", error.Message);
         }
 
-        private async Task<Diagnostic[]> GetDiagnosticsForYamlTextAsync(string text)
+        [Fact]
+        public async Task NoDiagnostic_OnLayoutMarker_WithEmptyText_Async()
+        {
+            var diagnostics = await GetDiagnosticsForYamlTextAsync(string.Empty, new Uri("file:///c:/agent/agent.sync.yaml"));
+
+            Assert.Empty(diagnostics);
+        }
+
+        [Fact]
+        public async Task NoDiagnostic_OnLayoutMarker_WithSemanticErrorText_Async()
+        {
+            const string YamlText = "  name: test\ntype: test";
+            var diagnostics = await GetDiagnosticsForYamlTextAsync(YamlText, new Uri("file:///c:/agent/agent.sync.yaml"));
+
+            Assert.Empty(diagnostics);
+        }
+
+        private async Task<Diagnostic[]> GetDiagnosticsForYamlTextAsync(string text, Uri? documentUri = null)
         {
             await using var context = new TestHost([new YamlLspModule()]);
             await context.InitializeLanguageServerAsync();
-            var response = await context.OpenDocumentWithTextAsync(new Uri("file:///c:/new_file.yml"), text);
+            var response = await context.OpenDocumentWithTextAsync(documentUri ?? new Uri("file:///c:/new_file.yml"), text);
             return response.Diagnostics;
         }
     }


### PR DESCRIPTION
Exclude agent.sync.yaml out of Yaml diagnostic.
Currently vscode report error on agent.sync.yaml and this file should be excluded out of diagnostic: "Failed to compute semantic model. Unhandled exception: System.ArgumentException: The current event is of an unsupported type. (Parameter 'parser')\r\n   at YamlDotNet.RepresentationModel.YamlNode.ParseNode(IParser parser, DocumentLoadingState state)\r\n   at YamlDotNet.RepresentationModel.YamlDocument..ctor(IParser parser)\r\n   at YamlDotNet.RepresentationModel.YamlStream.Load(IParser parser)\r\n   at Microsoft.PowerPlatformLS.Impl.Language.Yaml.Model.YamlSemanticModel..ctor(String text)"