### PR TITLE
Fix to allow reattach agent with no .mcs

### DIFF
--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/clients/bapClient.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/clients/bapClient.ts
@@ -148,55 +148,35 @@ export async function listEnvironmentsAsync(
     accountId: string | null,
     accountHint?: string
 ): Promise<EnvironmentInfo[]> {
-    const response = await getAsync<EnvironmentResponse>(
-        clusterCategory,
-        'environments',
-        "$filter=properties/environmentSku ne 'Platform'&$expand=properties.permissions",
-        cancellationToken,
-        accountId,
-        false,
-        accountHint
+    const perSkuResults = await Promise.all(
+        SKU_LOAD_ORDER.map(sku =>
+            listEnvironmentsBySkuAsync(clusterCategory, sku, cancellationToken, accountId, accountHint)
+                .catch(error => {
+                    logger.logError(
+                        TelemetryEventsKeys.LoadEnvironmentError,
+                        `[ListEnvironments] Failed to load ${sku} environments: <pii>${(error as Error)?.message || error}</pii>`
+                    );
+                    return [] as EnvironmentInfo[];
+                })
+        )
     );
 
-    const candidateEnvs = response.result.value.filter(env => hasEditPermission(env));
+    return mergeEnvironmentsBySku(perSkuResults);
+}
 
-    // Sort environments: Developer first, then Default, Sandbox, Production, Teams
-    // Within each SKU: hasAdmin first, then alphabetical
-    const skuPriority: Record<string, number> = {
-        'Developer': 0,
-        'Default': 1,
-        'Sandbox': 2,
-        'Production': 3,
-        'Teams': 4
-    };
-
-    const sortedEnvs = candidateEnvs.sort((a, b) => {
-        const skuA = a.properties?.environmentSku || 'Unknown';
-        const skuB = b.properties?.environmentSku || 'Unknown';
-        const priorityA = skuPriority[skuA] ?? 5;
-        const priorityB = skuPriority[skuB] ?? 5;
-
-        // First sort by SKU priority
-        if (priorityA !== priorityB) {
-            return priorityA - priorityB;
+export function mergeEnvironmentsBySku(perSkuResults: EnvironmentInfo[][]): EnvironmentInfo[] {
+    const seen = new Set<string>();
+    const merged: EnvironmentInfo[] = [];
+    for (const envs of perSkuResults) {
+        for (const env of envs) {
+            if (seen.has(env.environmentId)) {
+                continue;
+            }
+            seen.add(env.environmentId);
+            merged.push(env);
         }
-
-        // Within same SKU: hasAdmin first
-        const hasAdminA = !!a.properties?.permissions?.UpdateEnvironment;
-        const hasAdminB = !!b.properties?.permissions?.UpdateEnvironment;
-        if (hasAdminA !== hasAdminB) {
-            return hasAdminA ? -1 : 1;
-        }
-
-        // Finally alphabetical
-        const nameA = a.properties?.displayName || '';
-        const nameB = b.properties?.displayName || '';
-        return nameA.localeCompare(nameB);
-    });
-
-    return sortedEnvs
-        .map(toEnvironmentInfo)
-        .filter(envInfo => envInfo !== null) as EnvironmentInfo[];
+    }
+    return merged;
 }
 
 function hasEditPermission(env: EnvironmentDetails): boolean {

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/clients/bapClient.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/clients/bapClient.ts
@@ -152,10 +152,12 @@ export async function listEnvironmentsAsync(
         SKU_LOAD_ORDER.map(sku =>
             listEnvironmentsBySkuAsync(clusterCategory, sku, cancellationToken, accountId, accountHint)
                 .catch(error => {
-                    logger.logError(
-                        TelemetryEventsKeys.LoadEnvironmentError,
-                        `[ListEnvironments] Failed to load ${sku} environments: <pii>${(error as Error)?.message || error}</pii>`
-                    );
+                    if (!(error instanceof Error && error.name === 'AbortError')) {
+                        logger.logError(
+                            TelemetryEventsKeys.LoadEnvironmentError,
+                            `[ListEnvironments] Failed to load ${sku} environments: <pii>${(error as Error)?.message || error}</pii>`
+                        );
+                    }
                     return [] as EnvironmentInfo[];
                 })
         )

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/commands/reattachAgent.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/commands/reattachAgent.ts
@@ -9,6 +9,7 @@ import logger from '../services/logger';
 import { logAIPromptIssues, withSyncCommandBusy, getActiveSyncUri } from '../sync/workspaceSynchronizer';
 import { hasConnectionFileInWorkspace, WorkspaceType, CopilotStudioWorkspace } from '../sync/localWorkspaces';
 import { selectWorkspace } from '../sync/workspacePicker';
+import { getDiagnosticsErrors } from './syncWorkspace';
 import { autoBindAgentConnections, promptManageConnections } from '../connections/connectionManager';
 
 type ReattachEnvironmentPickItem = vscode.QuickPickItem & {
@@ -159,6 +160,17 @@ export const registerReattachAgentCommand = (context: vscode.ExtensionContext) =
         const retarget = 'Retarget';
         const choice = await vscode.window.showWarningMessage(`Retarget this agent (${agentDisplayName}) to '${targetEnvironmentName}'? Your local content will be uploaded to '${targetEnvironmentName}' and the agent will be connected there.`, { modal: true }, retarget);
         if (choice !== retarget) {
+          return;
+        }
+
+        const diagnostics = await getDiagnosticsErrors(currentWorkspace);
+        if (diagnostics.count > 0) {
+          const errorMessage = `Cannot retarget agent: found ${diagnostics.count} error(s) in ${diagnostics.files} file(s). Fix the errors and try again.`;
+          logger.logWarning(TelemetryEventsKeys.ReattachAgentError, undefined, { message: errorMessage });
+          const detailView = await vscode.window.showErrorMessage(errorMessage, 'View Details');
+          if (detailView === 'View Details') {
+            await vscode.commands.executeCommand('workbench.actions.view.problems');
+          }
           return;
         }
       }

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/commands/reattachAgent.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/commands/reattachAgent.ts
@@ -9,7 +9,6 @@ import logger from '../services/logger';
 import { logAIPromptIssues, withSyncCommandBusy, getActiveSyncUri } from '../sync/workspaceSynchronizer';
 import { hasConnectionFileInWorkspace, WorkspaceType, CopilotStudioWorkspace } from '../sync/localWorkspaces';
 import { selectWorkspace } from '../sync/workspacePicker';
-import { getDiagnosticsErrors } from './syncWorkspace';
 import { autoBindAgentConnections, promptManageConnections } from '../connections/connectionManager';
 
 type ReattachEnvironmentPickItem = vscode.QuickPickItem & {
@@ -160,17 +159,6 @@ export const registerReattachAgentCommand = (context: vscode.ExtensionContext) =
         const retarget = 'Retarget';
         const choice = await vscode.window.showWarningMessage(`Retarget this agent (${agentDisplayName}) to '${targetEnvironmentName}'? Your local content will be uploaded to '${targetEnvironmentName}' and the agent will be connected there.`, { modal: true }, retarget);
         if (choice !== retarget) {
-          return;
-        }
-
-        const diagnostics = await getDiagnosticsErrors(currentWorkspace);
-        if (diagnostics.count > 0) {
-          const errorMessage = `Cannot retarget agent: found ${diagnostics.count} error(s) in ${diagnostics.files} file(s). Fix the errors and try again.`;
-          logger.logWarning(TelemetryEventsKeys.ReattachAgentError, undefined, { message: errorMessage });
-          const detailView = await vscode.window.showErrorMessage(errorMessage, 'View Details');
-          if (detailView === 'View Details') {
-            await vscode.commands.executeCommand('workbench.actions.view.problems');
-          }
           return;
         }
       }

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/tests/host/bapClient.test.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/tests/host/bapClient.test.ts
@@ -1,0 +1,57 @@
+import * as assert from 'node:assert';
+import { describe, test } from 'node:test';
+
+import { mergeEnvironmentsBySku } from '../../clients/bapClient';
+import { EnvironmentInfo } from '../../types';
+
+function makeEnv(environmentId: string, sku: string, displayName = environmentId): EnvironmentInfo {
+	return {
+		environmentId,
+		displayName,
+		environmentSku: sku,
+		dataverseUrl: `https://${environmentId}.crm.dynamics.com/`,
+		agentManagementUrl: `https://${environmentId}.api.powerplatform.com/`,
+	};
+}
+
+describe('mergeEnvironmentsBySku', () => {
+	test('keeps every environment across all per-SKU batches (union, in order)', () => {
+		const dev = [makeEnv('dev-1', 'Developer'), makeEnv('dev-2', 'Developer')];
+		const sandbox = [makeEnv('sandbox-1', 'Sandbox')];
+		const production = [makeEnv('prod-1', 'Production')];
+
+		const merged = mergeEnvironmentsBySku([dev, [], sandbox, production]);
+
+		assert.deepStrictEqual(
+			merged.map(e => e.environmentId),
+			['dev-1', 'dev-2', 'sandbox-1', 'prod-1']
+		);
+	});
+
+	test('de-duplicates by environmentId with the first occurrence winning', () => {
+		const first = makeEnv('shared-1', 'Developer', 'From Developer batch');
+		const duplicate = makeEnv('shared-1', 'Sandbox', 'From Sandbox batch');
+
+		const merged = mergeEnvironmentsBySku([[first], [duplicate]]);
+
+		assert.strictEqual(merged.length, 1);
+		assert.strictEqual(merged[0], first, 'first occurrence should be retained');
+		assert.strictEqual(merged[0].displayName, 'From Developer batch');
+	});
+
+	test('returns an empty list when there are no environments', () => {
+		assert.deepStrictEqual(mergeEnvironmentsBySku([]), []);
+	});
+
+	test('ignores empty per-SKU batches', () => {
+		assert.deepStrictEqual(mergeEnvironmentsBySku([[], [], []]), []);
+	});
+
+	test('preserves within-batch ordering', () => {
+		const dev = [makeEnv('dev-b', 'Developer'), makeEnv('dev-a', 'Developer')];
+
+		const merged = mergeEnvironmentsBySku([dev]);
+
+		assert.deepStrictEqual(merged.map(e => e.environmentId), ['dev-b', 'dev-a']);
+	});
+});


### PR DESCRIPTION
Fix to allow reattach agent with no .mcs.
Fix to make sure list of environments in reattach is same with agent environment tree.