### PR TITLE
Enforce warnings as errors for all builds

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -28,7 +28,7 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(BUILD_ARTIFACTSTAGINGDIRECTORY)' != ''">
+  <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>

--- a/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/PowerPlatformLS.UnitTests.csproj
+++ b/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/PowerPlatformLS.UnitTests.csproj
@@ -38,5 +38,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Agents.ObjectModel.NodeGenerators"/>
     <PackageReference Include="Microsoft.Agents.ObjectModel.Dataverse" />
+    <PackageReference Include="Microsoft.Bot.Schema" />
   </ItemGroup>
 </Project>

--- a/src/Packages.props
+++ b/src/Packages.props
@@ -25,6 +25,7 @@
     <PackageReference Update="Azure.Identity" Version="1.19.0" />
     <PackageReference Update="Microsoft.Identity.Client" Version="4.71.1" />
     <PackageReference Update="Microsoft.Identity.Client.Extensions.Msal" Version="4.71.1" />
+    <PackageReference Update="Microsoft.Bot.Schema" Version="4.17.0" />
     <PackageReference Update="Microsoft.PowerFx.Interpreter" Version="$(PowerFxPackageVersion)" />
     <PackageReference Update="Microsoft.PowerFx.LanguageServerProtocol" Version="$(PowerFxPackageVersion)" />
     <PackageReference Update="Microsoft.VisualStudio.Threading" Version="17.13.2" />


### PR DESCRIPTION
## Summary
- Make `TreatWarningsAsErrors` apply to all builds instead of only Azure DevOps builds.
- Make `EnforceCodeStyleInBuild` apply consistently across local, GitHub Actions, and Azure DevOps builds.

## Why
`VSIX-Build.Push.yml` failed in Azure DevOps because XML documentation warnings (`CS1573`) were treated as errors there, while the GitHub PR build did not catch the same issue. The difference came from `Directory.Build.props`, where warnings-as-errors and code style enforcement were only enabled when `BUILD_ARTIFACTSTAGINGDIRECTORY` was present, which is specific to Azure DevOps.

Making the property group unconditional ensures local builds, GitHub PR builds, and Azure DevOps builds all enforce the same warning policy before changes reach the VSIX build pipeline.

## Validation
- `dotnet restore src\build.proj`
- `dotnet build src\build.proj --no-restore --configuration Debug -p:langversion=preview`
- `dotnet test src\build.proj --no-build --no-restore --configuration Debug --logger trx --collect "Code coverage" --results-directory TestResults --blame`