### PR TITLE
Fix knowledge file projection in CLI agent

### DIFF
--- a/src/CopilotStudio.McsCore/LspProjection.cs
+++ b/src/CopilotStudio.McsCore/LspProjection.cs
@@ -474,6 +474,7 @@ internal static class LspProjection
         // CLI knowledge/file rules also preserve underscore-bearing display-name files
         // that are not bot-prefixed (no dot, no infix to expand against).
         if (rule.PreserveBotPrefixedFiles
+            && !string.Equals(rule.Infix, FileAttachmentInfix, StringComparison.Ordinal)
             && fileName.IndexOf('_') > 0
             && (string.IsNullOrEmpty(botName)
                 || !fileName.StartsWith(botName + "_", StringComparison.OrdinalIgnoreCase)))

--- a/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Contracts.FileLayout/CliProjectionRuleTests.cs
+++ b/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Contracts.FileLayout/CliProjectionRuleTests.cs
@@ -76,6 +76,7 @@ namespace Microsoft.PowerPlatformLS.UnitTests.Contracts.FileLayout
         [Theory]
         [InlineData(typeof(KnowledgeSourceConfiguration), "capabilities/knowledge/Weather", "Default_draft_ECaOPZ.knowledge.Weather")]
         [InlineData(typeof(FileAttachmentComponent), "capabilities/knowledge/files/MyLedger.xlsx_hyG", "Default_draft_ECaOPZ.file.MyLedger.xlsx_hyG")]
+        [InlineData(typeof(FileAttachmentComponent), "capabilities/knowledge/files/file22txt_dBKwq", "Default_draft_ECaOPZ.file.file22txt_dBKwq")]
         public void GetSchemaName_CliSharedType_ProducesExpectedSchema(System.Type elementType, string pathWithoutExt, string expectedSchema)
         {
             var result = LspProjection.GetSchemaName(pathWithoutExt, Bot, elementType, Cli);
@@ -85,6 +86,7 @@ namespace Microsoft.PowerPlatformLS.UnitTests.Contracts.FileLayout
         [Theory]
         [InlineData(typeof(KnowledgeSourceConfiguration), "Default_draft_ECaOPZ.knowledge.Weather", "capabilities/knowledge/Weather.mcs.yml")]
         [InlineData(typeof(FileAttachmentComponent), "Default_draft_ECaOPZ.file.MyLedger.xlsx_hyG", "capabilities/knowledge/files/MyLedger.xlsx_hyG.mcs.yml")]
+        [InlineData(typeof(FileAttachmentComponent), "Default_draft_ECaOPZ.file.file22txt_dBKwq", "capabilities/knowledge/files/file22txt_dBKwq.mcs.yml")]
         public void GetFilePath_CliSharedType_ProducesExpectedPath(System.Type elementType, string schema, string expectedPath)
         {
             var result = LspProjection.GetFilePath(elementType, schema, Bot, subAgentFolder: null, pathWithoutExtension: null, Cli);

--- a/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.Language.CopilotStudio/McsWorkspaceCompilerCliTests.cs
+++ b/src/LanguageServers/PowerPlatformLS/UnitTests/PowerPlatformLS.UnitTests/Impl.Language.CopilotStudio/McsWorkspaceCompilerCliTests.cs
@@ -140,6 +140,29 @@ namespace Microsoft.PowerPlatformLS.UnitTests.Impl.Language.CopilotStudio
         }
 
         [Fact]
+        public void CliWorkspace_FileAttachmentMetadata_CompilesWithQualifiedSchemaName()
+        {
+            var (compiler, language) = BuildCompiler();
+            var entity = ReadEntity(CliBotDefinitionJson);
+
+            var metadataYaml = "mcs.metadata:\n  componentName: File 22.txt\n  description: This knowledge source searches information contained in File 22.txt\n";
+
+            var documents = new Dictionary<FilePath, LspDocument>();
+            AddDocument(documents, language, "settings.mcs.yml", CodeSerializer.Serialize(entity));
+            AddDocument(documents, language, "capabilities/knowledge/files/file22txt_dBKwq.mcs.yml", metadataYaml);
+
+            var compilation = compiler.Compile(documents, new DirectoryPath("c:/agent"));
+
+            Assert.NotNull(compilation.Model);
+            Assert.Empty(compilation.Errors);
+
+            Assert.Contains(compilation.Model.Components,
+                c => c.SchemaNameString == $"{CliBotSchemaName}.file.file22txt_dBKwq");
+            Assert.DoesNotContain(compilation.Model.Components,
+                c => c.SchemaNameString == "file22txt_dBKwq");
+        }
+
+        [Fact]
         public void ClassicWorkspace_ShapeDetection_AndCompile_Unchanged()
         {
             var (compiler, language) = BuildCompiler();


### PR DESCRIPTION
Fix knowledge file projection in CLI agent. 
Fix issue that after clone, knowledge file show in local diff right after clone for cli agent even no change