### PR TITLE
Fix esbuild lockfile resolution

### DIFF
--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/package.json
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/package.json
@@ -393,7 +393,7 @@
     "@typescript-eslint/eslint-plugin": "^8.30.0",
     "@typescript-eslint/parser": "^8.30.0",
     "@vscode/test-electron": "^2.4.1",
-    "esbuild": "0.28.0",
+    "esbuild": "0.28.1",
     "eslint": "^10.0.0",
     "nerdbank-gitversioning": "^3.7.115",
     "npm-run-all2": "^7.0.2",

--- a/src/vscode-extensions/package-lock.json
+++ b/src/vscode-extensions/package-lock.json
@@ -15,19 +15,19 @@
       "license": "MIT",
       "dependencies": {
         "@types/semver": "^7.7.0",
-        "@vscode/extension-telemetry": "^1.0.0",
+        "@vscode/extension-telemetry": "^1.5.2",
         "jsonc-parser": "^3.3.1",
-        "semver": "^7.7.2"
+        "semver": "^7.8.5"
       },
       "devDependencies": {
-        "@types/node": "^22.0.0",
-        "@types/vscode": "^1.108.0",
-        "@typescript-eslint/eslint-plugin": "^8.30.0",
-        "@typescript-eslint/parser": "^8.30.0",
+        "@types/node": "^22.19.18",
+        "@types/vscode": "^1.118.0",
+        "@typescript-eslint/eslint-plugin": "^8.59.2",
+        "@typescript-eslint/parser": "^8.59.2",
         "@vscode/test-electron": "^2.4.1",
-        "esbuild": "0.28.0",
-        "eslint": "^10.0.0",
-        "nerdbank-gitversioning": "^3.7.115",
+        "esbuild": "^0.28.0",
+        "eslint": "^10.6.0",
+        "nerdbank-gitversioning": "^3.10.85",
         "npm-run-all2": "^7.0.2",
         "shared": "file:../shared",
         "typescript": "^5.7.2"
@@ -50,8 +50,8 @@
       }
     },
     "microsoft-powerplatformlang-extension/node_modules/@eslint/config-helpers": {
-      "version": "0.5.5",
-      "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
+      "version": "0.6.0",
+      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
       "dev": true,
       "dependencies": {
         "@eslint/core": "^1.2.1"
@@ -80,8 +80,8 @@
       }
     },
     "microsoft-powerplatformlang-extension/node_modules/@eslint/plugin-kit": {
-      "version": "0.7.1",
-      "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
+      "version": "0.7.2",
+      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
       "dev": true,
       "dependencies": {
         "@eslint/core": "^1.2.1",
@@ -89,6 +89,83 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "microsoft-powerplatformlang-extension/node_modules/@microsoft/1ds-core-js": {
+      "version": "4.4.3",
+      "integrity": "sha512-lKMKpXh39c8fB47O6g3rFyVDUb+nweoJuxwZbnOLKkmE7+LrCVGbS+wpJ6Ylwqh2HeUeWoa2Sv/hg/TKcAxHJQ==",
+      "dependencies": {
+        "@microsoft/applicationinsights-core-js": "3.4.3",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-async": ">= 0.5.5 < 0.6.0",
+        "@nevware21/ts-utils": ">= 0.14.0 < 2.x"
+      }
+    },
+    "microsoft-powerplatformlang-extension/node_modules/@microsoft/1ds-post-js": {
+      "version": "4.4.3",
+      "integrity": "sha512-qKHEU9rtB60b0q2W48hYJZ0mj9u13EuECq3xOCM0GwVIqWuLMxzCAh1PsK4TUvCsINohf135Lrf3c0IXSw4R3w==",
+      "dependencies": {
+        "@microsoft/applicationinsights-core-js": "3.4.3",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-async": ">= 0.5.5 < 0.6.0",
+        "@nevware21/ts-utils": ">= 0.14.0 < 2.x"
+      }
+    },
+    "microsoft-powerplatformlang-extension/node_modules/@microsoft/applicationinsights-channel-js": {
+      "version": "3.4.3",
+      "integrity": "sha512-9EeGdGkpgmTH0UEAn9AwbSGfEAdPK1GQdZ1vmbsy+H4t01oFgW4drteykVvYUcXnNHNIjo4mI8hhN6taou5Ogg==",
+      "dependencies": {
+        "@microsoft/applicationinsights-core-js": "3.4.3",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-async": ">= 0.5.5 < 0.6.0",
+        "@nevware21/ts-utils": ">= 0.14.0 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": ">= 1.0.0"
+      }
+    },
+    "microsoft-powerplatformlang-extension/node_modules/@microsoft/applicationinsights-common": {
+      "version": "3.4.3",
+      "integrity": "sha512-LQvALAoqGSBjOCHHeBTkOh/RCfs1WVtJt2w8v3rNz3jMTV+WaCkMI2ZIpOT4xtAvRD9ypUljpLwjx58/Jo5P6w==",
+      "dependencies": {
+        "@microsoft/applicationinsights-core-js": "3.4.3",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-utils": ">= 0.14.0 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": ">= 1.0.0"
+      }
+    },
+    "microsoft-powerplatformlang-extension/node_modules/@microsoft/applicationinsights-core-js": {
+      "version": "3.4.3",
+      "integrity": "sha512-A+wkMLodF4JJsLoEvovgF3jyhKhbh9FNzO97sM7KQkbWUzdK47z4V/NDIETgwbaxw1O1u8mnP2qnp/2Bj9A0Uw==",
+      "dependencies": {
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-async": ">= 0.5.5 < 0.6.0",
+        "@nevware21/ts-utils": ">= 0.14.0 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": ">= 1.0.0"
+      }
+    },
+    "microsoft-powerplatformlang-extension/node_modules/@microsoft/applicationinsights-web-basic": {
+      "version": "3.4.3",
+      "integrity": "sha512-MqWaMbdsXgMDT5+RxM5yaztHVBVVHW2wZnNo8bbM7yeS9YDEMxMtLtlT6wZYI+b1/nfuOA8t+0+gZAkfCtMShg==",
+      "dependencies": {
+        "@microsoft/applicationinsights-channel-js": "3.4.3",
+        "@microsoft/applicationinsights-core-js": "3.4.3",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-async": ">= 0.5.5 < 0.6.0",
+        "@nevware21/ts-utils": ">= 0.14.0 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": ">= 1.0.0"
       }
     },
     "microsoft-powerplatformlang-extension/node_modules/@types/node": {
@@ -298,17 +375,6 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
-    "microsoft-powerplatformlang-extension/node_modules/@typescript-eslint/eslint-plugin/node_modules/ts-api-utils": {
-      "version": "2.5.0",
-      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
-      "dev": true,
-      "engines": {
-        "node": ">=18.12"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4"
-      }
-    },
     "microsoft-powerplatformlang-extension/node_modules/@typescript-eslint/parser": {
       "version": "8.59.2",
       "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
@@ -393,17 +459,6 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
-    "microsoft-powerplatformlang-extension/node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree/node_modules/ts-api-utils": {
-      "version": "2.5.0",
-      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
-      "dev": true,
-      "engines": {
-        "node": ">=18.12"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4"
-      }
-    },
     "microsoft-powerplatformlang-extension/node_modules/@typescript-eslint/scope-manager": {
       "version": "8.59.2",
       "integrity": "sha512-JzfyEpEtOU89CcFSwyNS3mu4MLvLSXqnmX05+aKBDM+TdR5jzcGOEBwxwGNxrEQ7p/z6kK2WyioCGBf2zZBnvg==",
@@ -448,6 +503,20 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "microsoft-powerplatformlang-extension/node_modules/@vscode/extension-telemetry": {
+      "version": "1.5.2",
+      "integrity": "sha512-fO4huHz5apb5RtddC8DuUeSbBqYQw1EiBaOOGngq57nGbsDgcvm0jAibTY/kigJyjY0fQ4Vx7owQcCJRUrkT4g==",
+      "dependencies": {
+        "@microsoft/1ds-core-js": "^4.4.1",
+        "@microsoft/1ds-post-js": "^4.4.1",
+        "@microsoft/applicationinsights-common": "^3.4.1",
+        "@microsoft/applicationinsights-core-js": "^3.4.1",
+        "@microsoft/applicationinsights-web-basic": "^3.4.1"
+      },
+      "engines": {
+        "vscode": "^1.75.0"
+      }
+    },
     "microsoft-powerplatformlang-extension/node_modules/esbuild": {
       "version": "0.28.0",
       "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
@@ -489,16 +558,16 @@
       }
     },
     "microsoft-powerplatformlang-extension/node_modules/eslint": {
-      "version": "10.3.0",
-      "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
+      "version": "10.6.0",
+      "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
         "@eslint/config-array": "^0.23.5",
-        "@eslint/config-helpers": "^0.5.5",
+        "@eslint/config-helpers": "^0.6.0",
         "@eslint/core": "^1.2.1",
-        "@eslint/plugin-kit": "^0.7.1",
+        "@eslint/plugin-kit": "^0.7.2",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
@@ -559,6 +628,25 @@
       "dev": true,
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "microsoft-powerplatformlang-extension/node_modules/nerdbank-gitversioning": {
+      "version": "3.10.85",
+      "integrity": "sha512-FTSiJH8drAlbFDm7/QVcnp+Kshir41zKjJ+x60tNaHnx2YWsVnvzkywRJ/fvDjE6LjHZ5Xk9IVLb1mebWu5P8A==",
+      "dev": true,
+      "bin": {
+        "nbgv": "main.js",
+        "nbgv-setversion": "npmVersion.js"
+      }
+    },
+    "microsoft-powerplatformlang-extension/node_modules/semver": {
+      "version": "7.8.5",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1091,97 +1179,12 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
-    "node_modules/@microsoft/1ds-core-js": {
-      "version": "4.3.11",
-      "integrity": "sha1-UjxgDSXgBDecWUBLDXXuAAQ2Jc0=",
-      "license": "MIT",
-      "dependencies": {
-        "@microsoft/applicationinsights-core-js": "3.3.11",
-        "@microsoft/applicationinsights-shims": "3.0.1",
-        "@microsoft/dynamicproto-js": "^2.0.3",
-        "@nevware21/ts-async": ">= 0.5.4 < 2.x",
-        "@nevware21/ts-utils": ">= 0.11.8 < 2.x"
-      }
-    },
-    "node_modules/@microsoft/1ds-post-js": {
-      "version": "4.3.11",
-      "integrity": "sha1-iOwI5LSrWWmwAiglT1MD1gO/8J4=",
-      "license": "MIT",
-      "dependencies": {
-        "@microsoft/1ds-core-js": "4.3.11",
-        "@microsoft/applicationinsights-shims": "3.0.1",
-        "@microsoft/dynamicproto-js": "^2.0.3",
-        "@nevware21/ts-async": ">= 0.5.4 < 2.x",
-        "@nevware21/ts-utils": ">= 0.11.8 < 2.x"
-      }
-    },
-    "node_modules/@microsoft/applicationinsights-channel-js": {
-      "version": "3.3.11",
-      "integrity": "sha1-eZGzFbKVIZpD6FyWqwTrBwpeE/Y=",
-      "license": "MIT",
-      "dependencies": {
-        "@microsoft/applicationinsights-common": "3.3.11",
-        "@microsoft/applicationinsights-core-js": "3.3.11",
-        "@microsoft/applicationinsights-shims": "3.0.1",
-        "@microsoft/dynamicproto-js": "^2.0.3",
-        "@nevware21/ts-async": ">= 0.5.4 < 2.x",
-        "@nevware21/ts-utils": ">= 0.11.8 < 2.x"
-      },
-      "peerDependencies": {
-        "tslib": ">= 1.0.0"
-      }
-    },
-    "node_modules/@microsoft/applicationinsights-common": {
-      "version": "3.3.11",
-      "integrity": "sha1-Gtdkowgz+A+soacq9Lj6K3w7KLo=",
-      "license": "MIT",
-      "dependencies": {
-        "@microsoft/applicationinsights-core-js": "3.3.11",
-        "@microsoft/applicationinsights-shims": "3.0.1",
-        "@microsoft/dynamicproto-js": "^2.0.3",
-        "@nevware21/ts-utils": ">= 0.11.8 < 2.x"
-      },
-      "peerDependencies": {
-        "tslib": ">= 1.0.0"
-      }
-    },
-    "node_modules/@microsoft/applicationinsights-core-js": {
-      "version": "3.3.11",
-      "integrity": "sha1-ks6WCSSxYSH4aBSpteo11canuOA=",
-      "license": "MIT",
-      "dependencies": {
-        "@microsoft/applicationinsights-shims": "3.0.1",
-        "@microsoft/dynamicproto-js": "^2.0.3",
-        "@nevware21/ts-async": ">= 0.5.4 < 2.x",
-        "@nevware21/ts-utils": ">= 0.11.8 < 2.x"
-      },
-      "peerDependencies": {
-        "tslib": ">= 1.0.0"
-      }
-    },
     "node_modules/@microsoft/applicationinsights-shims": {
       "version": "3.0.1",
       "integrity": "sha1-OGW3Os6EBbnEYYzFxXHy/jh28G8=",
       "license": "MIT",
       "dependencies": {
         "@nevware21/ts-utils": ">= 0.9.4 < 2.x"
-      }
-    },
-    "node_modules/@microsoft/applicationinsights-web-basic": {
-      "version": "3.3.11",
-      "integrity": "sha1-NT0VkSfCtWuC3Vd396NVYmQR+O8=",
-      "license": "MIT",
-      "dependencies": {
-        "@microsoft/applicationinsights-channel-js": "3.3.11",
-        "@microsoft/applicationinsights-common": "3.3.11",
-        "@microsoft/applicationinsights-core-js": "3.3.11",
-        "@microsoft/applicationinsights-shims": "3.0.1",
-        "@microsoft/dynamicproto-js": "^2.0.3",
-        "@nevware21/ts-async": ">= 0.5.4 < 2.x",
-        "@nevware21/ts-utils": ">= 0.11.8 < 2.x"
-      },
-      "peerDependencies": {
-        "tslib": ">= 1.0.0"
       }
     },
     "node_modules/@microsoft/dynamicproto-js": {
@@ -1237,19 +1240,6 @@
       "version": "7.7.1",
       "integrity": "sha1-POOvGlUk7zJ9Lank/YttlcjXBSg=",
       "license": "MIT"
-    },
-    "node_modules/@vscode/extension-telemetry": {
-      "version": "1.5.1",
-      "integrity": "sha1-4zbEBLFCSTlRa5E+X3I6nfcOkHs=",
-      "license": "MIT",
-      "dependencies": {
-        "@microsoft/1ds-core-js": "^4.3.10",
-        "@microsoft/1ds-post-js": "^4.3.10",
-        "@microsoft/applicationinsights-web-basic": "^3.3.10"
-      },
-      "engines": {
-        "vscode": "^1.75.0"
-      }
     },
     "node_modules/@vscode/test-electron": {
       "version": "2.5.2",
@@ -2033,16 +2023,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/nerdbank-gitversioning": {
-      "version": "3.9.50",
-      "integrity": "sha1-dwp3MN8SV6RD15qm3x269BWtg3o=",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "nbgv": "main.js",
-        "nbgv-setversion": "npmVersion.js"
-      }
-    },
     "node_modules/npm-normalize-package-bin": {
       "version": "4.0.0",
       "integrity": "sha1-33nnDNChE7d8AtH+JDyWuOYYrLE=",
@@ -2090,21 +2070,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/npm-run-all2/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/npm-run-all2/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/npm-run-all2/node_modules/isexe": {
       "version": "3.1.5",
       "integrity": "sha1-QuNo9o1eENrf7k/ae1ULwtiJLck=",
@@ -2112,21 +2077,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/npm-run-all2/node_modules/minimatch": {
-      "version": "9.0.9",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/npm-run-all2/node_modules/which": {
@@ -2426,6 +2376,7 @@
     "node_modules/semver": {
       "version": "7.7.4",
       "integrity": "sha1-KEZONgYOmR+noR0CedLT87V6foo=",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -2611,6 +2562,17 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "integrity": "sha1-YS7+TtI11Wfoq6Xypfq3AoCt6D8=",
@@ -2738,24 +2700,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/yargs": {
-      "version": "17.7.2",
-      "integrity": "sha1-mR3zmspnWhkrgW4eA2P5110qomk=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/yargs-parser": {
       "version": "21.1.1",
       "integrity": "sha1-kJa87r+ZDSG7MfqVFuDt4pSnfTU=",
@@ -2781,7 +2725,24 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
-        "yargs": "^17.7.2"
+        "yargs": "^17.7.3"
+      }
+    },
+    "shared/node_modules/yargs": {
+      "version": "17.7.3",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
       }
     }
   }

--- a/src/vscode-extensions/package-lock.json
+++ b/src/vscode-extensions/package-lock.json
@@ -15,19 +15,19 @@
       "license": "MIT",
       "dependencies": {
         "@types/semver": "^7.7.0",
-        "@vscode/extension-telemetry": "^1.5.2",
+        "@vscode/extension-telemetry": "^1.0.0",
         "jsonc-parser": "^3.3.1",
-        "semver": "^7.8.5"
+        "semver": "^7.7.2"
       },
       "devDependencies": {
-        "@types/node": "^22.19.18",
-        "@types/vscode": "^1.118.0",
-        "@typescript-eslint/eslint-plugin": "^8.59.2",
-        "@typescript-eslint/parser": "^8.59.2",
+        "@types/node": "^22.0.0",
+        "@types/vscode": "^1.108.0",
+        "@typescript-eslint/eslint-plugin": "^8.30.0",
+        "@typescript-eslint/parser": "^8.30.0",
         "@vscode/test-electron": "^2.4.1",
-        "esbuild": "^0.28.0",
-        "eslint": "^10.6.0",
-        "nerdbank-gitversioning": "^3.10.85",
+        "esbuild": "0.28.1",
+        "eslint": "^10.0.0",
+        "nerdbank-gitversioning": "^3.7.115",
         "npm-run-all2": "^7.0.2",
         "shared": "file:../shared",
         "typescript": "^5.7.2"
@@ -517,46 +517,6 @@
         "vscode": "^1.75.0"
       }
     },
-    "microsoft-powerplatformlang-extension/node_modules/esbuild": {
-      "version": "0.28.0",
-      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.0",
-        "@esbuild/android-arm": "0.28.0",
-        "@esbuild/android-arm64": "0.28.0",
-        "@esbuild/android-x64": "0.28.0",
-        "@esbuild/darwin-arm64": "0.28.0",
-        "@esbuild/darwin-x64": "0.28.0",
-        "@esbuild/freebsd-arm64": "0.28.0",
-        "@esbuild/freebsd-x64": "0.28.0",
-        "@esbuild/linux-arm": "0.28.0",
-        "@esbuild/linux-arm64": "0.28.0",
-        "@esbuild/linux-ia32": "0.28.0",
-        "@esbuild/linux-loong64": "0.28.0",
-        "@esbuild/linux-mips64el": "0.28.0",
-        "@esbuild/linux-ppc64": "0.28.0",
-        "@esbuild/linux-riscv64": "0.28.0",
-        "@esbuild/linux-s390x": "0.28.0",
-        "@esbuild/linux-x64": "0.28.0",
-        "@esbuild/netbsd-arm64": "0.28.0",
-        "@esbuild/netbsd-x64": "0.28.0",
-        "@esbuild/openbsd-arm64": "0.28.0",
-        "@esbuild/openbsd-x64": "0.28.0",
-        "@esbuild/openharmony-arm64": "0.28.0",
-        "@esbuild/sunos-x64": "0.28.0",
-        "@esbuild/win32-arm64": "0.28.0",
-        "@esbuild/win32-ia32": "0.28.0",
-        "@esbuild/win32-x64": "0.28.0"
-      }
-    },
     "microsoft-powerplatformlang-extension/node_modules/eslint": {
       "version": "10.6.0",
       "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
@@ -650,12 +610,13 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.28.0",
-      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "version": "0.28.1",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "aix"
@@ -665,12 +626,13 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.28.0",
-      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "version": "0.28.1",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -680,12 +642,13 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.28.0",
-      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "version": "0.28.1",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -695,12 +658,13 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.28.0",
-      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "version": "0.28.1",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -710,12 +674,13 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.28.0",
-      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "version": "0.28.1",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -725,12 +690,13 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.28.0",
-      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "version": "0.28.1",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -740,12 +706,13 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.28.0",
-      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "version": "0.28.1",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -755,12 +722,13 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.28.0",
-      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "version": "0.28.1",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -770,12 +738,13 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.28.0",
-      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "version": "0.28.1",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -785,12 +754,13 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.28.0",
-      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "version": "0.28.1",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -800,12 +770,13 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.28.0",
-      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "version": "0.28.1",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -815,12 +786,13 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.28.0",
-      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "version": "0.28.1",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -830,12 +802,13 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.28.0",
-      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "version": "0.28.1",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -845,12 +818,13 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.28.0",
-      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "version": "0.28.1",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -860,12 +834,13 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.28.0",
-      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "version": "0.28.1",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -875,12 +850,13 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.28.0",
-      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "version": "0.28.1",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -890,12 +866,13 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.28.0",
-      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "version": "0.28.1",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -905,12 +882,13 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.28.0",
-      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "version": "0.28.1",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
@@ -920,12 +898,13 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.28.0",
-      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "version": "0.28.1",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
@@ -935,12 +914,13 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.28.0",
-      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "version": "0.28.1",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
@@ -950,12 +930,13 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.28.0",
-      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "version": "0.28.1",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
@@ -965,12 +946,13 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.28.0",
-      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "version": "0.28.1",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "openharmony"
@@ -980,12 +962,13 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.28.0",
-      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "version": "0.28.1",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "sunos"
@@ -995,12 +978,13 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.28.0",
-      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "version": "0.28.1",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -1010,12 +994,13 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.28.0",
-      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "version": "0.28.1",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -1025,12 +1010,13 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.28.0",
-      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "version": "0.28.1",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -1478,6 +1464,47 @@
       "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
     },
     "node_modules/escalade": {
       "version": "3.2.0",

--- a/src/vscode-extensions/shared/package-lock.json
+++ b/src/vscode-extensions/shared/package-lock.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "name": "shared",
   "version": "1.0.0",
   "lockfileVersion": 2,
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
-        "yargs": "^17.7.2"
+        "yargs": "^17.7.3"
       }
     },
     "node_modules/ansi-regex": {
@@ -149,8 +149,8 @@
       }
     },
     "node_modules/yargs": {
-      "version": "17.7.2",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "version": "17.7.3",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
       "dev": true,
       "dependencies": {
         "cliui": "^8.0.1",
@@ -270,8 +270,8 @@
       "dev": true
     },
     "yargs": {
-      "version": "17.7.2",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "version": "17.7.3",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
       "dev": true,
       "requires": {
         "cliui": "^8.0.1",
@@ -290,4 +290,3 @@
     }
   }
 }
