### PR TITLE
Fix LspJournalCli journal failures on a clean checkout (#313)

### DIFF
--- a/src/LanguageServers/PowerPlatformLS/Tools/LspJournalCli.UnitTests/SerializationOptionsTests.cs
+++ b/src/LanguageServers/PowerPlatformLS/Tools/LspJournalCli.UnitTests/SerializationOptionsTests.cs
@@ -1,0 +1,26 @@
+namespace Microsoft.PowerPlatformLS.Tools.LspJournalCli.UnitTests
+{
+    using System.Text.Json;
+    using Microsoft.PowerPlatformLS.Tools.LspJournalCli.Transport;
+    using Xunit;
+
+    public sealed class SerializationOptionsTests
+    {
+        // Journal baselines are committed as LF (.gitattributes: *.json eol=lf). The tool
+        // must write them with LF newlines directly so that regenerating a baseline on
+        // Windows does not introduce CRLF churn that git then has to renormalize. Without
+        // an explicit NewLine, System.Text.Json's indented writer uses Environment.NewLine
+        // (CRLF on Windows), which is exactly the line-ending noise issue #313 is about.
+        [Fact]
+        public void Indented_WritesLfNewlines_NotCrlf()
+        {
+            var json = JsonSerializer.Serialize(
+                new { first = 1, second = "two", nested = new { third = true } },
+                SerializationOptions.Indented);
+
+            Assert.Contains("\n", json);
+            Assert.DoesNotContain("\r\n", json);
+            Assert.DoesNotContain("\r", json);
+        }
+    }
+}

--- a/src/LanguageServers/PowerPlatformLS/Tools/LspJournalCli.UnitTests/TempWorkspaceCopyTests.cs
+++ b/src/LanguageServers/PowerPlatformLS/Tools/LspJournalCli.UnitTests/TempWorkspaceCopyTests.cs
@@ -1,0 +1,123 @@
+namespace Microsoft.PowerPlatformLS.Tools.LspJournalCli.UnitTests
+{
+    using System;
+    using System.IO;
+    using System.Text;
+    using Microsoft.PowerPlatformLS.Tools.LspJournalCli.Execution;
+    using Xunit;
+
+    /// <summary>
+    /// Guards the isolation invariant behind issue #313: the language server rewrites
+    /// workspace files on load (migrating legacy "# Name:" headers into "mcs.metadata:"
+    /// blocks), so journals must run against a throwaway copy. If the server ever writes
+    /// through to the committed fixture again, these tests fail.
+    /// </summary>
+    public sealed class TempWorkspaceCopyTests
+    {
+        private static string CreateSourceWorkspace()
+        {
+            var root = Path.Combine(Path.GetTempPath(), "lsp-journal-src-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(root);
+            // Use LF-only content to mirror the committed fixtures.
+            File.WriteAllText(Path.Combine(root, "agent.mcs.yml"), "kind: GptComponentMetadata\n", new UTF8Encoding(false));
+            var topics = Path.Combine(root, "topics");
+            Directory.CreateDirectory(topics);
+            File.WriteAllText(Path.Combine(topics, "Greeting.mcs.yml"), "# Name: Greeting\nkind: AdaptiveDialog\n", new UTF8Encoding(false));
+            return root;
+        }
+
+        [Fact]
+        public void Create_CopiesAllFilesAndSubdirectoriesWithIdenticalBytes()
+        {
+            var source = CreateSourceWorkspace();
+            try
+            {
+                using var copy = TempWorkspaceCopy.Create(source);
+
+                var copiedAgent = Path.Combine(copy.WorkspacePath, "agent.mcs.yml");
+                var copiedGreeting = Path.Combine(copy.WorkspacePath, "topics", "Greeting.mcs.yml");
+
+                Assert.True(File.Exists(copiedAgent));
+                Assert.True(File.Exists(copiedGreeting));
+                Assert.Equal(
+                    File.ReadAllBytes(Path.Combine(source, "agent.mcs.yml")),
+                    File.ReadAllBytes(copiedAgent));
+                Assert.Equal(
+                    File.ReadAllBytes(Path.Combine(source, "topics", "Greeting.mcs.yml")),
+                    File.ReadAllBytes(copiedGreeting));
+            }
+            finally
+            {
+                Directory.Delete(source, recursive: true);
+            }
+        }
+
+        [Fact]
+        public void Create_PointsAtCopyNotSource()
+        {
+            var source = CreateSourceWorkspace();
+            try
+            {
+                using var copy = TempWorkspaceCopy.Create(source);
+
+                Assert.NotEqual(
+                    Path.GetFullPath(source),
+                    Path.GetFullPath(copy.WorkspacePath));
+                Assert.Equal(
+                    Path.GetFullPath(copy.WorkspacePath),
+                    Path.GetFullPath(new Uri(copy.Uri).LocalPath));
+            }
+            finally
+            {
+                Directory.Delete(source, recursive: true);
+            }
+        }
+
+        [Fact]
+        public void MutatingCopy_DoesNotAffectSource()
+        {
+            // This is the exact scenario that mutated committed fixtures: the server rewrites
+            // a file (changed content) and deletes another during workspace indexing. Those
+            // writes must land on the copy only.
+            var source = CreateSourceWorkspace();
+            var sourceGreeting = Path.Combine(source, "topics", "Greeting.mcs.yml");
+            var originalGreetingBytes = File.ReadAllBytes(sourceGreeting);
+            try
+            {
+                using var copy = TempWorkspaceCopy.Create(source);
+
+                var copiedGreeting = Path.Combine(copy.WorkspacePath, "topics", "Greeting.mcs.yml");
+                File.WriteAllText(copiedGreeting, "mcs.metadata:\r\n  componentName: Greeting\r\nkind: AdaptiveDialog", new UTF8Encoding(false));
+                File.Delete(Path.Combine(copy.WorkspacePath, "agent.mcs.yml"));
+
+                Assert.Equal(originalGreetingBytes, File.ReadAllBytes(sourceGreeting));
+                Assert.True(File.Exists(Path.Combine(source, "agent.mcs.yml")));
+            }
+            finally
+            {
+                Directory.Delete(source, recursive: true);
+            }
+        }
+
+        [Fact]
+        public void Dispose_RemovesCopyDirectory()
+        {
+            var source = CreateSourceWorkspace();
+            try
+            {
+                string copyPath;
+                using (var copy = TempWorkspaceCopy.Create(source))
+                {
+                    copyPath = copy.WorkspacePath;
+                    Assert.True(Directory.Exists(copyPath));
+                }
+
+                Assert.False(Directory.Exists(copyPath));
+            }
+            finally
+            {
+                Directory.Delete(source, recursive: true);
+            }
+        }
+    }
+}

--- a/src/LanguageServers/PowerPlatformLS/Tools/LspJournalCli/Commands/RunCommand.cs
+++ b/src/LanguageServers/PowerPlatformLS/Tools/LspJournalCli/Commands/RunCommand.cs
@@ -120,9 +120,19 @@ namespace Microsoft.PowerPlatformLS.Tools.LspJournalCli.Commands
             // Snapshot original expected values for material-change detection
             var originalExpected = SnapshotExpected(journal.Steps);
 
-            // Resolve workspace URI and expand ${workspace} → absolute URIs in params
-            var resolvedWorkspaceUri = ResolveWorkspaceUri(journal, journalPath);
+            // Run the server against a throwaway COPY of the fixture workspace. The server
+            // rewrites files while indexing them (e.g. migrating legacy "# Name:" headers into
+            // "mcs.metadata:" blocks), so pointing it at the committed fixture would dirty the
+            // working tree and let one journal's rewrites break a later journal's text-hash check
+            // during --all. Text-hash validation (resolvedWorkspacePath) stays bound to the
+            // pristine committed fixture so recorded hashes remain stable across runs.
             var resolvedWorkspacePath = ResolveWorkspacePath(journal, journalPath);
+            using var workspaceSandbox = resolvedWorkspacePath is null
+                ? null
+                : TempWorkspaceCopy.Create(resolvedWorkspacePath);
+            var resolvedWorkspaceUri = workspaceSandbox?.Uri;
+
+            // Expand ${workspace} → absolute (sandbox) URIs in params
             if (resolvedWorkspaceUri is not null)
             {
                 foreach (var step in journal.Steps)
@@ -308,16 +318,20 @@ namespace Microsoft.PowerPlatformLS.Tools.LspJournalCli.Commands
                 // Promote actual → expected for baseline
                 foreach (var step in journal.Steps)
                 {
-                    // Relativize params back to ${workspace} form before writing
-                    if (resolvedWorkspacePath is not null && step.Params.HasValue)
-                    {
-                        step.Params = DocumentTextPolicy.ScrubParamsForStorage(step.Params.Value, resolvedWorkspacePath);
-                    }
-
+                    // Relativize absolute (sandbox) URIs back to ${workspace} FIRST, so scrubbing
+                    // maps each document to its committed-fixture-relative path and hashes the
+                    // pristine committed file — not the sandbox copy the server rewrote on load.
                     if (resolvedWorkspaceUri is not null && step.Params.HasValue)
                     {
                         var relParams = UriPlaceholder.Relativize(step.Params.Value.GetRawText(), resolvedWorkspaceUri);
                         step.Params = JsonDocument.Parse(relParams).RootElement.Clone();
+                    }
+
+                    // Replace inline document text with a ${file:...} reference + hash of the
+                    // committed fixture for storage.
+                    if (resolvedWorkspacePath is not null && step.Params.HasValue)
+                    {
+                        step.Params = DocumentTextPolicy.ScrubParamsForStorage(step.Params.Value, resolvedWorkspacePath);
                     }
 
                     step.Expected = step.Actual;
@@ -600,20 +614,10 @@ namespace Microsoft.PowerPlatformLS.Tools.LspJournalCli.Commands
         }
 
         /// <summary>
-        /// Compute the absolute file:/// URI for the workspace root described by
+        /// Resolve the absolute path to the committed fixture workspace described by
         /// <see cref="JournalMetadata.WorkspaceRoot"/> relative to the journal file.
         /// Returns null when the journal has no workspace root.
         /// </summary>
-        private static string? ResolveWorkspaceUri(Journal journal, string journalFilePath)
-        {
-            var workspaceRoot = journal.Metadata.WorkspaceRoot;
-            if (string.IsNullOrEmpty(workspaceRoot)) return null;
-
-            var journalDir = Path.GetDirectoryName(Path.GetFullPath(journalFilePath)) ?? ".";
-            var resolvedRoot = Path.GetFullPath(Path.Combine(journalDir, workspaceRoot));
-            return new Uri(resolvedRoot).ToString().TrimEnd('/');
-        }
-
         private static string? ResolveWorkspacePath(Journal journal, string journalFilePath)
         {
             var workspaceRoot = journal.Metadata.WorkspaceRoot;

--- a/src/LanguageServers/PowerPlatformLS/Tools/LspJournalCli/Execution/TempWorkspaceCopy.cs
+++ b/src/LanguageServers/PowerPlatformLS/Tools/LspJournalCli/Execution/TempWorkspaceCopy.cs
@@ -1,0 +1,91 @@
+namespace Microsoft.PowerPlatformLS.Tools.LspJournalCli.Execution
+{
+    using System;
+    using System.IO;
+
+    /// <summary>
+    /// An isolated, disposable copy of a fixture workspace.
+    /// <para>
+    /// The language server rewrites workspace files while indexing them on load — for
+    /// example, migrating legacy <c># Name:</c> comment headers into structured
+    /// <c>mcs.metadata:</c> blocks. Running a journal directly against the committed
+    /// fixtures therefore mutates them (dirtying the working tree) and, during
+    /// <c>--all</c>, lets one journal's rewrites break a later journal's text-hash check.
+    /// </para>
+    /// <para>
+    /// Journals run the server against one of these throwaway copies instead. The copy is
+    /// deleted on <see cref="Dispose"/>, so committed fixtures stay pristine and journals
+    /// never contaminate one another. Text-hash validation stays bound to the committed
+    /// fixture (see <see cref="DocumentTextPolicy"/>) so recorded hashes remain stable.
+    /// </para>
+    /// </summary>
+    public sealed class TempWorkspaceCopy : IDisposable
+    {
+        private TempWorkspaceCopy(string workspacePath)
+        {
+            WorkspacePath = workspacePath;
+        }
+
+        /// <summary>Absolute path to the throwaway workspace copy.</summary>
+        public string WorkspacePath { get; }
+
+        /// <summary>
+        /// The <c>file://</c> URI of the copy, without a trailing slash — matching the
+        /// shape the runner expands <c>${workspace}</c> placeholders into.
+        /// </summary>
+        public string Uri => new Uri(WorkspacePath).ToString().TrimEnd('/');
+
+        /// <summary>
+        /// Recursively copy <paramref name="sourceWorkspacePath"/> into a fresh temp directory.
+        /// </summary>
+        public static TempWorkspaceCopy Create(string sourceWorkspacePath)
+        {
+            if (string.IsNullOrEmpty(sourceWorkspacePath))
+            {
+                throw new ArgumentException("Source workspace path must be provided.", nameof(sourceWorkspacePath));
+            }
+
+            var source = Path.GetFullPath(sourceWorkspacePath);
+            if (!Directory.Exists(source))
+            {
+                throw new DirectoryNotFoundException($"Workspace fixture not found: {source}");
+            }
+
+            var destination = Path.Combine(Path.GetTempPath(), "lsp-journal-" + Guid.NewGuid().ToString("N"));
+            CopyDirectory(source, destination);
+            return new TempWorkspaceCopy(destination);
+        }
+
+        private static void CopyDirectory(string sourceDir, string destinationDir)
+        {
+            Directory.CreateDirectory(destinationDir);
+
+            foreach (var file in Directory.EnumerateFiles(sourceDir))
+            {
+                var destFile = Path.Combine(destinationDir, Path.GetFileName(file));
+                File.Copy(file, destFile, overwrite: true);
+            }
+
+            foreach (var directory in Directory.EnumerateDirectories(sourceDir))
+            {
+                var destSubDir = Path.Combine(destinationDir, Path.GetFileName(directory));
+                CopyDirectory(directory, destSubDir);
+            }
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                if (Directory.Exists(WorkspacePath))
+                {
+                    Directory.Delete(WorkspacePath, recursive: true);
+                }
+            }
+            catch
+            {
+                // Best-effort cleanup: a leftover temp directory must never fail a journal run.
+            }
+        }
+    }
+}

--- a/src/LanguageServers/PowerPlatformLS/Tools/LspJournalCli/TestAssets/journals/all-the-things-completions.journal.json
+++ b/src/LanguageServers/PowerPlatformLS/Tools/LspJournalCli/TestAssets/journals/all-the-things-completions.journal.json
@@ -3,11 +3,11 @@
     "description": "All-the-things: request completions on every document type at meaningful positions.",
     "workspaceRoot": "../fixtures/all-the-things-clean-workspace",
     "classification": "recorded",
-    "branch": "dev/stevesteiner/testcli.2",
-    "commit": "fa6143602",
-    "timestamp": "2026-02-10T22:44:58.2574758Z",
-    "branchBase": "27b3c27f3",
-    "branchDepth": 5
+    "branch": "main",
+    "commit": "6348142",
+    "timestamp": "2026-07-09T21:58:01.3898893Z",
+    "branchBase": "6348142",
+    "branchDepth": 0
   },
   "steps": [
     {
@@ -1029,6 +1029,44 @@
             }
           },
           {
+            "insertTextMode": 2,
+            "kind": 9,
+            "label": "ipa: ",
+            "sortText": "3ipa",
+            "textEdit": {
+              "newText": "ipa",
+              "range": {
+                "end": {
+                  "character": 6,
+                  "line": 4
+                },
+                "start": {
+                  "character": 4,
+                  "line": 4
+                }
+              }
+            }
+          },
+          {
+            "insertTextMode": 2,
+            "kind": 9,
+            "label": "soundsLike: ",
+            "sortText": "3soundsLike",
+            "textEdit": {
+              "newText": "soundsLike",
+              "range": {
+                "end": {
+                  "character": 6,
+                  "line": 4
+                },
+                "start": {
+                  "character": 4,
+                  "line": 4
+                }
+              }
+            }
+          },
+          {
             "detail": "DTMF Key",
             "insertTextMode": 2,
             "kind": 9,
@@ -1353,6 +1391,44 @@
                 }
               }
             }
