### PR TITLE
Redact PII in sync telemetry

### DIFF
--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/commands/syncWorkspace.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/commands/syncWorkspace.ts
@@ -7,7 +7,7 @@ import { getWorkspaceChanges, refreshAgentChangesAfterFetch } from "../sync/work
 import { handleSyncAuthError } from "../sync/authFailureNotification";
 import { clearSuppressedAuthState } from "../clients/account";
 import { isKnowledgeFileChangeKind, TelemetryEventsKeys } from "../constants";
-import logger, { formatPii, PiiRedactionType, sanitizeErrorDetails } from "../services/logger";
+import logger, { formatFileName, sanitizeErrorDetails } from "../services/logger";
 
 type Workspace = { ws: CopilotStudioWorkspace } | CopilotStudioWorkspace | null;
 
@@ -20,7 +20,7 @@ interface SyncCommand {
 export function formatOpenFileError(fileName: string, error: unknown, agentName?: string): string {
   const errorMessage = error instanceof Error ? error.message : String(error);
 
-  return `Error opening file ${formatPii(fileName, PiiRedactionType.McsYamlFileName)}: ${sanitizeErrorDetails(errorMessage, agentName ? [agentName] : [])}`;
+  return `Error opening file ${formatFileName(fileName)}: ${sanitizeErrorDetails(errorMessage, agentName ? [agentName] : [])}`;
 }
 
 export const registerSyncCommands = (context: ExtensionContext) => {

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/commands/syncWorkspace.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/commands/syncWorkspace.ts
@@ -80,7 +80,8 @@ export const getDiagnosticsErrors = async (workspace: CopilotStudioWorkspace) =>
       const document = await VSworkspace.openTextDocument(fileUri);
       openedDocuments.push(document);
     } catch (error) {
-      logger.logError(TelemetryEventsKeys.SyncWorkspaceError, undefined, { message: `Error opening file <pii>${fileUri.fsPath}</pii>: ${(error as Error).message}` });
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      logger.logError(TelemetryEventsKeys.SyncWorkspaceError, undefined, { message: `Error opening file <pii>${fileUri.fsPath}</pii>: <pii>${errorMessage}</pii>` });
     }
   }
 
@@ -227,7 +228,8 @@ const registerSyncCommand = (
       if (workspaceForCatch && await handleSyncAuthError(workspaceForCatch, error, async () => { await commands.executeCommand(id, workspaceForCatch); })) {
         return;
       }
-      logger.logError(TelemetryEventsKeys.SyncWorkspaceError, `Failed to execute ${displayName} operation: ${(error as Error).message}`);
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      logger.logError(TelemetryEventsKeys.SyncWorkspaceError, `Failed to execute ${displayName} operation: <pii>${errorMessage}</pii>`);
     }
   });
 

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/commands/syncWorkspace.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/commands/syncWorkspace.ts
@@ -7,7 +7,7 @@ import { getWorkspaceChanges, refreshAgentChangesAfterFetch } from "../sync/work
 import { handleSyncAuthError } from "../sync/authFailureNotification";
 import { clearSuppressedAuthState } from "../clients/account";
 import { isKnowledgeFileChangeKind, TelemetryEventsKeys } from "../constants";
-import logger from "../services/logger";
+import logger, { formatPii, PiiRedactionType, sanitizeErrorDetails } from "../services/logger";
 
 type Workspace = { ws: CopilotStudioWorkspace } | CopilotStudioWorkspace | null;
 
@@ -15,6 +15,12 @@ interface SyncCommand {
   id: string;
   displayName: string;
   action: (synchroniser: WorkspaceSynchronizer) => Promise<void>;
+}
+
+export function formatOpenFileError(fileName: string, error: unknown, agentName?: string): string {
+  const errorMessage = error instanceof Error ? error.message : String(error);
+
+  return `Error opening file ${formatPii(fileName, PiiRedactionType.McsYamlFileName)}: ${sanitizeErrorDetails(errorMessage, agentName ? [agentName] : [])}`;
 }
 
 export const registerSyncCommands = (context: ExtensionContext) => {
@@ -80,8 +86,9 @@ export const getDiagnosticsErrors = async (workspace: CopilotStudioWorkspace) =>
       const document = await VSworkspace.openTextDocument(fileUri);
       openedDocuments.push(document);
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      logger.logError(TelemetryEventsKeys.SyncWorkspaceError, undefined, { message: `Error opening file <pii>${fileUri.fsPath}</pii>: <pii>${errorMessage}</pii>` });
+      logger.logError(TelemetryEventsKeys.SyncWorkspaceError, undefined, {
+        message: formatOpenFileError(fileUri.fsPath, error, workspace.displayName),
+      });
     }
   }
 
@@ -229,7 +236,10 @@ const registerSyncCommand = (
         return;
       }
       const errorMessage = error instanceof Error ? error.message : String(error);