-

--- a/src/vscode-extensions/shared/package.json
+++ b/src/vscode-extensions/shared/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "license": "MIT",
   "devDependencies": {
-    "yargs": "^17.7.2"
+    "yargs": "^17.7.3"
   }
 }


### PR DESCRIPTION
## Summary
- carries forward the dependency updates from Dependabot PR #318
- regenerates `src/vscode-extensions/package-lock.json` so `esbuild` and all `@esbuild/*` optional packages resolve to `0.28.1`
- fixes the `npm ci` lockfile mismatch caused by `package.json` requiring `esbuild@0.28.1` while the lockfile still resolved `0.28.0`

## Validation
- `npm ci` passes after the lockfile update
- `npm audit` no longer reports the `esbuild` advisory; one existing moderate `brace-expansion` advisory remains
- `npm run compile-tests` passes
- `npm run compile` passes
- `npm run lint` passes
- `dotnet build src\build.proj --configuration Debug -p:langversion=preview` passes with 0 warnings/errors
- `dotnet test src\build.proj --no-build --no-restore --configuration Debug` passes: 1347 passed, 9 skipped

## Notes
- Full `npm test` remains blocked in the VS Code host-test phase: `@vscode/test-electron` downloads VS Code 1.128.0, then Electron fails to load `workbench.html` from the extracted archive and hangs. The pretest portion of `npm test` completed successfully before that blocker.