+          },
+          {
+            "insertTextMode": 2,
+            "kind": 9,
+            "label": "sharedConnectionParameters: ",
+            "sortText": "3sharedConnectionParameters",
+            "textEdit": {
+              "newText": "sharedConnectionParameters",
+              "range": {
+                "end": {
+                  "character": 34,
+                  "line": 1
+                },
+                "start": {
+                  "character": 4,
+                  "line": 1
+                }
+              }
+            }
+          },
+          {
+            "insertTextMode": 2,
+            "kind": 9,
+            "label": "allowSharing: ",
+            "sortText": "3allowSharing",
+            "textEdit": {
+              "newText": "allowSharing",
+              "range": {
+                "end": {
+                  "character": 34,
+                  "line": 1
+                },
+                "start": {
+                  "character": 4,
+                  "line": 1
+                }
+              }
+            }
           }
         ]
       }
@@ -1536,6 +1612,25 @@
             "sortText": "3note",
             "textEdit": {
               "newText": "note",
+              "range": {
+                "end": {
+                  "character": 32,
+                  "line": 60
+                },
+                "start": {
+                  "character": 17,
+                  "line": 16
+                }
+              }
+            }
+          },
+          {
+            "insertTextMode": 2,
+            "kind": 9,
+            "label": "sensitivityLevel: ",
+            "sortText": "3sensitivityLevel",
+            "textEdit": {
+              "newText": "sensitivityLevel",
               "range": {
                 "end": {
                   "character": 32,

--- a/src/LanguageServers/PowerPlatformLS/Tools/LspJournalCli/TestAssets/journals/all-the-things-indexing.journal.json
+++ b/src/LanguageServers/PowerPlatformLS/Tools/LspJournalCli/TestAssets/journals/all-the-things-indexing.journal.json
@@ -3,11 +3,11 @@
     "description": "All-the-things: open every document type, check diagnostics and completions across the full surface area.",
     "workspaceRoot": "../fixtures/all-the-things-clean-workspace",
     "classification": "recorded",
-    "branch": "dev/stevesteiner/testcli.2",
-    "commit": "fa6143602",
-    "timestamp": "2026-02-10T22:45:06.0036837Z",
-    "branchBase": "27b3c27f3",
-    "branchDepth": 5
+    "branch": "main",
+    "commit": "6348142",
+    "timestamp": "2026-07-09T21:56:52.2762893Z",
+    "branchBase": "6348142",
+    "branchDepth": 0
   },
   "steps": [
     {
@@ -645,22 +645,7 @@
           "params": {
             "uri": "${workspace}/knowledge/files/ProductGuide.mcs.yml",
             "version": 0,
-            "diagnostics": [
-              {
-                "range": {
-                  "start": {
-                    "line": 0,
-                    "character": 0
-                  },
-                  "end": {
-                    "line": 0,
-                    "character": 0
-                  }
-                },
-                "severity": 3,
-                "message": "Document was not compiled under the current Agent Definition."
-              }
-            ]
+            "diagnostics": []
           }
         }
       ]

--- a/src/LanguageServers/PowerPlatformLS/Tools/LspJournalCli/TestAssets/journals/completion-depth.journal.json
+++ b/src/LanguageServers/PowerPlatformLS/Tools/LspJournalCli/TestAssets/journals/completion-depth.journal.json
@@ -3,11 +3,11 @@
     "description": "Completion depth: property-key in nested contexts, enum-value after change, and all four trigger-character variants.",
     "workspaceRoot": "../fixtures/all-the-things-clean-workspace",
     "classification": "recorded",
-    "branch": "dev/stevesteiner/migrate.4",
-    "commit": "292d97d68",
-    "timestamp": "2026-02-13T04:46:01.6524784Z",
-    "branchBase": "2d59832ef",
-    "branchDepth": 2
+    "branch": "main",
+    "commit": "6348142",
+    "timestamp": "2026-07-09T21:58:13.6797588Z",
+    "branchBase": "6348142",
+    "branchDepth": 0
   },
   "steps": [
     {
@@ -381,6 +381,25 @@
                 }
               }
             }
+          },
+          {
+            "insertTextMode": 2,
+            "kind": 9,
+            "label": "sensitivityLevel: ",
+            "sortText": "3sensitivityLevel",
+            "textEdit": {
+              "newText": "sensitivityLevel",
+              "range": {
+                "end": {
+                  "character": 8,
+                  "line": 14
+                },
+                "start": {
+                  "character": 6,
+                  "line": 14
+                }
+              }
+            }
           }
         ]
       },