-      logger.logError(TelemetryEventsKeys.SyncWorkspaceError, `Failed to execute ${displayName} operation: <pii>${errorMessage}</pii>`);
+      logger.logError(
+        TelemetryEventsKeys.SyncWorkspaceError,
+        `Failed to execute ${displayName} operation: ${sanitizeErrorDetails(errorMessage, workspaceForCatch ? [workspaceForCatch.displayName] : [])}`,
+      );
     }
   });
 

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/services/logger.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/services/logger.ts
@@ -15,8 +15,175 @@ type TelemetryEventProps = {
  */
 type TelemetryEventData = Record<string, string | number | undefined>;
 
-const stripPiiTags = (value: string): string => value.replace(/<pii>(.*?)<\/pii>/gs, '$1');
-const redactPii = (value: string): string => value.replace(/<pii>.*?<\/pii>/gs, '[REDACTED]');
+export enum PiiRedactionType {
+  AccountIdentifier = 'ACCOUNT IDENTIFIER',
+  AgentName = 'AGENT NAME',
+  EmailAddress = 'EMAIL ADDRESS',
+  FileUri = 'FILE URI',
+  McsYamlFileName = '.MCS.YML FILE NAME',
+  AiBuilderPromptDetails = 'AI BUILDER PROMPT DETAILS',
+  WorkflowErrorDetails = 'WORKFLOW ERROR DETAILS',
+  WorkflowNames = 'WORKFLOW NAMES',
+}
+
+interface PiiMatch {
+  start: number;
+  end: number;
+  type: PiiRedactionType;
+  priority: number;
+}
+
+const piiPattern = /<pii(?: type="([^"]+)")?(?: encoded="(true)")?>(.*?)<\/pii>/gs;
+
+const encodePiiValue = (value: string): string =>
+  value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+const decodePiiValue = (value: string): string =>
+  value.replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&amp;/g, '&');
+
+export function formatPii(value: string, type: PiiRedactionType): string {
+  return `<pii type="${type}" encoded="true">${encodePiiValue(value)}</pii>`;
+}
+
+function collectMatches(
+  value: string,
+  pattern: RegExp,
+  type: PiiRedactionType,
+  priority: number,
+  captureGroup = 0,
+): PiiMatch[] {
+  const matches: PiiMatch[] = [];
+  for (const match of value.matchAll(pattern)) {
+    const capturedValue = match[captureGroup];
+    if (!capturedValue || match.index === undefined) {
+      continue;
+    }
+    const captureOffset = match[0].indexOf(capturedValue);
+    matches.push({
+      start: match.index + captureOffset,
+      end: match.index + captureOffset + capturedValue.length,
+      type,
+      priority,
+    });
+  }
+  return matches;
+}
+
+export function sanitizeErrorDetails(errorMessage: string, agentNames: readonly string[] = []): string {
+  const matches: PiiMatch[] = [
+    ...collectMatches(
+      errorMessage,
+      /[A-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[A-Z0-9-]+(?:\.[A-Z0-9-]+)+/gi,
+      PiiRedactionType.EmailAddress,
+      3,
+    ),
+    ...collectMatches(
+      errorMessage,
+      /[A-Za-z]:[\\/](?:[^\\/\r\n:*?"<>|]+[\\/])*[^\\/\r\n:*?"<>|]+\.mcs\.ya?ml/gi,
+      PiiRedactionType.McsYamlFileName,
+      4,
+    ),
+    ...collectMatches(
+      errorMessage,
+      /\\\\[^\\/\r\n:*?"<>|]+[\\/](?:[^\\/\r\n:*?"<>|]+[\\/])*[^\\/\r\n:*?"<>|]+\.mcs\.ya?ml/gi,
+      PiiRedactionType.McsYamlFileName,
+      4,
+    ),
+    ...collectMatches(
+      errorMessage,
+      /(?:\/[^\/\r\n"'<>|?*]+)+\.mcs\.ya?ml/gi,
+      PiiRedactionType.McsYamlFileName,
+      4,
+    ),
+    ...collectMatches(
+      errorMessage,
+      /(?:[^\s\\/:"'<>|?*]+[\\/])+[^\s\\/:"'<>|?*]+\.mcs\.ya?ml|[^\s\\/:"'<>|?*]+\.mcs\.ya?ml/gi,
+      PiiRedactionType.McsYamlFileName,
+      3,
+    ),
+    ...collectMatches(
+      errorMessage,
+      /"([^"\r\n]*?\.mcs\.ya?ml)"/gi,
+      PiiRedactionType.McsYamlFileName,
+      4,
+      1,
+    ),
+    ...collectMatches(
+      errorMessage,
+      /'([^'\r\n]*?\.mcs\.ya?ml)'/gi,
+      PiiRedactionType.McsYamlFileName,
+      4,
+      1,
+    ),
+  ];
+
+  for (const agentName of agentNames.filter(name => name.length > 0)) {
+    const escapedAgentName = agentName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const agentNamePattern = new RegExp(
+      `(?<![\\p{L}\\p{N}])${escapedAgentName}(?![\\p{L}\\p{N}])`,
+      'giu',
+    );
+    matches.push(...collectMatches(
+      errorMessage,
+      agentNamePattern,
+      PiiRedactionType.AgentName,
+      2,
+    ));
+  }
+
+  const quotedAgentPattern = /\bAgent\s+(?:"([^"\r\n]+)"|'([^'\r\n]+)')/gi;
+  for (const match of errorMessage.matchAll(quotedAgentPattern)) {
+    const agentName = match[1] ?? match[2] ?? match[3];
+    if (!agentName || match.index === undefined) {
+      continue;
+    }
+    const nameOffset = match[0].indexOf(agentName);
+    matches.push({
+      start: match.index + nameOffset,
+      end: match.index + nameOffset + agentName.length,
+      type: PiiRedactionType.AgentName,
+      priority: 1,
+    });
+  }
+
+  const unquotedAgentPattern = /\bAgent\s+([A-Za-z0-9][A-Za-z0-9 _.-]*?)(?=\s+(?:at|was|is|has|had|failed|could|cannot|can't|did|does|will|would|returned|with|from|for|unavailable|rejected)\b)/gi;
+  matches.push(...collectMatches(
+    errorMessage,
+    unquotedAgentPattern,
+    PiiRedactionType.AgentName,
+    1,
+    1,
+  ));
+
+  matches.sort((left, right) =>
+    left.start - right.start
+    || right.priority - left.priority
+    || right.end - right.start - (left.end - left.start));
+
+  let sanitized = '';
+  let cursor = 0;
+  for (const match of matches) {
+    if (match.start < cursor) {
+      continue;
+    }
+    sanitized += errorMessage.slice(cursor, match.start);
+    sanitized += formatPii(errorMessage.slice(match.start, match.end), match.type);
+    cursor = match.end;
+  }
+
+  return sanitized + errorMessage.slice(cursor);
+}
+
+const stripPiiTags = (value: string): string =>
+  value.replace(
+    piiPattern,
+    (_match, _type: string | undefined, encoded: string | undefined, piiValue: string) =>
+      encoded ? decodePiiValue(piiValue) : piiValue,
+  );
+
+const redactPii = (value: string): string =>
+  value.replace(piiPattern, (_match, type: string | undefined) =>
+    type ? `[REDACTED ${type}]` : '[REDACTED]');
 
 export function prepareLogData(message: string | undefined, properties: TelemetryEventProperties): {
   displayMessage: string | undefined;
@@ -138,7 +305,8 @@ const eventCategoryMap: Partial<Record<TelemetryEventType, LogCategory>> = {
  * @remarks
  * - Automatically attaches `sessionId` property to all events, `isError` property to error events, and `isWarning` property to warning events.
  * - Supports sending events with just a name, or with additional message and data.
- * - PII: wrap sensitive content in `<pii>...</pii>` tags for automatic redaction in telemetry.
+ * - PII: use `formatPii` to retain sensitive content in the UI while emitting a descriptive redaction in telemetry.
+ *   Legacy `<pii>...</pii>` tags remain supported and emit `[REDACTED]`.
 */
 class Logger {
   private static instance: Logger;
@@ -187,7 +355,7 @@ class Logger {
    * Sends a telemetry event with the given name, message, and data.
    * Writes to the output channel for diagnostic purposes.
    * If message is provided, shows a message in the VS Code UI based on the log level.
-   * PII in the message should be wrapped in `<pii>...</pii>` tags to ensure it is redacted in telemetry.
+   * PII in the message should be wrapped with `formatPii` to ensure it is redacted in telemetry.
    *
    * @param logLevel - The level of the log (Info, Warning, Error).
    * @param eventName - Telemetry event name.
@@ -237,7 +405,7 @@ class Logger {
   /**
    * Sends a standard telemetry event.
    * If message is provided, shows an information message to users.
-   * PII in the message should be wrapped in `<pii>...</pii>` tags to ensure it is redacted in telemetry.
+   * PII in the message should be wrapped with `formatPii` to ensure it is redacted in telemetry.
    *
    * @param eventName - The name of the telemetry event.
    * @param message - Optional message string to display to the user.
@@ -254,7 +422,7 @@ class Logger {
   /**
    * Sends a warning telemetry event.
    * If message is provided, shows a warning message to users.
-   * PII in the message should be wrapped in `<pii>...</pii>` tags to ensure it is redacted in telemetry.
+   * PII in the message should be wrapped with `formatPii` to ensure it is redacted in telemetry.
    *
    * @param eventName - The name of the telemetry event.
    * @param message - Optional message string to display to the user.
@@ -271,7 +439,7 @@ class Logger {
   /**
 * Sends error-specific telemetry event.
    * If message is provided, shows an error message to users.
-   * PII in the message should be wrapped in `<pii>...</pii>` tags to ensure it is redacted in telemetry.
+   * PII in the message should be wrapped with `formatPii` to ensure it is redacted in telemetry.
    *
    * @param eventName - The name of the telemetry event.
    * @param message - Optional message string to display to the user.

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/services/logger.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/services/logger.ts
@@ -15,6 +15,32 @@ type TelemetryEventProps = {
  */
 type TelemetryEventData = Record<string, string | number | undefined>;
 
+const stripPiiTags = (value: string): string => value.replace(/<pii>(.*?)<\/pii>/gs, '$1');
+const redactPii = (value: string): string => value.replace(/<pii>.*?<\/pii>/gs, '[REDACTED]');
+
+export function prepareLogData(message: string | undefined, properties: TelemetryEventProperties): {
+  displayMessage: string | undefined;
+  telemetryProperties: Record<string, string>;
+} {
+  const displayMessage = message === undefined ? undefined : stripPiiTags(message);
+  const rawMessage = properties.message as string || message;
+  const telemetryProperties: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(properties)) {
+    if (typeof value === 'string') {
+      telemetryProperties[key] = redactPii(value);
+    } else if (value !== undefined) {
+      telemetryProperties[key] = String(value);
+    }
+  }
+
+  if (rawMessage) {
+    telemetryProperties.message = redactPii(rawMessage);
+  }
+
+  return { displayMessage, telemetryProperties };
+}
+
 const NOOP_REPORTER = {
   sendTelemetryEvent: () => { },
   sendTelemetryErrorEvent: () => { },
@@ -175,29 +201,7 @@ class Logger {
     data?: TelemetryEventData
   ) {
     const { properties, measurements } = this.parseData(logLevel, data);
-
-    // A clean version of the message for the user, with PII tags stripped out
-    const displayMessage = message?.replace(/<pii>(.*?)<\/pii>/g, '$1');
-
-    // The message for telemetry with potential PII tags
-    const rawMessage = properties?.message as string || message;
-
-    // Redact all string properties that contain <pii> tags before sending to telemetry
-    const redactedProperties: Record<string, string> = {};
-    if (properties) {
-      for (const [key, value] of Object.entries(properties)) {
-        if (typeof value === 'string') {
-          redactedProperties[key] = value.replace(/<pii>.*?<\/pii>/g, '[REDACTED]');
-        } else if (value !== undefined) {
-          redactedProperties[key] = String(value);
-        }
-      }
-    }
-    // Ensure the message property uses the raw message source for redaction
-    const redactedMessage = rawMessage?.replace(/<pii>.*?<\/pii>/g, '[REDACTED]');
-    const updatedProperties = redactedMessage
-      ? { ...redactedProperties, message: redactedMessage }
-      : redactedProperties;
+    const { displayMessage, telemetryProperties } = prepareLogData(message, properties);
 
     const canSendTelemetry = isTelemetryEnabled();
     this.writeToOutputChannel(logLevel, eventName, displayMessage, properties);
@@ -205,7 +209,7 @@ class Logger {
     switch (logLevel) {
       case LogLevel.Info:
         if (canSendTelemetry) {
-          this.reporter.sendTelemetryEvent(eventName, updatedProperties, measurements);
+          this.reporter.sendTelemetryEvent(eventName, telemetryProperties, measurements);
         }
         if (displayMessage) {
           vscode.window.showInformationMessage(displayMessage);
@@ -213,7 +217,7 @@ class Logger {
         break;
       case LogLevel.Warning:
         if (canSendTelemetry) {
-          this.reporter.sendTelemetryErrorEvent(eventName, updatedProperties, measurements);
+          this.reporter.sendTelemetryErrorEvent(eventName, telemetryProperties, measurements);
         }
         if (displayMessage) {
           vscode.window.showWarningMessage(displayMessage);
@@ -221,7 +225,7 @@ class Logger {
         break;
       case LogLevel.Error:
         if (canSendTelemetry) {
-          this.reporter.sendTelemetryErrorEvent(eventName, updatedProperties, measurements);
+          this.reporter.sendTelemetryErrorEvent(eventName, telemetryProperties, measurements);
         }
         if (displayMessage) {
           vscode.window.showErrorMessage(displayMessage);
@@ -294,7 +298,8 @@ class Logger {
 
     const category = eventCategoryMap[eventName];
 
-    const mainMessage = displayMessage ?? (properties?.['message'] as string | undefined)?.replace(/<pii>(.*?)<\/pii>/g, '$1');
+    const propertyMessage = properties?.['message'] as string | undefined;
+    const mainMessage = displayMessage ?? (propertyMessage ? stripPiiTags(propertyMessage) : undefined);
     if (!mainMessage) {
       return;
     }

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/services/logger.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/services/logger.ts
@@ -20,7 +20,7 @@ export enum PiiRedactionType {
   AgentName = 'AGENT NAME',
   EmailAddress = 'EMAIL ADDRESS',
   FileUri = 'FILE URI',
-  McsYamlFileName = '.MCS.YML FILE NAME',
+  Url = 'URL',
   AiBuilderPromptDetails = 'AI BUILDER PROMPT DETAILS',
   WorkflowErrorDetails = 'WORKFLOW ERROR DETAILS',
   WorkflowNames = 'WORKFLOW NAMES',
@@ -29,7 +29,7 @@ export enum PiiRedactionType {
 interface PiiMatch {
   start: number;
   end: number;
-  type: PiiRedactionType;
+  type: PiiRedactionType | string;
   priority: number;
 }
 
@@ -41,14 +41,37 @@ const encodePiiValue = (value: string): string =>
 const decodePiiValue = (value: string): string =>
   value.replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&amp;/g, '&');
 
-export function formatPii(value: string, type: PiiRedactionType): string {
+export function formatPii(value: string, type: PiiRedactionType | string): string {
   return `<pii type="${type}" encoded="true">${encodePiiValue(value)}</pii>`;
+}
+
+/**
+ * Derives a telemetry redaction label from a file path's extension chain so the
+ * redacted marker discloses the file type without leaking the file name or path.
+ * Examples: "agent.mcs.yml" -> ".MCS.YML FILE NAME", "botdefinition.json" -> ".JSON FILE NAME".
+ * Falls back to "FILE NAME" when no extension is present.
+ */
+function fileExtensionLabel(filePath: string): string {
+  const baseName = filePath.split(/[\\/]/).pop() ?? filePath;
+  const firstDot = baseName.indexOf('.', 1);
+  const extension = (firstDot >= 0 ? baseName.slice(firstDot) : '')
+    .replace(/[^A-Za-z0-9.]/g, '')
+    .toUpperCase();
+  return extension ? `${extension} FILE NAME` : 'FILE NAME';
+}
+
+/**
+ * Wraps a known file path or name so telemetry shows only its extension,
+ * e.g. "[REDACTED .JSON FILE NAME]", while the user still sees the full path.
+ */
+export function formatFileName(filePath: string): string {
+  return formatPii(filePath, fileExtensionLabel(filePath));
 }
 
 function collectMatches(
   value: string,
   pattern: RegExp,
-  type: PiiRedactionType,
+  type: PiiRedactionType | string,
   priority: number,
   captureGroup = 0,
 ): PiiMatch[] {
@@ -69,51 +92,83 @@ function collectMatches(
   return matches;
 }
 
+/**
+ * Like {@link collectMatches}, but derives a per-match redaction label from the
+ * matched file path's extension so telemetry discloses the file type only.
+ */
+function collectFileMatches(
+  value: string,
+  pattern: RegExp,
+  priority: number,
+  captureGroup = 0,
+): PiiMatch[] {
+  const matches: PiiMatch[] = [];
+  for (const match of value.matchAll(pattern)) {
+    const capturedValue = match[captureGroup];
+    if (!capturedValue || match.index === undefined) {
+      continue;
+    }
+    const captureOffset = match[0].indexOf(capturedValue);
+    matches.push({
+      start: match.index + captureOffset,
+      end: match.index + captureOffset + capturedValue.length,
+      type: fileExtensionLabel(capturedValue),
+      priority,
+    });
+  }
+  return matches;
+}
+
 export function sanitizeErrorDetails(errorMessage: string, agentNames: readonly string[] = []): string {
   const matches: PiiMatch[] = [
+    // Full URL (scheme://host/path...). Matched first and whole so a tenant or
+    // Dataverse endpoint is redacted as a URL rather than being partially
+    // consumed and mislabeled as a file name by the path rules below.
+    ...collectMatches(
+      errorMessage,
+      /[A-Za-z][A-Za-z0-9+.-]*:\/\/[^\s<>"'|]+/gi,
+      PiiRedactionType.Url,
+      6,
+    ),
     ...collectMatches(
       errorMessage,
       /[A-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[A-Z0-9-]+(?:\.[A-Z0-9-]+)+/gi,
       PiiRedactionType.EmailAddress,
+      5,
+    ),
+    // Drive-letter path ending in any file name: C:\dir\file.ext
+    // The final file token excludes whitespace so a match stops at the file
+    // name and does not run into following prose ("... for alex@contoso.com").
+    ...collectFileMatches(
+      errorMessage,
+      /[A-Za-z]:[\\/](?:[^\\/\r\n:*?"<>|]+[\\/])*[^\s\\/\r\n:*?"<>|]*\.[A-Za-z0-9]{1,12}/gi,
+      4,
+    ),
+    // UNC path ending in any file name: \\server\share\file.ext
+    ...collectFileMatches(
+      errorMessage,
+      /\\\\[^\\/\r\n:*?"<>|]+[\\/](?:[^\\/\r\n:*?"<>|]+[\\/])*[^\s\\/\r\n:*?"<>|]*\.[A-Za-z0-9]{1,12}/gi,
+      4,
+    ),
+    // POSIX path ending in any file name: /dir/file.ext
+    ...collectFileMatches(
+      errorMessage,
+      /(?:\/[^\/\r\n"'<>|?*]+)*\/[^\s\/\r\n"'<>|?*]*\.[A-Za-z0-9]{1,12}/gi,
+      4,
+    ),
+    // Relative or mixed-separator path ending in any file name: dir\file.ext
+    ...collectFileMatches(
+      errorMessage,
+      /(?:[^\s\\/:"'<>|?*]+[\\/])+[^\s\\/:"'<>|?*]*\.[A-Za-z0-9]{1,12}/gi,
+      4,
+    ),
+    // Bare file name (no path). Each extension segment must be letter-initial and
+    // at least two characters, so version numbers ("1.2.3") and abbreviations
+    // ("e.g.", "U.S.A") are not mistaken for file names.
+    ...collectFileMatches(
+      errorMessage,
+      /[A-Za-z0-9_-]+(?:\.[A-Za-z][A-Za-z0-9]{1,11})+/gi,
       3,
-    ),
-    ...collectMatches(
-      errorMessage,
-      /[A-Za-z]:[\\/](?:[^\\/\r\n:*?"<>|]+[\\/])*[^\\/\r\n:*?"<>|]+\.mcs\.ya?ml/gi,
-      PiiRedactionType.McsYamlFileName,
-      4,
-    ),
-    ...collectMatches(
-      errorMessage,
-      /\\\\[^\\/\r\n:*?"<>|]+[\\/](?:[^\\/\r\n:*?"<>|]+[\\/])*[^\\/\r\n:*?"<>|]+\.mcs\.ya?ml/gi,
-      PiiRedactionType.McsYamlFileName,
-      4,
-    ),
-    ...collectMatches(
-      errorMessage,
-      /(?:\/[^\/\r\n"'<>|?*]+)+\.mcs\.ya?ml/gi,
-      PiiRedactionType.McsYamlFileName,
-      4,
-    ),
-    ...collectMatches(
-      errorMessage,
-      /(?:[^\s\\/:"'<>|?*]+[\\/])+[^\s\\/:"'<>|?*]+\.mcs\.ya?ml|[^\s\\/:"'<>|?*]+\.mcs\.ya?ml/gi,
-      PiiRedactionType.McsYamlFileName,
-      3,
-    ),
-    ...collectMatches(
-      errorMessage,
-      /"([^"\r\n]*?\.mcs\.ya?ml)"/gi,
-      PiiRedactionType.McsYamlFileName,
-      4,
-      1,
-    ),
-    ...collectMatches(
-      errorMessage,
-      /'([^'\r\n]*?\.mcs\.ya?ml)'/gi,
-      PiiRedactionType.McsYamlFileName,
-      4,
-      1,
     ),
   ];
 
@@ -130,30 +185,6 @@ export function sanitizeErrorDetails(errorMessage: string, agentNames: readonly 
       2,
     ));
   }
-
-  const quotedAgentPattern = /\bAgent\s+(?:"([^"\r\n]+)"|'([^'\r\n]+)')/gi;
-  for (const match of errorMessage.matchAll(quotedAgentPattern)) {
-    const agentName = match[1] ?? match[2] ?? match[3];
-    if (!agentName || match.index === undefined) {
-      continue;
-    }
-    const nameOffset = match[0].indexOf(agentName);
-    matches.push({
-      start: match.index + nameOffset,
-      end: match.index + nameOffset + agentName.length,
-      type: PiiRedactionType.AgentName,
-      priority: 1,
-    });
-  }
-
-  const unquotedAgentPattern = /\bAgent\s+([A-Za-z0-9][A-Za-z0-9 _.-]*?)(?=\s+(?:at|was|is|has|had|failed|could|cannot|can't|did|does|will|would|returned|with|from|for|unavailable|rejected)\b)/gi;
-  matches.push(...collectMatches(
-    errorMessage,
-    unquotedAgentPattern,
-    PiiRedactionType.AgentName,
-    1,
-    1,
-  ));
 
   matches.sort((left, right) =>
     left.start - right.start

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/services/lspClient.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/services/lspClient.ts
@@ -9,7 +9,7 @@ import { getSolutionVersionsAsync } from '../clients/dataverseClient';
 import { getClusterCategory } from '../utils/genericUtils';
 import { onWorkspaceChange } from '../sync/workspaceScm';
 import { isTelemetryEnabled } from './telemetry';
-import logger from './logger';
+import logger, { sanitizeErrorDetails } from './logger';
 
 let currentContext: vscode.ExtensionContext | null = null;
 let currentOutputChannel: vscode.OutputChannel | null = null;
@@ -76,7 +76,10 @@ class LspClientService {
       const response = spawnSync('chmod', ['+x', lspHostPath]);
       if (response.status !== 0) {
         const errorMessage = new TextDecoder().decode(response.stderr);
-        logger.logError(TelemetryEventsKeys.UnixPlatformError, `<pii>${errorMessage}</pii>`);
+        logger.logError(
+          TelemetryEventsKeys.UnixPlatformError,
+          sanitizeErrorDetails(errorMessage),
+        );
       }
     }
 
@@ -141,7 +144,7 @@ class LspClientService {
           } catch (error) {
             const errorMessage = error instanceof Error ? error.message : String(error);
             logger.logError(TelemetryEventsKeys.LanguageServerError, undefined, {
-              message: `Diagnostics error: <pii>${errorMessage}</pii>`,
+              message: `Diagnostics error: ${sanitizeErrorDetails(errorMessage)}`,
             });
             throw error;
           }
@@ -166,7 +169,7 @@ class LspClientService {
           } catch (error) {
             const errorMessage = error instanceof Error ? error.message : String(error);
             logger.logError(TelemetryEventsKeys.LanguageServerError, undefined, {
-              message: `Notification ${telemetryMethod} failed: <pii>${errorMessage}</pii>`,
+              message: `Notification ${telemetryMethod} failed: ${sanitizeErrorDetails(errorMessage)}`,
             });
             throw error;
           }
@@ -196,7 +199,7 @@ class LspClientService {
           } catch (error) {
             const errorMessage = error instanceof Error ? error.message : String(error);
             logger.logError(TelemetryEventsKeys.LanguageServerError, undefined, {
-              message: `Request ${telemetryMethod} failed: <pii>${errorMessage}</pii>`
+              message: `Request ${telemetryMethod} failed: ${sanitizeErrorDetails(errorMessage)}`
             });
             throw error;
           }
@@ -266,7 +269,10 @@ class LspClientService {
       context.subscriptions.push(this._client);
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
-      logger.logError(TelemetryEventsKeys.LanguageServerError, `Copilot Studio Language Server failed to start: <pii>${errorMessage}</pii>`);
+      logger.logError(
+        TelemetryEventsKeys.LanguageServerError,
+        `Copilot Studio Language Server failed to start: ${sanitizeErrorDetails(errorMessage)}`,
+      );
       throw error;
     }
   }

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/services/lspClient.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/services/lspClient.ts
@@ -76,7 +76,7 @@ class LspClientService {
       const response = spawnSync('chmod', ['+x', lspHostPath]);
       if (response.status !== 0) {
         const errorMessage = new TextDecoder().decode(response.stderr);
-        logger.logError(TelemetryEventsKeys.UnixPlatformError, errorMessage);
+        logger.logError(TelemetryEventsKeys.UnixPlatformError, `<pii>${errorMessage}</pii>`);
       }
     }
 
@@ -139,8 +139,9 @@ class LspClientService {
           try {
             next(uri, diagnostics);
           } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
             logger.logError(TelemetryEventsKeys.LanguageServerError, undefined, {
-              message: `Diagnostics error: ${(error as Error).message}`,
+              message: `Diagnostics error: <pii>${errorMessage}</pii>`,
             });
             throw error;
           }
@@ -163,8 +164,9 @@ class LspClientService {
               });
             }
           } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
             logger.logError(TelemetryEventsKeys.LanguageServerError, undefined, {
-              message: `Notification ${telemetryMethod} failed: ${(error as Error).message}`,
+              message: `Notification ${telemetryMethod} failed: <pii>${errorMessage}</pii>`,
             });
             throw error;
           }
@@ -192,8 +194,9 @@ class LspClientService {
               return result;
             }
           } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
             logger.logError(TelemetryEventsKeys.LanguageServerError, undefined, {
-              message: `Request ${telemetryMethod} failed: ${(error as Error).message}`
+              message: `Request ${telemetryMethod} failed: <pii>${errorMessage}</pii>`
             });
             throw error;
           }
@@ -262,7 +265,8 @@ class LspClientService {
 
       context.subscriptions.push(this._client);
     } catch (error) {
-      logger.logError(TelemetryEventsKeys.LanguageServerError, `Copilot Studio Language Server failed to start: ${(error as Error).message}`);
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      logger.logError(TelemetryEventsKeys.LanguageServerError, `Copilot Studio Language Server failed to start: <pii>${errorMessage}</pii>`);
       throw error;
     }
   }

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/sync/originalFileSystem.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/sync/originalFileSystem.ts
@@ -3,7 +3,7 @@ import { GetFileRequest, GetFileResponse } from "../types";
 import { getWorkspaceByUri } from "./localWorkspaces";
 import { lspClient } from "../services/lspClient";
 import { LspMethods, TelemetryEventsKeys } from "../constants";
-import logger from "../services/logger";
+import logger, { formatPii, PiiRedactionType, sanitizeErrorDetails } from "../services/logger";
 
 export const LOCAL_STATE_SCHEME = "mcs";
 
@@ -23,14 +23,16 @@ export class OriginalFileSystem implements FileSystemProvider {
     }
 
     async readFile(uri: Uri): Promise<Uint8Array> {
+        let agentName: string | undefined;
         try {
             const workspace = getWorkspaceByUri(uri);
             if (!workspace) {
                 logger.logError(TelemetryEventsKeys.GetLocalFileError, undefined, {
-                    message: `Error fetching file: could not locate workspace for file <pii>${uri}</pii>`
+                    message: `Error fetching file: could not locate workspace for file ${formatPii(String(uri), PiiRedactionType.FileUri)}`
                 });
                 return new Uint8Array();
             }
+            agentName = workspace.displayName;
 
             const { workspaceUri } = workspace;
             let schemaName = uri.path.substring(1); // remove leading slash
@@ -44,7 +46,10 @@ export class OriginalFileSystem implements FileSystemProvider {
             return Buffer.from(result.content ?? '', 'utf8');
         } catch (error) {
             const errorMessage = error instanceof Error ? error.message : String(error);
-            logger.logError(TelemetryEventsKeys.GetLocalFileError, `Error fetching file: <pii>${errorMessage}</pii>`);
+            logger.logError(
+                TelemetryEventsKeys.GetLocalFileError,
+                `Error fetching file: ${sanitizeErrorDetails(errorMessage, agentName ? [agentName] : [])}`,
+            );
             return new Uint8Array();
         }
     }

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/sync/originalFileSystem.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/sync/originalFileSystem.ts
@@ -43,7 +43,8 @@ export class OriginalFileSystem implements FileSystemProvider {
 
             return Buffer.from(result.content ?? '', 'utf8');
         } catch (error) {
-            logger.logError(TelemetryEventsKeys.GetLocalFileError, `Error fetching file: ${(error as Error).message}`);
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            logger.logError(TelemetryEventsKeys.GetLocalFileError, `Error fetching file: <pii>${errorMessage}</pii>`);
             return new Uint8Array();
         }
     }

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/sync/originalState.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/sync/originalState.ts
@@ -3,7 +3,7 @@ import { getWorkspaceByUri } from "./localWorkspaces";
 import { lspClient } from "../services/lspClient";
 import { LspMethods, TelemetryEventsKeys } from "../constants";
 import { GetFileRequest, GetFileResponse } from "../types";
-import logger from "../services/logger";
+import logger, { formatPii, PiiRedactionType, sanitizeErrorDetails } from "../services/logger";
 
 export const LOCAL_STATE_SCHEME = 'mcs';
 
@@ -24,7 +24,9 @@ async function retrieveLastSyncedFile(uri: Uri): Promise<string | null> {
 
   const workspace = getWorkspaceByUri(uri);
   if (!workspace) {
-    logger.logError(TelemetryEventsKeys.GetLocalFileError, undefined, { message: `Error retrieving file: could not locate workspace for file <pii>${uri}</pii>` });
+    logger.logError(TelemetryEventsKeys.GetLocalFileError, undefined, {
+      message: `Error retrieving file: could not locate workspace for file ${formatPii(String(uri), PiiRedactionType.FileUri)}`,
+    });
     return null;
   }
 
@@ -38,7 +40,10 @@ async function retrieveLastSyncedFile(uri: Uri): Promise<string | null> {
     return result.content;
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
-    logger.logError(TelemetryEventsKeys.GetLocalFileError, `Error retrieving file: <pii>${errorMessage}</pii>`);
+    logger.logError(
+      TelemetryEventsKeys.GetLocalFileError,
+      `Error retrieving file: ${sanitizeErrorDetails(errorMessage, [workspace.displayName])}`,
+    );
     return null;
   }
 }

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/sync/originalState.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/sync/originalState.ts
@@ -37,7 +37,8 @@ async function retrieveLastSyncedFile(uri: Uri): Promise<string | null> {
     const result = await lspClient.sendRequest<GetFileResponse>(LspMethods.GET_CACHED_FILE, request);
     return result.content;
   } catch (error) {
-    logger.logError(TelemetryEventsKeys.GetLocalFileError, `Error retrieving file: ${(error as Error).message}`);
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    logger.logError(TelemetryEventsKeys.GetLocalFileError, `Error retrieving file: <pii>${errorMessage}</pii>`);
     return null;
   }
 }

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/sync/remoteFileSystem.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/sync/remoteFileSystem.ts
@@ -55,7 +55,8 @@ export class RemoteFileSystem implements FileSystemProvider {
             const result = await lspClient.sendRequest<GetFileResponse>(LspMethods.GET_REMOTE_FILE, request);
             return Buffer.from(result.content ?? '', 'utf8');
         } catch (error) {
-            logger.logError(TelemetryEventsKeys.GetRemoteFileError, `Error fetching file: ${(error as Error).message}`);
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            logger.logError(TelemetryEventsKeys.GetRemoteFileError, `Error fetching file: <pii>${errorMessage}</pii>`);
             return new Uint8Array();
         }
     }

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/sync/remoteFileSystem.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/sync/remoteFileSystem.ts
@@ -3,7 +3,7 @@ import { RemoteFileRequest, GetFileResponse } from '../types';
 import { findWorkspaceForUri, tryRepairAgentManagementEndpoint } from './localWorkspaces';
 import { lspClient, buildLspRequestPayload } from "../services/lspClient";
 import { LspMethods, TelemetryEventsKeys } from "../constants";
-import logger from "../services/logger";
+import logger, { formatPii, PiiRedactionType, sanitizeErrorDetails } from "../services/logger";
 
 export const REMOTE_STATE_SCHEME = 'mcs-remote';
 
@@ -23,12 +23,16 @@ export class RemoteFileSystem implements FileSystemProvider {
     }
 
     async readFile(uri: Uri): Promise<Uint8Array> {
+        let agentName: string | undefined;
         try {
             const workspace = findWorkspaceForUri(uri.query);
             if (!workspace) {
-                logger.logError(TelemetryEventsKeys.GetRemoteFileError, undefined, { message: `Error fetching file: could not locate workspace for file <pii>${uri}</pii>` });                
+                logger.logError(TelemetryEventsKeys.GetRemoteFileError, undefined, {
+                    message: `Error fetching file: could not locate workspace for file ${formatPii(String(uri), PiiRedactionType.FileUri)}`,
+                });
                 return new Uint8Array();
             }
+            agentName = workspace.displayName;
 
             const { syncInfo, workspaceUri } = workspace;
             if (!syncInfo) {
@@ -56,7 +60,10 @@ export class RemoteFileSystem implements FileSystemProvider {
             return Buffer.from(result.content ?? '', 'utf8');
         } catch (error) {
             const errorMessage = error instanceof Error ? error.message : String(error);
-            logger.logError(TelemetryEventsKeys.GetRemoteFileError, `Error fetching file: <pii>${errorMessage}</pii>`);
+            logger.logError(
+                TelemetryEventsKeys.GetRemoteFileError,
+                `Error fetching file: ${sanitizeErrorDetails(errorMessage, agentName ? [agentName] : [])}`,
+            );
             return new Uint8Array();
         }
     }

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/sync/remoteState.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/sync/remoteState.ts
@@ -4,7 +4,7 @@ import { RemoteFileRequest, GetFileResponse } from '../types';
 import { findWorkspaceForUri } from './localWorkspaces';
 import { lspClient, buildLspRequestPayload } from "../services/lspClient";
 import { LspMethods, TelemetryEventsKeys } from "../constants";
-import logger from "../services/logger";
+import logger, { formatPii, PiiRedactionType, sanitizeErrorDetails } from "../services/logger";
 
 export const REMOTE_STATE_SCHEME = 'mcs-remote';
 
@@ -25,7 +25,9 @@ export function initializeRemoteCacheDocumentContentProvider(context: ExtensionC
 async function getRemoteFileContent(uri: Uri): Promise<string | null> {
   const workspace = findWorkspaceForUri(uri.query);
   if (!workspace) {
-    logger.logError(TelemetryEventsKeys.GetRemoteFileError, undefined, { message: `Error fetching file: could not locate workspace for file <pii>${uri}</pii>` });
+    logger.logError(TelemetryEventsKeys.GetRemoteFileError, undefined, {
+      message: `Error fetching file: could not locate workspace for file ${formatPii(String(uri), PiiRedactionType.FileUri)}`,
+    });
     return null;
   }
 
@@ -52,7 +54,10 @@ async function getRemoteFileContent(uri: Uri): Promise<string | null> {
     return result.content;
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
-    logger.logError(TelemetryEventsKeys.GetRemoteFileError, `Error fetching file: <pii>${errorMessage}</pii>`);
+    logger.logError(
+      TelemetryEventsKeys.GetRemoteFileError,
+      `Error fetching file: ${sanitizeErrorDetails(errorMessage, [workspace.displayName])}`,
+    );
     return null;
   }
 }

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/sync/remoteState.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/sync/remoteState.ts
@@ -51,7 +51,8 @@ async function getRemoteFileContent(uri: Uri): Promise<string | null> {
     const result = await lspClient.sendRequest<GetFileResponse>(LspMethods.GET_REMOTE_FILE, request);
     return result.content;
   } catch (error) {
-    logger.logError(TelemetryEventsKeys.GetRemoteFileError, `Error fetching file: ${(error as Error).message}`);
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    logger.logError(TelemetryEventsKeys.GetRemoteFileError, `Error fetching file: <pii>${errorMessage}</pii>`);
     return null;
   }
 }

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/sync/workspaceScm.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/sync/workspaceScm.ts
@@ -9,7 +9,7 @@ import { registerVirtualKnowledgeProvider } from "../knowledgeFiles/virtualKnowl
 import { lspClient, buildLspRequestPayload } from '../services/lspClient';
 import { isChildUri, isSameUri } from "../utils/genericUtils";
 import { LspMethods, TelemetryEventsKeys } from "../constants";
-import logger from "../services/logger";
+import logger, { sanitizeErrorDetails } from "../services/logger";
 import { refreshAgentChangesTree } from "./agentChangesTreeProvider";
 
 interface WorkspaceScm {
@@ -75,7 +75,7 @@ export function onWorkspaceChange(uri: string): void {
         .then(() => refreshAgentChangesTree())
         .catch(err => {
           logger.logError(TelemetryEventsKeys.SyncWorkspaceError, undefined, {
-            message: `onLocalChange failed: <pii>${err instanceof Error ? err.message : String(err)}</pii>`
+            message: `onLocalChange failed: ${sanitizeErrorDetails(err instanceof Error ? err.message : String(err), [scm.workspace.displayName])}`
           });
         });
       return;
@@ -121,7 +121,7 @@ export function initializeWorkspaceScm(context: ExtensionContext) {
 
 export async function refreshWorkspaces(workspaces: CopilotStudioWorkspace[], context: ExtensionContext) {
   const desiredUris = new Set(workspaces.map(w => w.workspaceUri));
-  const newPromises: Promise<void>[] = [];
+  const newSetups: { promise: Promise<void>; agentName: string }[] = [];
   // Precompute connection file availability (case-insensitive path on Windows)
   const eligibility = workspaces.map(ws => ({
     ws,
@@ -151,19 +151,19 @@ export async function refreshWorkspaces(workspaces: CopilotStudioWorkspace[], co
           }
         })();
         workspaceSetupPromises.set(uri, setupPromise);
-        newPromises.push(setupPromise);
+        newSetups.push({ promise: setupPromise, agentName: ws.displayName });
     }
   }
 
-  if (newPromises.length) {
-    // await on newPromises rather than all workspaceSetupPromises to make this independent of other refreshWorkspaces calls.
+  if (newSetups.length) {
+    // Await only the new setups to keep this independent of other refreshWorkspaces calls.
     // we might wish to change this in the future if we want to ensure all workspaces are fully initialized before any refresh completes.
-    const results = await Promise.allSettled(newPromises);
-    for (const r of results) {
+    const results = await Promise.allSettled(newSetups.map(setup => setup.promise));
+    for (const [index, r] of results.entries()) {
       if (r.status === 'rejected') {
         const reason = r.reason instanceof Error ? r.reason.message : String(r.reason);
         logger.logError(TelemetryEventsKeys.SyncWorkspaceError, undefined, {
-          message: `Workspace setup failed: <pii>${reason}</pii>`
+          message: `Workspace setup failed: ${sanitizeErrorDetails(reason, [newSetups[index].agentName])}`
         });
       }
     }
@@ -340,7 +340,7 @@ async function setupChangeTracking(ws: CopilotStudioWorkspace, context: Extensio
         setLocalChanges(generalChanges);
       } catch (e) {
         logger.logError(TelemetryEventsKeys.SyncWorkspaceError, undefined, {
-          message: `onLocalChangeError: <pii>${e instanceof Error ? e.message : String(e)}</pii>`
+          message: `onLocalChangeError: ${sanitizeErrorDetails(e instanceof Error ? e.message : String(e), [ws.displayName])}`
         });
         throw e;
       }
@@ -371,7 +371,7 @@ async function setupChangeTracking(ws: CopilotStudioWorkspace, context: Extensio
         } catch (e) {
           if (remoteHadSuccess) {
             logger.logError(TelemetryEventsKeys.SyncWorkspaceError, undefined, {
-              message: `onRemoteChangeErrorAfterSuccess: <pii>${e instanceof Error ? e.message : String(e)}</pii>`
+              message: `onRemoteChangeErrorAfterSuccess: ${sanitizeErrorDetails(e instanceof Error ? e.message : String(e), [ws.displayName])}`
             });
           }
           // Swallow to avoid aborting setup; remote can retry later.
@@ -434,7 +434,7 @@ async function setupChangeTracking(ws: CopilotStudioWorkspace, context: Extensio
   return result;
   } catch (e) {
     logger.logError(TelemetryEventsKeys.SyncWorkspaceError, undefined, {
-      message: `setupChangeTrackingRejected: <pii>${e instanceof Error ? e.message : String(e)}</pii>`
+      message: `setupChangeTrackingRejected: ${sanitizeErrorDetails(e instanceof Error ? e.message : String(e), [ws.displayName])}`
     });
     // Dispose any partially created resources
     try {

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/sync/workspaceScm.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/sync/workspaceScm.ts
@@ -75,7 +75,7 @@ export function onWorkspaceChange(uri: string): void {
         .then(() => refreshAgentChangesTree())
         .catch(err => {
           logger.logError(TelemetryEventsKeys.SyncWorkspaceError, undefined, {
-            message: `onLocalChange failed: ${(err as Error).message}`
+            message: `onLocalChange failed: <pii>${err instanceof Error ? err.message : String(err)}</pii>`
           });
         });
       return;
@@ -163,7 +163,7 @@ export async function refreshWorkspaces(workspaces: CopilotStudioWorkspace[], co
       if (r.status === 'rejected') {
         const reason = r.reason instanceof Error ? r.reason.message : String(r.reason);
         logger.logError(TelemetryEventsKeys.SyncWorkspaceError, undefined, {
-          message: `Workspace setup failed: ${reason}`
+          message: `Workspace setup failed: <pii>${reason}</pii>`
         });
       }
     }
@@ -340,7 +340,7 @@ async function setupChangeTracking(ws: CopilotStudioWorkspace, context: Extensio
         setLocalChanges(generalChanges);
       } catch (e) {
         logger.logError(TelemetryEventsKeys.SyncWorkspaceError, undefined, {
-          message: `onLocalChangeError: ${e instanceof Error ? e.message : String(e)}`
+          message: `onLocalChangeError: <pii>${e instanceof Error ? e.message : String(e)}</pii>`
         });
         throw e;
       }
@@ -371,7 +371,7 @@ async function setupChangeTracking(ws: CopilotStudioWorkspace, context: Extensio
         } catch (e) {
           if (remoteHadSuccess) {
             logger.logError(TelemetryEventsKeys.SyncWorkspaceError, undefined, {
-              message: `onRemoteChangeErrorAfterSuccess: ${e instanceof Error ? e.message : String(e)}`
+              message: `onRemoteChangeErrorAfterSuccess: <pii>${e instanceof Error ? e.message : String(e)}</pii>`
             });
           }
           // Swallow to avoid aborting setup; remote can retry later.
@@ -434,7 +434,7 @@ async function setupChangeTracking(ws: CopilotStudioWorkspace, context: Extensio
   return result;
   } catch (e) {
     logger.logError(TelemetryEventsKeys.SyncWorkspaceError, undefined, {
-      message: `setupChangeTrackingRejected: ${e instanceof Error ? e.message : String(e)}`
+      message: `setupChangeTrackingRejected: <pii>${e instanceof Error ? e.message : String(e)}</pii>`
     });
     // Dispose any partially created resources
     try {

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/sync/workspaceSynchronizer.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/sync/workspaceSynchronizer.ts
@@ -7,7 +7,7 @@ import { virtualKnowledgeFileSystemProvider } from '../knowledgeFiles/virtualKno
 import { knowledgeTreeDataProvider } from '../knowledgeFiles/knowledgeFileTree';
 import { LspMethods, TelemetryEventsKeys } from '../constants';
 import { lspClient, buildLspRequestPayload } from '../services/lspClient';
-import logger from '../services/logger';
+import logger, { formatPii, PiiRedactionType, sanitizeErrorDetails } from '../services/logger';
 
 let treeDataProvider: knowledgeTreeDataProvider | undefined;
 
@@ -84,11 +84,16 @@ interface SyncStateListener {
   (state: SyncState): void | Promise<void>;
 }
 
+export function formatReauthenticationError(error: unknown, agentName?: string): string {
+  const errorMessage = error instanceof Error ? error.message : String(error);
+  return `Re-authentication failed: ${sanitizeErrorDetails(errorMessage, agentName ? [agentName] : [])}`;
+}
+
 export function createSyncSuccessLog(agentName: string, operation: string, durationMs: number): {
   message: string;
   data: { agent: string; operation: string; durationMs: number };
 } {
-  const protectedAgentName = `<pii>${agentName}</pii>`;
+  const protectedAgentName = formatPii(agentName, PiiRedactionType.AgentName);
   return {
     message: `Completed ${operation} for ${protectedAgentName} in ${durationMs}ms`,
     data: {
@@ -124,7 +129,7 @@ function getSynchronizer(ws: CopilotStudioWorkspace): WorkspaceSynchronizer {
     for (const result of results) {
       if (result.status === 'rejected') {
         logger.logError(TelemetryEventsKeys.SyncWorkspaceError, undefined, {
-          message: `syncStateListenerError: <pii>${result.reason instanceof Error ? result.reason.message : String(result.reason)}</pii>`
+          message: `syncStateListenerError: ${sanitizeErrorDetails(result.reason instanceof Error ? result.reason.message : String(result.reason), [ws.displayName])}`
         });
       }
     }
@@ -233,20 +238,28 @@ export async function sync(workspace: CopilotStudioWorkspace, displayText: strin
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     if (retryOnUserNotMember && errorMessage.includes("UserNotMemberOfOrg")) {
-      logger.logError(TelemetryEventsKeys.SyncWorkspaceError, `Your current account does not have permission. Please sign in with the account <pii>(${accountInfo.accountEmail ?? accountInfo.accountId})</pii> to perform this operation.`);
+      const accountIdentifier = `(${accountInfo.accountEmail ?? accountInfo.accountId})`;
+      logger.logError(
+        TelemetryEventsKeys.SyncWorkspaceError,
+        `Your current account does not have permission. Please sign in with the account ${formatPii(accountIdentifier, PiiRedactionType.AccountIdentifier)} to perform this operation.`,
+      );
       try {
         resetAccount();
         return await sync(workspace, displayText, methodName, silent, suppressErrorNotification, suppressDisabledWorkflowWarnings, draftConnectionReferenceWorkflows, false);
       } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        logger.logError(TelemetryEventsKeys.SyncWorkspaceError, `Re-authentication failed: <pii>${errorMessage}</pii>`);
+        logger.logError(TelemetryEventsKeys.SyncWorkspaceError, formatReauthenticationError(error, workspace.displayName));
         throw error;
       }
     } else if (suppressErrorNotification) {
-      logger.logError(TelemetryEventsKeys.SyncWorkspaceError, undefined, { message: `Error ${displayText}: <pii>${errorMessage}</pii>` });
+      logger.logError(TelemetryEventsKeys.SyncWorkspaceError, undefined, {
+        message: `Error ${displayText}: ${sanitizeErrorDetails(errorMessage, [workspace.displayName])}`,
+      });
       throw error;
     } else {
-      logger.logError(TelemetryEventsKeys.SyncWorkspaceError, `Error ${displayText}: <pii>${errorMessage}</pii>`);
+      logger.logError(
+        TelemetryEventsKeys.SyncWorkspaceError,
+        `Error ${displayText}: ${sanitizeErrorDetails(errorMessage, [workspace.displayName])}`,
+      );
       throw error;
     }
   }
@@ -270,11 +283,17 @@ export function logWorkflowIssues(workflows: WorkflowResponse[] | undefined, sup
   }
 
   if (!suppressDisabledWarnings && disabledWorkflows.length > 0) {
-    logger.logWarning(TelemetryEventsKeys.SyncWorkspaceError, `These workflows are disabled. Bind their connections, then enable them from the connection manager: <pii>${disabledWorkflows.join(", ")}</pii>`);
+    logger.logWarning(
+      TelemetryEventsKeys.SyncWorkspaceError,
+      `These workflows are disabled. Bind their connections, then enable them from the connection manager: ${formatPii(disabledWorkflows.join(", "), PiiRedactionType.WorkflowNames)}`,
+    );
   }
 
   if (failedWorkflows.length > 0) {
-    logger.logError(TelemetryEventsKeys.SyncWorkspaceError, `Workflow errors: <pii>${failedWorkflows.join(", ")}</pii>`);
+    logger.logError(
+      TelemetryEventsKeys.SyncWorkspaceError,
+      `Workflow errors: ${formatPii(failedWorkflows.join(", "), PiiRedactionType.WorkflowErrorDetails)}`,
+    );
     return true;
   }
 
@@ -296,7 +315,7 @@ export function logAIPromptIssues(prompts: AIPromptResponse[] | undefined) {
   if (failed.length > 0) {
     logger.logError(
       TelemetryEventsKeys.SyncWorkspaceError,
-      `Failed to push AI Builder prompt(s): <pii>${failed.join('; ')}</pii>`
+      `Failed to push AI Builder prompt(s): ${formatPii(failed.join('; '), PiiRedactionType.AiBuilderPromptDetails)}`
     );
   }
 }

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/sync/workspaceSynchronizer.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/sync/workspaceSynchronizer.ts
@@ -84,6 +84,21 @@ interface SyncStateListener {
   (state: SyncState): void | Promise<void>;
 }
 
+export function createSyncSuccessLog(agentName: string, operation: string, durationMs: number): {
+  message: string;
+  data: { agent: string; operation: string; durationMs: number };
+} {
+  const protectedAgentName = `<pii>${agentName}</pii>`;
+  return {
+    message: `Completed ${operation} for ${protectedAgentName} in ${durationMs}ms`,
+    data: {
+      agent: protectedAgentName,
+      operation,
+      durationMs,
+    },
+  };
+}
+
 export function getOrAddSynchronizer(ws: CopilotStudioWorkspace): WorkspaceSynchronizer {
   const uri = ws.workspaceUri.toString();
   if (map.has(uri)) {
@@ -109,7 +124,7 @@ function getSynchronizer(ws: CopilotStudioWorkspace): WorkspaceSynchronizer {
     for (const result of results) {
       if (result.status === 'rejected') {
         logger.logError(TelemetryEventsKeys.SyncWorkspaceError, undefined, {
-          message: `syncStateListenerError: ${result.reason instanceof Error ? result.reason.message : String(result.reason)}`
+          message: `syncStateListenerError: <pii>${result.reason instanceof Error ? result.reason.message : String(result.reason)}</pii>`
         });
       }
     }
@@ -210,29 +225,28 @@ export async function sync(workspace: CopilotStudioWorkspace, displayText: strin
     const durationMs = Date.now() - startTime;
     const workflowErrorsFound = logWorkflowIssues(result.workflowResponse, suppressDisabledWorkflowWarnings);
     if (!workflowErrorsFound) {
-      logger.logInfo(TelemetryEventsKeys.SyncWorkspaceSuccess, `Completed ${displayText} for ${workspace.displayName} in ${durationMs}ms`, {
-        agent: workspace.displayName,
-        operation: displayText,
-        durationMs,
-      });
+      const successLog = createSyncSuccessLog(workspace.displayName, displayText, durationMs);
+      logger.logInfo(TelemetryEventsKeys.SyncWorkspaceSuccess, successLog.message, successLog.data);
     }
     logAIPromptIssues(result.aiPromptResponse);
     return result;
   } catch (error) {
-    if (retryOnUserNotMember && (error as Error).message?.includes("UserNotMemberOfOrg")) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    if (retryOnUserNotMember && errorMessage.includes("UserNotMemberOfOrg")) {
       logger.logError(TelemetryEventsKeys.SyncWorkspaceError, `Your current account does not have permission. Please sign in with the account <pii>(${accountInfo.accountEmail ?? accountInfo.accountId})</pii> to perform this operation.`);
       try {
         resetAccount();
         return await sync(workspace, displayText, methodName, silent, suppressErrorNotification, suppressDisabledWorkflowWarnings, draftConnectionReferenceWorkflows, false);
       } catch (error) {
-        logger.logError(TelemetryEventsKeys.SyncWorkspaceError, `Re-authentication failed: ${(error as Error).message}`);
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        logger.logError(TelemetryEventsKeys.SyncWorkspaceError, `Re-authentication failed: <pii>${errorMessage}</pii>`);
         throw error;
       }
     } else if (suppressErrorNotification) {
-      logger.logError(TelemetryEventsKeys.SyncWorkspaceError, undefined, { message: `Error ${displayText}: <pii>${(error as Error).message}</pii>` });
+      logger.logError(TelemetryEventsKeys.SyncWorkspaceError, undefined, { message: `Error ${displayText}: <pii>${errorMessage}</pii>` });
       throw error;
     } else {
-      logger.logError(TelemetryEventsKeys.SyncWorkspaceError, `Error ${displayText}: ${(error as Error).message}`);
+      logger.logError(TelemetryEventsKeys.SyncWorkspaceError, `Error ${displayText}: <pii>${errorMessage}</pii>`);
       throw error;
     }
   }
@@ -282,7 +296,7 @@ export function logAIPromptIssues(prompts: AIPromptResponse[] | undefined) {
   if (failed.length > 0) {
     logger.logError(
       TelemetryEventsKeys.SyncWorkspaceError,
-      `Failed to push AI Builder prompt(s): ${failed.join('; ')}`
+      `Failed to push AI Builder prompt(s): <pii>${failed.join('; ')}</pii>`
     );
   }
 }

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/tests/host/workspaceSynchronizer.test.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/tests/host/workspaceSynchronizer.test.ts
@@ -2,6 +2,7 @@ import * as assert from 'node:assert';
 import { describe, test } from 'node:test';
 import {
 	createSyncSuccessLog,
+	formatReauthenticationError,
 	getActiveSyncUri,
 	getSyncStateFor,
 	logWorkflowIssues,
@@ -9,7 +10,8 @@ import {
 	SyncState,
 	withSyncCommandBusy,
 } from '../../sync/workspaceSynchronizer';
-import logger, { prepareLogData } from '../../services/logger';
+import { formatOpenFileError } from '../../commands/syncWorkspace';
+import logger, { prepareLogData, sanitizeErrorDetails } from '../../services/logger';
 import type { WorkflowResponse } from '../../types';
 
 describe('workspaceSynchronizer: sync success telemetry', () => {
@@ -23,9 +25,158 @@ describe('workspaceSynchronizer: sync success telemetry', () => {
 		});
 
 		assert.strictEqual(prepared.displayMessage, 'Completed applying changes for Contoso Support in 42ms');
-		assert.strictEqual(prepared.telemetryProperties.message, 'Completed applying changes for [REDACTED] in 42ms');
-		assert.strictEqual(prepared.telemetryProperties.agent, '[REDACTED]');
+		assert.strictEqual(prepared.telemetryProperties.message, 'Completed applying changes for [REDACTED AGENT NAME] in 42ms');
+		assert.strictEqual(prepared.telemetryProperties.agent, '[REDACTED AGENT NAME]');
 		assert.strictEqual(prepared.telemetryProperties.operation, 'applying changes');
+	});
+
+	test('does not allow PII values to close their redaction marker', () => {
+		const agentName = 'Contoso </pii> alice@contoso.com';
+		const successLog = createSyncSuccessLog(agentName, 'applying changes', 42);
+		const prepared = prepareLogData(successLog.message, {
+			sessionId: 'test-session',
+			agent: successLog.data.agent,
+		});
+
+		assert.strictEqual(prepared.displayMessage, `Completed applying changes for ${agentName} in 42ms`);
+		assert.strictEqual(
+			prepared.telemetryProperties.message,
+			'Completed applying changes for [REDACTED AGENT NAME] in 42ms',
+		);
+		assert.strictEqual(prepared.telemetryProperties.agent, '[REDACTED AGENT NAME]');
+	});
+
+	test('identifies an MCS YAML file name while preserving a safe file error', () => {
+		const message = formatOpenFileError('C:\\agents\\contoso\\agent.mcs.yml', new Error('Access denied'));
+		const prepared = prepareLogData(message, {
+			sessionId: 'test-session',
+			message,
+		});
+
+		assert.strictEqual(
+			prepared.displayMessage,
+			'Error opening file C:\\agents\\contoso\\agent.mcs.yml: Access denied',
+		);
+		assert.strictEqual(
+			prepared.telemetryProperties.message,
+			'Error opening file [REDACTED .MCS.YML FILE NAME]: Access denied',
+		);
+	});
+
+	test('preserves filesystem error details for the user while redacting unsafe qualifiers', () => {
+		const error = Object.assign(new Error('Access denied by policy Contoso-Restricted'), {
+			code: 'NoPermissions',
+		});
+		const message = formatOpenFileError('C:\\agents\\contoso\\agent.mcs.yml', error);
+		const prepared = prepareLogData(message, { sessionId: 'test-session' });
+
+		assert.strictEqual(
+			prepared.displayMessage,
+			'Error opening file C:\\agents\\contoso\\agent.mcs.yml: Access denied by policy Contoso-Restricted',
+		);
+		assert.strictEqual(
+			prepared.telemetryProperties.message,
+			'Error opening file [REDACTED .MCS.YML FILE NAME]: Access denied by policy Contoso-Restricted',
+		);
+	});
+
+	test('preserves a file error reason while redacting its agent and MCS YAML file', () => {
+		const message = formatOpenFileError(
+			'C:\\agents\\contoso\\agent.mcs.yml',
+			new Error('Agent Contoso could not open C:\\agents\\contoso\\topic.mcs.yml'),
+			'Contoso',
+		);
+		const prepared = prepareLogData(message, { sessionId: 'test-session' });
+
+		assert.strictEqual(
+			prepared.telemetryProperties.message,
+			'Error opening file [REDACTED .MCS.YML FILE NAME]: Agent [REDACTED AGENT NAME] could not open [REDACTED .MCS.YML FILE NAME]',
+		);
+	});
+
+	test('identifies an email address while preserving a safe rejection reason', () => {
+		const message = formatReauthenticationError(new Error('alex@contoso.com was rejected'));
+		const prepared = prepareLogData(message, { sessionId: 'test-session' });
+
+		assert.strictEqual(prepared.displayMessage, 'Re-authentication failed: alex@contoso.com was rejected');
+		assert.strictEqual(
+			prepared.telemetryProperties.message,
+			'Re-authentication failed: [REDACTED EMAIL ADDRESS] was rejected',
+		);
+	});
+
+	test('preserves a re-authentication reason while redacting its PII', () => {
+		const message = formatReauthenticationError(
+			new Error('Agent Contoso could not open C:\\agents\\contoso\\agent.mcs.yml for alex@contoso.com'),
+			'Contoso',
+		);
+		const prepared = prepareLogData(message, { sessionId: 'test-session' });
+
+		assert.strictEqual(
+			prepared.telemetryProperties.message,
+			'Re-authentication failed: Agent [REDACTED AGENT NAME] could not open [REDACTED .MCS.YML FILE NAME] for [REDACTED EMAIL ADDRESS]',
+		);
+	});
+
+	test('sanitizes recognized PII while preserving the complete error reason', () => {
+		const errorMessage = 'Agent Contoso Support could not open C:\\agents\\contoso\\topic.mcs.yaml for alex@contoso.com';
+		const protectedMessage = sanitizeErrorDetails(errorMessage, ['Contoso Support']);
+		const prepared = prepareLogData(protectedMessage, { sessionId: 'test-session' });
+
+		assert.strictEqual(prepared.displayMessage, errorMessage);
+		assert.strictEqual(
+			prepared.telemetryProperties.message,
+			'Agent [REDACTED AGENT NAME] could not open [REDACTED .MCS.YML FILE NAME] for [REDACTED EMAIL ADDRESS]',
+		);
+	});
+
+	test('leaves non-PII error details unchanged', () => {
+		const errorMessage = 'Request timed out after 30 seconds';
+		const prepared = prepareLogData(sanitizeErrorDetails(errorMessage), { sessionId: 'test-session' });
+
+		assert.strictEqual(prepared.displayMessage, errorMessage);
+		assert.strictEqual(prepared.telemetryProperties.message, errorMessage);
+	});
+
+	test('redacts complete emails with apostrophes and Windows paths with spaces', () => {
+		const errorMessage = "Could not open C:\\Users\\John Doe\\agent.mcs.yml for o'connor@example.com";
+		const prepared = prepareLogData(sanitizeErrorDetails(errorMessage), { sessionId: 'test-session' });
+
+		assert.strictEqual(
+			prepared.telemetryProperties.message,
+			'Could not open [REDACTED .MCS.YML FILE NAME] for [REDACTED EMAIL ADDRESS]',
+		);
+	});
+
+	test('redacts complete UNC MCS YAML paths with spaces', () => {
+		const errorMessage = 'Could not open \\\\server\\John Doe\\agent.mcs.yml';
+		const prepared = prepareLogData(sanitizeErrorDetails(errorMessage), { sessionId: 'test-session' });
+
+		assert.strictEqual(
+			prepared.telemetryProperties.message,
+			'Could not open [REDACTED .MCS.YML FILE NAME]',
+		);
+	});
+
+	test('uses original-string indices for Unicode agent-name matching', () => {
+		const errorMessage = 'İssue for Contoso failed';
+		const prepared = prepareLogData(sanitizeErrorDetails(errorMessage, ['Contoso']), {
+			sessionId: 'test-session',
+		});
+
+		assert.strictEqual(
+			prepared.telemetryProperties.message,
+			'İssue for [REDACTED AGENT NAME] failed',
+		);
+	});
+
+	test('does not redact short agent names inside words or status clauses as agent names', () => {
+		const errorMessage = 'Validation failed. Agent failed to start.';
+		const prepared = prepareLogData(sanitizeErrorDetails(errorMessage, ['AI']), {
+			sessionId: 'test-session',
+		});
+
+		assert.strictEqual(prepared.telemetryProperties.message, errorMessage);
 	});
 
 	test('redacts multiline sensitive values without changing display text', () => {

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/tests/host/workspaceSynchronizer.test.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/tests/host/workspaceSynchronizer.test.ts
@@ -1,6 +1,7 @@
 import * as assert from 'node:assert';
 import { describe, test } from 'node:test';
 import {
+	createSyncSuccessLog,
 	getActiveSyncUri,
 	getSyncStateFor,
 	logWorkflowIssues,
@@ -8,8 +9,37 @@ import {
 	SyncState,
 	withSyncCommandBusy,
 } from '../../sync/workspaceSynchronizer';
-import logger from '../../services/logger';
+import logger, { prepareLogData } from '../../services/logger';
 import type { WorkflowResponse } from '../../types';
+
+describe('workspaceSynchronizer: sync success telemetry', () => {
+
+	test('keeps the agent name visible while redacting it from telemetry', () => {
+		const successLog = createSyncSuccessLog('Contoso Support', 'applying changes', 42);
+		const prepared = prepareLogData(successLog.message, {
+			sessionId: 'test-session',
+			agent: successLog.data.agent,
+			operation: successLog.data.operation,
+		});
+
+		assert.strictEqual(prepared.displayMessage, 'Completed applying changes for Contoso Support in 42ms');
+		assert.strictEqual(prepared.telemetryProperties.message, 'Completed applying changes for [REDACTED] in 42ms');
+		assert.strictEqual(prepared.telemetryProperties.agent, '[REDACTED]');
+		assert.strictEqual(prepared.telemetryProperties.operation, 'applying changes');
+	});
+
+	test('redacts multiline sensitive values without changing display text', () => {
+		const message = 'Sync failed: <pii>Agent Contoso\nC:\\agents\\contoso</pii>';
+		const prepared = prepareLogData(message, {
+			sessionId: 'test-session',
+			error: '<pii>Agent Contoso\nC:\\agents\\contoso</pii>',
+		});
+
+		assert.strictEqual(prepared.displayMessage, 'Sync failed: Agent Contoso\nC:\\agents\\contoso');
+		assert.strictEqual(prepared.telemetryProperties.message, 'Sync failed: [REDACTED]');
+		assert.strictEqual(prepared.telemetryProperties.error, '[REDACTED]');
+	});
+});
 
 /**
  * Tests for the command-level busy tracking exposed by workspaceSynchronizer.

--- a/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/tests/host/workspaceSynchronizer.test.ts
+++ b/src/vscode-extensions/microsoft-powerplatformlang-extension/client/src/tests/host/workspaceSynchronizer.test.ts
@@ -126,7 +126,7 @@ describe('workspaceSynchronizer: sync success telemetry', () => {
 		assert.strictEqual(prepared.displayMessage, errorMessage);
 		assert.strictEqual(
 			prepared.telemetryProperties.message,
-			'Agent [REDACTED AGENT NAME] could not open [REDACTED .MCS.YML FILE NAME] for [REDACTED EMAIL ADDRESS]',
+			'Agent [REDACTED AGENT NAME] could not open [REDACTED .MCS.YAML FILE NAME] for [REDACTED EMAIL ADDRESS]',
 		);
 	});
 
@@ -155,6 +155,48 @@ describe('workspaceSynchronizer: sync success telemetry', () => {
 		assert.strictEqual(
 			prepared.telemetryProperties.message,
 			'Could not open [REDACTED .MCS.YML FILE NAME]',
+		);
+	});
+
+	test('redacts full URLs as a URL rather than mislabeling them as file names', () => {
+		const errorMessage = 'Cannot reach https://contoso.crm.dynamics.com/api endpoint';
+		const prepared = prepareLogData(sanitizeErrorDetails(errorMessage), { sessionId: 'test-session' });
+
+		assert.strictEqual(prepared.displayMessage, errorMessage);
+		assert.strictEqual(
+			prepared.telemetryProperties.message,
+			'Cannot reach [REDACTED URL] endpoint',
+		);
+	});
+
+	test('redacts non-MCS file paths while disclosing the file extension', () => {
+		const errorMessage = 'ENOENT: spawn C:\\Users\\alex\\.vscode\\extensions\\lspOut\\LanguageServerHost.exe';
+		const prepared = prepareLogData(sanitizeErrorDetails(errorMessage), { sessionId: 'test-session' });
+
+		assert.strictEqual(prepared.displayMessage, errorMessage);
+		assert.strictEqual(
+			prepared.telemetryProperties.message,
+			'ENOENT: spawn [REDACTED .EXE FILE NAME]',
+		);
+	});
+
+	test('redacts cached botdefinition paths disclosing the .json extension', () => {
+		const errorMessage = 'Failed reading C:\\Users\\alex\\agents\\contoso\\.mcs\\botdefinition.json';
+		const prepared = prepareLogData(sanitizeErrorDetails(errorMessage), { sessionId: 'test-session' });
+
+		assert.strictEqual(
+			prepared.telemetryProperties.message,
+			'Failed reading [REDACTED .JSON FILE NAME]',
+		);
+	});
+
+	test('redacts bare file names disclosing the file extension', () => {
+		const errorMessage = 'Could not parse settings.mcs.yml';
+		const prepared = prepareLogData(sanitizeErrorDetails(errorMessage), { sessionId: 'test-session' });
+
+		assert.strictEqual(
+			prepared.telemetryProperties.message,
+			'Could not parse [REDACTED .MCS.YML FILE NAME]',
 		);
 	});
 


### PR DESCRIPTION
## Summary

- redact agent display names from sync success telemetry while preserving readable VS Code messages
- protect adjacent sync and LSP error telemetry, including multiline PII
- add focused coverage for display text and telemetry redaction

## Validation

- `npm run compile`
- `npm run lint`
- VS Code extension host tests: 156 passed

Closes #354