@@ -477,6 +496,11 @@
             "detail": "Connector action",
             "documentation": "Invokes a connector\u0027s operation, possibly with inputs and outputs.",
             "label": "InvokeConnectorAction"
+          },
+          {
+            "detail": "MCP tool",
+            "documentation": "Invokes an MCP tool from an MCP server, possibly with inputs and outputs.",
+            "label": "InvokeMcpToolAction"
           },
           {
             "detail": "Action",

--- a/src/LanguageServers/PowerPlatformLS/Tools/LspJournalCli/TestAssets/journals/completion-error-context.journal.json
+++ b/src/LanguageServers/PowerPlatformLS/Tools/LspJournalCli/TestAssets/journals/completion-error-context.journal.json
@@ -3,11 +3,11 @@
     "description": "Completions in error-state files: verify the server returns results when diagnostics are present.",
     "workspaceRoot": "../fixtures/all-the-things-workspace",
     "classification": "recorded",
-    "branch": "dev/stevesteiner/testcli.2",
-    "commit": "fa6143602",
-    "timestamp": "2026-02-10T22:45:13.9814942Z",
-    "branchBase": "27b3c27f3",
-    "branchDepth": 5
+    "branch": "main",
+    "commit": "6348142",
+    "timestamp": "2026-07-09T21:58:17.7692820Z",
+    "branchBase": "6348142",
+    "branchDepth": 0
   },
   "steps": [
     {
@@ -551,6 +551,44 @@
             "sortText": "3synonyms",
             "textEdit": {
               "newText": "synonyms",
+              "range": {
+                "end": {
+                  "character": 15,
+                  "line": 4
+                },
+                "start": {
+                  "character": 4,
+                  "line": 4
+                }
+              }
+            }
+          },
+          {
+            "insertTextMode": 2,
+            "kind": 9,
+            "label": "ipa: ",
+            "sortText": "3ipa",
+            "textEdit": {
+              "newText": "ipa",
+              "range": {
+                "end": {
+                  "character": 15,
+                  "line": 4
+                },
+                "start": {
+                  "character": 4,
+                  "line": 4
+                }
+              }
+            }
+          },
+          {
+            "insertTextMode": 2,
+            "kind": 9,
+            "label": "soundsLike: ",
+            "sortText": "3soundsLike",
+            "textEdit": {
+              "newText": "soundsLike",
               "range": {
                 "end": {
                   "character": 15,

--- a/src/LanguageServers/PowerPlatformLS/Tools/LspJournalCli/TestAssets/journals/completion-smoke.journal.json
+++ b/src/LanguageServers/PowerPlatformLS/Tools/LspJournalCli/TestAssets/journals/completion-smoke.journal.json
@@ -2,11 +2,11 @@
   "metadata": {
     "workspaceRoot": "../fixtures/all-the-things-clean-workspace",
     "classification": "recorded",
-    "branch": "dev/stevesteiner/testcli.2",
-    "commit": "fa6143602",
-    "timestamp": "2026-02-10T22:45:20.9701594Z",
-    "branchBase": "27b3c27f3",
-    "branchDepth": 5
+    "branch": "main",
+    "commit": "6348142",
+    "timestamp": "2026-07-09T21:58:25.2069152Z",
+    "branchBase": "6348142",
+    "branchDepth": 0
   },
   "steps": [
     {
@@ -439,6 +439,44 @@
             "sortText": "3synonyms",
             "textEdit": {
               "newText": "synonyms",
+              "range": {
+                "end": {
+                  "character": 6,
+                  "line": 4
+                },
+                "start": {
+                  "character": 4,
+                  "line": 4
+                }
+              }
+            }
+          },
+          {
+            "insertTextMode": 2,
+            "kind": 9,
+            "label": "ipa: ",
+            "sortText": "3ipa",
+            "textEdit": {
+              "newText": "ipa",
+              "range": {
+                "end": {
+                  "character": 6,
+                  "line": 4
+                },
+                "start": {
+                  "character": 4,
+                  "line": 4
+                }
+              }
+            }
+          },
+          {
+            "insertTextMode": 2,
+            "kind": 9,
+            "label": "soundsLike: ",
+            "sortText": "3soundsLike",
+            "textEdit": {
+              "newText": "soundsLike",
               "range": {
                 "end": {
                   "character": 6,

--- a/src/LanguageServers/PowerPlatformLS/Tools/LspJournalCli/Transport/SerializationOptions.cs
+++ b/src/LanguageServers/PowerPlatformLS/Tools/LspJournalCli/Transport/SerializationOptions.cs
@@ -19,6 +19,9 @@ namespace Microsoft.PowerPlatformLS.Tools.LspJournalCli.Transport
 
         /// <summary>
         /// Options for writing journals with indentation for readability.
+        /// Journal baselines are committed as LF, so newlines are pinned to "\n"
+        /// to keep regenerated baselines byte-stable across operating systems
+        /// (System.Text.Json otherwise defaults to Environment.NewLine).
         /// </summary>
         public static readonly JsonSerializerOptions Indented = new()
         {
@@ -26,6 +29,7 @@ namespace Microsoft.PowerPlatformLS.Tools.LspJournalCli.Transport
             PropertyNameCaseInsensitive = true,
             DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
             WriteIndented = true,
+            NewLine = "\n",
             Converters = { new NullableJsonElementConverter() },
         };
     }


### PR DESCRIPTION
## Summary

Fixes #313. `LspJournalCli` did not pass on a clean checkout of `main`:

- The `all-the-things-indexing` journal failed at step 21 (missing `publishDiagnostics`).
- `-- --all` aborted with `Text hash mismatch for 'topics/Greeting.mcs.yml'`.
- Every run rewrote committed fixtures under `TestAssets/fixtures/`, leaving the working tree dirty.

## Root causes

1. **Fixture mutation / cross-journal contamination.** The language server rewrites workspace files while indexing them (e.g. migrating legacy `# Name:` comment headers into `mcs.metadata:` blocks). Running a journal directly against the committed fixtures mutated them, and during `--all` one journal''s rewrites broke a later journal''s text-hash check, aborting the whole run.
2. **Line-ending churn.** `SerializationOptions.Indented` left `NewLine` unset, so `System.Text.Json` used `Environment.NewLine` (CRLF on Windows) when regenerating baselines, producing spurious diffs against the LF-committed baselines.

## Fix (harness only — no language-server behavior changed)

- **`TempWorkspaceCopy`**: the server now runs against a throwaway copy of the fixture workspace, so committed fixtures stay pristine and journals never contaminate one another. Text-hash validation stays bound to the pristine committed fixture, so recorded hashes are stable across runs and operating systems.
- **`RunCommand`**: wires in the sandbox and reorders baseline promotion so params are relativized back to `${workspace}` *before* scrubbing (scrubbing then hashes the committed fixture, not the rewritten sandbox copy).
- **`SerializationOptions.Indented`**: pinned to `NewLine = "\n"` so regenerated baselines are byte-stable LF.
- **Refreshed 5 stale baselines** that the `--all` abort had been masking:
  - `all-the-things-indexing` — the comment-only knowledge file now parses as a source file and correctly yields empty diagnostics.
  - `all-the-things-completions`, `completion-depth`, `completion-error-context`, `completion-smoke` — purely additive schema growth (new properties/actions such as `ipa`, `soundsLike`, `sensitivityLevel`, `InvokeMcpToolAction`); no items removed, so no regressions.

## Tests

- `TempWorkspaceCopyTests` — proves the isolation invariant (mutating the copy never touches the source).
- `SerializationOptionsTests` — proves indented journal output is LF, not CRLF.

## Verification

- Rebased onto latest `main` (includes #334 inline-comment rule and #335 projection fix) and rebuilt the server.
- Single journal and `-- --all` both pass (**13/13**), with **no fixture mutation** (`git status` on `TestAssets/fixtures/` stays clean).
- New unit tests pass; clean build, 0 warnings.

### Note

`NotificationSetMatchingTests.Notifications_AreVerifiedAsMultiset` flakes under full-suite parallel load (passes in isolation, ~30ms). It reproduces **without** these changes and is a pre-existing, timing-based flake unrelated to #313 — left untouched here; worth a separate follow-up.
